### PR TITLE
Fix overlapping text of long answers

### DIFF
--- a/src/components/Questions/QuestionMultiple.vue
+++ b/src/components/Questions/QuestionMultiple.vue
@@ -283,14 +283,16 @@ export default {
 	position: relative;
 	display: inline-flex;
 	align-items: center;
-	height: 44px;
+	min-height: 44px;
 
 	.question__label {
 		flex: 1 1 100%;
 		// Overwrite guest page core styles
 		text-align: left !important;
+		padding: 11px 0 11px 30px;
 		&::before {
-			margin: 14px !important;
+			margin-left: -30px !important;
+			margin-right: 14px !important;
 		}
 	}
 }

--- a/src/views/Submit.vue
+++ b/src/views/Submit.vue
@@ -215,13 +215,6 @@ export default {
 		.question {
 			// Less padding needed as submit view does not have drag handles
 			padding-left: 16px;
-			// stylelint-disable-next-line selector-pseudo-element-no-unknown
-			::v-deep ul.question__content {
-				// Left-align multiple choice and checkboxes with question text
-				// Only in submit view
-				// TODO: use variables
-				margin-left: -14px;
-			}
 		}
 
 		input[type=submit] {


### PR DESCRIPTION
Ref https://github.com/nextcloud/forms/issues/296#issuecomment-623120930

The vertical spacing of course changes when switching to edit mode on longer answers. On shorter, one-line ones, it stays the same as before. :)

Before | After
-|-
![Form answers broken overlapping](https://user-images.githubusercontent.com/925062/81458719-2fbc0b80-919c-11ea-8765-06655f575038.png) | ![Fixed form answers short clip](https://user-images.githubusercontent.com/925062/81458939-75c59f00-919d-11ea-805a-1b58478d2239.gif)



