### PR TITLE
Order Questions

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -47,6 +47,7 @@ return [
 		['name' => 'api#newForm', 'url' => 'api/v1/form', 'verb' => 'POST'],
 		['name' => 'api#deleteForm', 'url' => 'api/v1/form/{id}', 'verb' => 'DELETE'],
 		['name' => 'api#updateQuestion', 'url' => 'api/v1/question/update/', 'verb' => 'POST'],
+		['name' => 'api#reorderQuestions', 'url' => 'api/v1/question/reorder/', 'verb' => 'POST'],
 		['name' => 'api#newQuestion', 'url' => 'api/v1/question/', 'verb' => 'POST'],
 		['name' => 'api#deleteQuestion', 'url' => 'api/v1/question/{id}', 'verb' => 'DELETE'],
 		['name' => 'api#newOption', 'url' => 'api/v1/option/', 'verb' => 'POST'],

--- a/lib/Db/Question.php
+++ b/lib/Db/Question.php
@@ -29,6 +29,8 @@ use OCP\AppFramework\Db\Entity;
 /**
  * @method integer getFormId()
  * @method void setFormId(integer $value)
+ * @method integer getOrder()
+ * @method void setOrder(integer $value)
  * @method string getType()
  * @method void setType(string $value)
  * @method string getText()
@@ -36,15 +38,14 @@ use OCP\AppFramework\Db\Entity;
  */
 class Question extends Entity {
 	protected $formId;
+	protected $order;
 	protected $type;
 	protected $mandatory;
 	protected $text;
 
-	/**
-	 * Question constructor.
-	 */
 	public function __construct() {
 		$this->addType('formId', 'integer');
+		$this->addType('order', 'integer');
 		$this->addType('type', 'string');
 		$this->addType('mandatory', 'bool');
 		$this->addType('text', 'string');
@@ -54,6 +55,7 @@ class Question extends Entity {
 		return [
 			'id' => $this->getId(),
 			'formId' => $this->getFormId(),
+			'order' => $this->getOrder(),
 			'type' => htmlspecialchars_decode($this->getType()),
 			'mandatory' => $this->getMandatory(),
 			'text' => htmlspecialchars_decode($this->getText()),

--- a/src/views/Create.vue
+++ b/src/views/Create.vue
@@ -211,10 +211,11 @@ export default {
 			} else {
 				if (this.newQuestion !== null & this.newQuestion !== '' & (/\S/.test(this.newQuestion))) {
 					const response = await axios.post(generateUrl('/apps/forms/api/v1/question/'), { formId: this.form.id, type: this.selected, text: this.newQuestion })
-					const questionId = response.data
+					const respData = response.data
 
 					this.form.questions.push({
-						id: questionId,
+						id: respData.id,
+						order: respData.order,
 						text: this.newQuestion,
 						type: this.selected,
 						options: [],


### PR DESCRIPTION
Ok, so next thing i started already a few days ago, was to include the possibility to reorder questions:
- I first used 'order' as key, until phpmyadmin told me, that order would be a sql-keyword. I'm not completely happy with the naming 'rank', if you know sth. better, just tell me.
- Rank can be updated with updateQuestion. Changing the Ranking of two questions needs to call update with rank on both questions separately.
- Delete Question only changes the Rank to 0, deleteForm really deletes all Questions & corresponding options.
- newQuestion takes the last highest Rank +1 and returns not only the question-id but also the rank of the new question.
- On simple questionMapper->findByForm, only the non-deleted questions are loaded, an optional switch makes it possible to load all Questions.

@skjnldsv:
- On frontend i didn't change anything, except the return on newQuestion, as this one changed in API. Like this, this PR doesn't destroy the functionality to add Questions. I hope this works for you?
- I now changed the 'old' new Migration-Script, as it has not been released yet, so users will only get one migration. For your installation, you maybe have to add the Column rank manually with notnull true and default 1. Then insert the values manually or just delete all forms and insert new ones if you want to test a ranking functionality... Are you ok with this?