### PR TITLE
Fix/expirations

### DIFF
--- a/lib/Controller/ApiController.php
+++ b/lib/Controller/ApiController.php
@@ -222,6 +222,19 @@ class ApiController extends Controller {
 		$data = array();
 		try {
 			$data = $this->formMapper->find($formId)->read();
+
+			//Add some computed data
+			if (!strpos('|public|hidden|registered', $data['access'])) {
+				$data['access'] = 'select';
+			}
+			if ($data['expirationDate'] === date('Y-m-d H:i:s', null)) {
+				$data['expired'] = false;
+				$data['expires'] = false;
+			} else {
+				$data['expired'] = time() > strtotime($data['expirationDate']);
+				$data['expires'] = true;
+			}
+
 		} catch (DoesNotExistException $e) {
 			// return silently
 		} finally {
@@ -434,7 +447,7 @@ class ApiController extends Controller {
 		if ($form['expires']) {
 			$newForm->setExpirationDate(date('Y-m-d H:i:s', strtotime($form['expirationDate'])));
 		} else {
-			$newForm->setExpirationDate(null);
+			$newForm->setExpirationDate(date('Y-m-d H:i:s', null));
 		}
 
 		if ($mode === 'edit') {
@@ -483,6 +496,7 @@ class ApiController extends Controller {
 		$currentUser = \OC::$server->getUserSession()->getUser()->getUID();
 		$form->setOwnerId($currentUser);
 		$form->setCreated(date('Y-m-d H:i:s'));
+		$form->setExpirationDate(date('Y-m-d H:i:s', null));
 		$form->setHash(\OC::$server->getSecureRandom()->generate(
 			16,
 			ISecureRandom::CHAR_HUMAN_READABLE

--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -166,7 +166,7 @@ class PageController extends Controller {
 			return new TemplateResponse('forms', 'no.acc.tmpl', []);
 		}
 
-		if ($form->getExpirationDate() === null) {
+		if ($form->getExpirationDate() === date('Y-m-d H:i:s', null)) {
 			$expired = false;
 		} else {
 			$expired = time() > strtotime($form->getExpirationDate());

--- a/lib/Db/Form.php
+++ b/lib/Db/Form.php
@@ -69,18 +69,6 @@ class Form extends Entity {
 	}
 
 	public function read() {
-		$accessType = $this->getAccess();
-		if (!strpos('|public|hidden|registered', $accessType)) {
-			$accessType = 'select';
-		}
-		if ($this->getExpirationDate() === null) {
-			$expired = false;
-			$expires = false;
-		} else {
-			$expired = time() > strtotime($this->getExpirationDate());
-			$expires = true;
-		}
-
 		return [
 			'id' => $this->getId(),
 			'hash' => $this->getHash(),
@@ -89,9 +77,7 @@ class Form extends Entity {
 			'ownerId' => $this->getOwnerId(),
 			'ownerDisplayName' => \OC_User::getDisplayName($this->getOwnerId()),
 			'created' => $this->getCreated(),
-			'access' => $accessType,
-			'expires' => $expires,
-			'expired' => $expired,
+			'access' => $this->getAccess(),
 			'expirationDate' => $this->getExpirationDate(),
 			'isAnonymous' => $this->getIsAnonymous(),
 			'submitOnce' => $this->getSubmitOnce()

--- a/lib/Migration/Version010200Date2020323141300.php
+++ b/lib/Migration/Version010200Date2020323141300.php
@@ -206,7 +206,12 @@ class Version010200Date2020323141300 extends SimpleMigrationStep {
 			$qb_fetch->select('id', 'hash', 'title', 'description', 'owner', 'created', 'access', 'expire', 'is_anonymous', 'unique')
 				->from('forms_events');
 			$cursor = $qb_fetch->execute();
-			while( $event = $cursor->fetch() ){ 
+			while( $event = $cursor->fetch() ){
+				//Adapt expiration dates to new usage of (date('Y-m-d H:i:s', null))
+				if ($event['expire'] === null) {
+					$event['expire'] === date('Y-m-d H:i:s', null);
+				}
+
 				$qb_restore->insert('forms_v2_forms')
 					->values([
 						'hash' => $qb_restore->createNamedParameter($event['hash'], IQueryBuilder::PARAM_STR),

--- a/src/views/Sidebar.vue
+++ b/src/views/Sidebar.vue
@@ -58,7 +58,6 @@
 				v-model="form.form.expirationDate"
 				v-bind="expirationDatePicker"
 
-				:time-picker-options="{ start: '00:00', step: '00:05', end: '23:55' }"
 				style="width:170px" />
 		</div>
 
@@ -140,13 +139,15 @@ export default {
 				editable: true,
 				minuteStep: 1,
 				type: 'datetime',
+				valueType: 'YYYY-MM-DD HH:mm:ss',
+				defaultValue: moment(),
 				format: moment.localeData().longDateFormat('L') + ' ' + moment.localeData().longDateFormat('LT'),
-				lang: this.lang.split('-')[0],
+				lang: moment.localeData()['_config'],
 				placeholder: t('forms', 'Expiration date'),
 				timePickerOptions: {
 					start: '00:00',
-					step: '00:30',
-					end: '23:30',
+					step: '00:15',
+					end: '23:45',
 				},
 			}
 		},

--- a/src/views/Sidebar.vue
+++ b/src/views/Sidebar.vue
@@ -55,10 +55,10 @@
 			</label>
 
 			<DatetimePicker v-show="form.form.expires"
+				id="expirationDatePicker"
 				v-model="form.form.expirationDate"
 				v-bind="expirationDatePicker"
-
-				style="width:170px" />
+				@change="checkExpired" />
 		</div>
 
 		<div class="configBox">
@@ -198,6 +198,9 @@ export default {
 		removeShare(item) {
 			this.form.shares.splice(this.form.shares.indexOf(item), 1)
 		},
+		checkExpired() {
+			this.form.form.expired = moment() > moment(this.form.form.expirationDate)
+		},
 	},
 }
 </script>
@@ -228,5 +231,9 @@ textarea {
 		border: 2px solid var(--color-error);
 		box-shadow: 1px 0 var(--border-radius) var(--color-box-shadow);
 	}
+}
+
+#expirationDatePicker {
+	width: 170px;
 }
 </style>


### PR DESCRIPTION
This PR is a draft, as it is already based on the AlterDB PR.

- [x] The expiration Date was not shown when loading a form. -> ExpirationDatePicker didn't like the Variable-Format, so didn't interpret the variable
- [x] When disabling an expiration, this was not stored to Db. -> Changed null in Db to date(null), which is 1970-01-01
- [x] The expired-Variable is not updated, when changing the Expiration-Date. -> Update on ExpirationChange.

@skjnldsv What i need some help on the Design/Frontend side, maybe you understand why & have an easy idea for this:
- [x] The expired-Variable is now updated, when changing the Date. Still, the Bullet in AppNavigation is not updated. Is this just due to the formatForm-Script and will disappear when resolving the flattened structure? => Edit: Seems like my tests went wrong. Suddenly this works for me.
- [ ] Do you know a good way for not to show the 1970-Date in ExpirationDatePicker? When expiraitonDate corresponds to the Null-Date, better the placeholder would be shown.