### PR TITLE
Make sure to render as public if the user is not logged in

### DIFF
--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -284,6 +284,7 @@ class PageController extends Controller {
 		}
 
 		if ($this->hasUserAccess($form)) {
+			$renderAs = $this->userId !== null ? 'user' : 'public';
 			return new TemplateResponse('forms', 'vote.tmpl', [
 				'form' => $form,
 				'questions' => $this->getQuestions($form->getId()),
@@ -294,7 +295,7 @@ class PageController extends Controller {
 				'userMgr' => $this->userMgr,
 				'urlGenerator' => $this->urlGenerator,
 				'avatarManager' => $this->avatarManager
-			]);
+			], $renderAs);
 		} else {
 			User::checkLoggedIn();
 			return new TemplateResponse('forms', 'no.acc.tmpl', []);


### PR DESCRIPTION
Else we will render the apps, contacts menu etc. Which is undesireable.

Signed-off-by: Roeland Jago Douma <roeland@famdouma.nl>