### PR TITLE
Migrate Timestamps

### DIFF
--- a/lib/Controller/ApiController.php
+++ b/lib/Controller/ApiController.php
@@ -272,9 +272,9 @@ class ApiController extends Controller {
 		$newForm->setAccess($form['access']);
 
 		if ($form['expires']) {
-			$newForm->setExpirationDate(date('Y-m-d H:i:s', strtotime($form['expirationDate'])));
+			$newForm->setExpiresTimestamp($form['expiresTimestamp']);
 		} else {
-			$newForm->setExpirationDate(null);
+			$newForm->setExpiresTimestamp(0);
 		}
 
 		if ($mode === 'edit') {
@@ -297,7 +297,7 @@ class ApiController extends Controller {
 			// Create new form
 			// Define current user as owner, set new creation date and create a new hash
 			$newForm->setOwnerId($currentUser);
-			$newForm->setCreated(date('Y-m-d H:i:s'));
+			$newForm->setCreated(time());
 			$newForm->setHash(\OC::$server->getSecureRandom()->generate(
 				16,
 				ISecureRandom::CHAR_DIGITS .
@@ -322,7 +322,7 @@ class ApiController extends Controller {
 
 		$currentUser = \OC::$server->getUserSession()->getUser()->getUID();
 		$form->setOwnerId($currentUser);
-		$form->setCreated(date('Y-m-d H:i:s'));
+		$form->setCreated(time());
 		$form->setHash(\OC::$server->getSecureRandom()->generate(
 			16,
 			ISecureRandom::CHAR_HUMAN_READABLE

--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -172,10 +172,10 @@ class PageController extends Controller {
 			return new TemplateResponse('forms', 'no.acc.tmpl', []);
 		}
 
-		if ($form->getExpirationDate() === null) {
+		if ($form->getExpiresTimestamp() === 0) {
 			$expired = false;
 		} else {
-			$expired = time() > strtotime($form->getExpirationDate());
+			$expired = time() > $form->getExpiresTimestamp();
 		}
 
 		if ($expired) {
@@ -277,7 +277,7 @@ class PageController extends Controller {
 		}else{
 			$submission->setUserId($userId);
 		}
-		$submission->setTimestamp(date('Y-m-d H:i:s'));
+		$submission->setTimestamp(time());
 		$this->submissionMapper->insert($submission);
 		$submissionId = $submission->getId();
 

--- a/lib/Db/Submission.php
+++ b/lib/Db/Submission.php
@@ -32,8 +32,8 @@ use OCP\AppFramework\Db\Entity;
  * @method void setFormId(integer $value)
  * @method string getUserId()
  * @method void setUserId(string $value)
- * @method string getTimestamp()
- * @method void setTimestamp(string $value)
+ * @method integer getTimestamp()
+ * @method void setTimestamp(integer $value)
  */
 class Submission extends Entity {
 	protected $formId;
@@ -45,6 +45,7 @@ class Submission extends Entity {
 	 */
 	public function __construct() {
 		$this->addType('formId', 'integer');
+		$this->addType('timestamp', 'integer');
 	}
 
 	public function read(): array {

--- a/lib/Migration/Version010200Date2020323141300.php
+++ b/lib/Migration/Version010200Date2020323141300.php
@@ -33,6 +33,8 @@ use OCP\IDBConnection;
 use OCP\Migration\SimpleMigrationStep;
 use OCP\Migration\IOutput;
 
+use \DateTime;
+
 /**
  * Installation class for the forms app.
  * Initial db creation
@@ -90,11 +92,13 @@ class Version010200Date2020323141300 extends SimpleMigrationStep {
 			$table->addColumn('access_json', Type::JSON, [
 				'notnull' => false,
 			]);
-			$table->addColumn('created', Type::DATETIME, [
+			$table->addColumn('created', Type::INTEGER, [
 				'notnull' => false,
+				'comment' => 'unix-timestamp',
 			]);
-			$table->addColumn('expiration_date', Type::DATETIME, [
+			$table->addColumn('expires_timestamp', Type::INTEGER, [
 				'notnull' => false,
+				'comment' => 'unix-timestamp',
 			]);
 			$table->addColumn('is_anonymous', Type::BOOLEAN, [
 				'notnull' => true,
@@ -164,8 +168,9 @@ class Version010200Date2020323141300 extends SimpleMigrationStep {
 				'notnull' => true,
 				'length' => 64,
 			]);
-			$table->addColumn('timestamp', Type::DATETIME, [
+			$table->addColumn('timestamp', Type::INTEGER, [
 				'notnull' => false,
+				'comment' => 'unix-timestamp',
 			]);
 			$table->setPrimaryKey(['id']);
 		}
@@ -220,8 +225,8 @@ class Version010200Date2020323141300 extends SimpleMigrationStep {
 						'description' => $qb_restore->createNamedParameter($event['description'], IQueryBuilder::PARAM_STR),
 						'owner_id' => $qb_restore->createNamedParameter($event['owner'], IQueryBuilder::PARAM_STR),
 						'access_json' => $qb_restore->createNamedParameter($newAccessJSON, IQueryBuilder::PARAM_STR),
-						'created' => $qb_restore->createNamedParameter($event['created'], IQueryBuilder::PARAM_STR),
-						'expiration_date' => $qb_restore->createNamedParameter($event['expire'], IQueryBuilder::PARAM_STR),
+						'created' => $qb_restore->createNamedParameter($this->convertDateTime($event['created']), IQueryBuilder::PARAM_INT),
+						'expires_timestamp' => $qb_restore->createNamedParameter($this->convertDateTime($event['expire']), IQueryBuilder::PARAM_INT),
 						'is_anonymous' => $qb_restore->createNamedParameter($event['is_anonymous'], IQueryBuilder::PARAM_BOOL),
 						'submit_once' => $qb_restore->createNamedParameter($event['unique'], IQueryBuilder::PARAM_BOOL)
 					]);
@@ -327,7 +332,7 @@ class Version010200Date2020323141300 extends SimpleMigrationStep {
 						->values([
 							'form_id' => $qb_restore->createNamedParameter($id_mapping['events'][$vote['form_id']]['newId'], IQueryBuilder::PARAM_INT),
 							'user_id' => $qb_restore->createNamedParameter($vote['user_id'], IQueryBuilder::PARAM_STR),
-							'timestamp' => $qb_restore->createNamedParameter(date('Y-m-d H:i:s'), IQueryBuilder::PARAM_STR) //Information not available. Just using Migration-Timestamp.
+							'timestamp' => $qb_restore->createNamedParameter(time(), IQueryBuilder::PARAM_STR) //Information not available. Just using Migration-Timestamp.
 						]);
 					$qb_restore->execute();
 					$id_mapping['currentSubmission'] = $qb_restore->getLastInsertId(); //Store submission-id to connect answers to submission.
@@ -388,5 +393,15 @@ class Version010200Date2020323141300 extends SimpleMigrationStep {
 		}
 
 		return json_encode($accessArray);
+	}
+
+	/** Convert old Date-Format to unix-timestamps */
+	private function convertDateTime($oldDate): int {
+		// Expires can be NULL -> Converting to timestamp 0
+		if (!$oldDate) {
+			return 0;
+		}
+
+		return DateTime::createFromFormat('Y-m-d H:i:s', $oldDate)->getTimestamp();
 	}
 }

--- a/src/views/Sidebar.vue
+++ b/src/views/Sidebar.vue
@@ -55,11 +55,9 @@
 			</label>
 
 			<DatetimePicker v-show="form.form.expires"
-				v-model="form.form.expirationDate"
-				v-bind="expirationDatePicker"
-
-				:time-picker-options="{ start: '00:00', step: '00:05', end: '23:55' }"
-				style="width:170px" />
+				id="expiresDatetimePicker"
+				v-model="form.form.expiresTimestamp"
+				v-bind="expirationDatePicker" />
 		</div>
 
 		<div class="configBox">
@@ -140,13 +138,14 @@ export default {
 				editable: true,
 				minuteStep: 1,
 				type: 'datetime',
+				valueType: 'X', // unix-timestamp
 				format: moment.localeData().longDateFormat('L') + ' ' + moment.localeData().longDateFormat('LT'),
 				lang: this.lang.split('-')[0],
 				placeholder: t('forms', 'Expiration date'),
 				timePickerOptions: {
 					start: '00:00',
-					step: '00:30',
-					end: '23:30',
+					step: '00:15',
+					end: '23:45',
 				},
 			}
 		},
@@ -227,5 +226,9 @@ textarea {
 		border: 2px solid var(--color-error);
 		box-shadow: 1px 0 var(--border-radius) var(--color-box-shadow);
 	}
+}
+
+#expiresDatetimePicker {
+	width: 170px;
 }
 </style>


### PR DESCRIPTION
- Moving all dates to unix-timestamps.
- Renamed expirationDate now to expiresTimestamp
- Defined `expiresTimestamp==0` as 'form does not expire/`expires==false`'
- Created the procedures getExpires() & getExpired() for the computed properties of the form.
- Didn't take too much effort into the sidebar now due to the pending rewrite, just so it works for now.

closes #275 