### PR TITLE
Fix/api cleanup

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -36,14 +36,10 @@ return [
 		['name' => 'page#insert_submission', 'url' => '/insert/submission', 'verb' => 'POST'],
 		['name' => 'page#get_display_name', 'url' => '/get/displayname', 'verb' => 'POST'],
 
-		['name' => 'api#write_form', 'url' => '/write/form', 'verb' => 'POST'],
-		['name' => 'api#get_full_form', 'url' => '/get/fullform/{formIdOrHash}', 'verb' => 'GET'],
-		['name' => 'api#get_options', 'url' => '/get/options/{formId}', 'verb' => 'GET'],
-		['name' => 'api#get_shares', 'url' => '/get/shares/{formId}', 'verb' => 'GET'],
-		['name' => 'api#get_form', 'url' => '/get/form/{formId}', 'verb' => 'GET'],
-
 		['name' => 'api#getForms', 'url' => 'api/v1/forms', 'verb' => 'GET'],
 		['name' => 'api#newForm', 'url' => 'api/v1/form', 'verb' => 'POST'],
+		['name' => 'api#getForm', 'url' => 'api/v1/form/{id}', 'verb' => 'GET'],
+		['name' => 'api#updateForm', 'url' => 'api/v1/form/update/', 'verb' => 'POST'],
 		['name' => 'api#deleteForm', 'url' => 'api/v1/form/{id}', 'verb' => 'DELETE'],
 		['name' => 'api#updateQuestion', 'url' => 'api/v1/question/update/', 'verb' => 'POST'],
 		['name' => 'api#reorderQuestions', 'url' => 'api/v1/question/reorder/', 'verb' => 'POST'],

--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -32,9 +32,7 @@ return [
 		['name' => 'page#getResult', 'url' => '/{hash}/results/', 'verb' => 'GET'],
 
 		['name' => 'page#goto_form', 'url' => '/{hash}', 'verb' => 'GET'],
-
 		['name' => 'page#insert_submission', 'url' => '/insert/submission', 'verb' => 'POST'],
-		['name' => 'page#get_display_name', 'url' => '/get/displayname', 'verb' => 'POST'],
 
 		['name' => 'api#getForms', 'url' => 'api/v1/forms', 'verb' => 'GET'],
 		['name' => 'api#newForm', 'url' => 'api/v1/form', 'verb' => 'POST'],

--- a/lib/Controller/ApiController.php
+++ b/lib/Controller/ApiController.php
@@ -164,7 +164,7 @@ class ApiController extends Controller {
 
 		$currentUser = \OC::$server->getUserSession()->getUser()->getUID();
 		$form->setOwnerId($currentUser);
-		$form->setCreated(date('Y-m-d H:i:s'));
+		$form->setCreated(time());
 		$form->setHash(\OC::$server->getSecureRandom()->generate(
 			16,
 			ISecureRandom::CHAR_HUMAN_READABLE

--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -8,6 +8,7 @@
  * @author Natalie Gilbert
  * @author Affan Hussain
  * @author John Molakvoæ <skjnldsv@protonmail.com>
+ * @author Jonas Rittershofer <jotoeri@users.noreply.github.com>
  *
  * @license GNU AGPL version 3 or any later version
  *
@@ -236,23 +237,6 @@ class PageController extends Controller {
 		return $optionList;
 	}
 
-	/**
-	 * @NoAdminRequired
-	 * @param int $formId
-	 * @return TemplateResponse|RedirectResponse
-	 */
-	public function deleteForm($formId) {
-		$formToDelete = $this->formMapper->find($formId);
-		if ($this->userId !== $formToDelete->getOwnerId() && !$this->groupManager->isAdmin($this->userId)) {
-			return new TemplateResponse('forms', 'no.delete.tmpl');
-		}
-		$form = new Form();
-		$form->setId($formId);
-		$this->submissionMapper->deleteByForm($formId);
-		$this->formMapper->delete($form);
-		$url = $this->urlGenerator->linkToRoute('forms.page.index');
-		return new RedirectResponse($url);
-	}
 
 	/**
 	 * @NoAdminRequired
@@ -265,7 +249,7 @@ class PageController extends Controller {
 	 */
 	public function insertSubmission($id, $userId, $answers, $questions) {
 
-		$form = $this->formMapper->find($id);
+		$form = $this->formMapper->findById($id);
 		$anonID = "anon-user-".  hash('md5', (time() + rand()));
 
 		//Insert Submission

--- a/lib/Db/FormMapper.php
+++ b/lib/Db/FormMapper.php
@@ -45,7 +45,7 @@ class FormMapper extends QBMapper {
 	 * @throws \OCP\AppFramework\Db\MultipleObjectsReturnedException if more than one result
 	 * @throws \OCP\AppFramework\Db\DoesNotExistException if not found
 	 */
-	public function find(int $id): Form {
+	public function findById(int $id): Form {
 		$qb = $this->db->getQueryBuilder();
 
 		$qb->select('*')


### PR DESCRIPTION
This would cleanup the rest of API-Controller.
- Changing writeForm to an updateForm right as we did for questions.
- Removing unused and not useful routes getOptions & getShares.
- Providing the API to load just necessary data for forms-list `getForms()`, while loading the full form only via `getForm()`, when the form is chosen to edit (was proposed somewhere on first design-enhancement...?)
- Renamed `formMapper->find()` to `formMapper->findById()` to have consistent and clear calls.
- Due to reordering the procedures, the diff became quite strange. I tried to split into commit&fixup here.

Depends now a bit on #256, as it would for now destroy functionality of the UI, but would provide a proper interface for this PR...?