### PR TITLE
Do not prefill form or question title for less confusion

### DIFF
--- a/lib/Controller/ApiController.php
+++ b/lib/Controller/ApiController.php
@@ -633,7 +633,7 @@ class ApiController extends Controller {
 			// Append Display Name
 			if (substr($submission['userId'], 0, 10) === 'anon-user-') {
 				// Anonymous User
-				$submission['userDisplayName'] = $this->l10n->t('anonymous user');
+				$submission['userDisplayName'] = $this->l10n->t('Anonymous response');
 			} else {
 				$userEntity = $this->userManager->get($submission['userId']);
 

--- a/lib/Controller/ApiController.php
+++ b/lib/Controller/ApiController.php
@@ -148,7 +148,7 @@ class ApiController extends Controller {
 			$this->logger->debug('Could not find form');
 			return new Http\JSONResponse([], Http::STATUS_BAD_REQUEST);
 		}
-	
+
 		if (!$this->formsService->hasUserAccess($id)) {
 			$this->logger->debug('User has no permissions to get this form');
 			return new Http\JSONResponse([], Http::STATUS_FORBIDDEN);
@@ -171,7 +171,7 @@ class ApiController extends Controller {
 			16,
 			ISecureRandom::CHAR_HUMAN_READABLE
 		));
-		$form->setTitle('New form');
+		$form->setTitle('');
 		$form->setDescription('');
 		$form->setAccess([
 			'type' => 'public'
@@ -279,7 +279,7 @@ class ApiController extends Controller {
 			$this->logger->debug('Invalid type');
 			return new Http\JSONResponse(['message' => 'Invalid type'], Http::STATUS_BAD_REQUEST);
 		}
-		
+
 		try {
 			$form = $this->formMapper->findById($formId);
 		} catch (IMapperException $e) {

--- a/src/components/AppNavigationForm.vue
+++ b/src/components/AppNavigationForm.vue
@@ -25,7 +25,7 @@
 		ref="navigationItem"
 		:exact="true"
 		:icon="icon"
-		:title="form.title"
+		:title="formTitle"
 		:to="{ name: 'edit', params: { hash: form.hash } }">
 		<template v-if="!loading" #actions>
 			<ActionLink
@@ -125,6 +125,17 @@ export default {
 		},
 
 		/**
+		 * Return form title, or placeholder if not set
+		 * @returns {string}
+		 */
+		formTitle() {
+			if (this.form.title) {
+				return this.form.title
+			}
+			return 'New form'
+		},
+
+		/**
 		 * Return the form share link
 		 * @returns {string}
 		 */
@@ -148,7 +159,7 @@ export default {
 
 	methods: {
 		async onDeleteForm() {
-			if (!confirm(t('forms', 'Are you sure you want to delete the form “{title}”?', { title: this.form.title }))) {
+			if (!confirm(t('forms', 'Are you sure you want to delete {title}?', { title: this.formTitle }))) {
 				return
 			}
 
@@ -158,7 +169,7 @@ export default {
 				await axios.delete(generateUrl('/apps/forms/api/v1/form/{id}', { id: this.form.id }))
 				this.$emit('delete', this.form.id)
 			} catch (error) {
-				showError(t('forms', 'Error while deleting form “{title}”', { title: this.form.title }))
+				showError(t('forms', 'Error while deleting {title}', { title: this.formTitle }))
 				console.error(error.response)
 			} finally {
 				this.loading = false

--- a/src/components/AppNavigationForm.vue
+++ b/src/components/AppNavigationForm.vue
@@ -132,7 +132,7 @@ export default {
 			if (this.form.title) {
 				return this.form.title
 			}
-			return 'New form'
+			return t('forms', 'New form')
 		},
 
 		/**

--- a/src/components/Questions/Question.vue
+++ b/src/components/Questions/Question.vue
@@ -34,8 +34,8 @@
 
 		<!-- Header -->
 		<div class="question__header">
-			<input v-if="edit"
-				:placeholder="t('forms', 'Enter a title for this question')"
+			<input v-if="edit || !text"
+				:placeholder="t('forms', 'Question title')"
 				:aria-label="t('forms', 'Title of question number {index}', {index})"
 				:value="text"
 				class="question__header-title"

--- a/src/components/Results/Submission.vue
+++ b/src/components/Results/Submission.vue
@@ -23,9 +23,7 @@
 <template>
 	<div class="section submission">
 		<div class="submission-head">
-			<h3>
-				{{ t('forms', 'Response by {userDisplayName}', { userDisplayName: submission.userDisplayName }) }}
-			</h3>
+			<h3>{{ submission.userDisplayName }}</h3>
 			<Actions class="submission-menu" :force-menu="true">
 				<ActionButton icon="icon-delete" @click="onDelete">
 					{{ t('forms', 'Delete this response') }}

--- a/src/views/Create.vue
+++ b/src/views/Create.vue
@@ -248,7 +248,7 @@ export default {
 		 * @param {string} type the question type, see AnswerTypes
 		 */
 		async addQuestion(type) {
-			const text = t('forms', 'New question')
+			const text = ''
 			this.isLoadingQuestions = true
 
 			try {

--- a/src/views/Results.vue
+++ b/src/views/Results.vue
@@ -33,12 +33,12 @@
 		<TopBar>
 			<button @click="showEdit">
 				<span class="icon-forms" role="img" />
-				{{ t('forms', 'Back to form') }}
+				{{ t('forms', 'Back to questions') }}
 			</button>
 		</TopBar>
 
 		<header v-if="!noSubmissions">
-			<h2>{{ t('forms', 'Responses for {title}', { title: form.title }) }}</h2>
+			<h2>{{ t('forms', 'Responses for {title}', { title: formTitle }) }}</h2>
 			<div class="response_actions">
 				<button class="response_actions__export" @click="download">
 					<span class="icon-download" role="img" />
@@ -125,6 +125,17 @@ export default {
 		noSubmissions() {
 			return this.submissions && this.submissions.length === 0
 		},
+
+		/**
+		 * Return form title, or placeholder if not set
+		 * @returns {string}
+		 */
+		formTitle() {
+			if (this.form.title) {
+				return this.form.title
+			}
+			return 'New form'
+		},
 	},
 
 	beforeMount() {
@@ -185,7 +196,7 @@ export default {
 		},
 
 		async deleteAllSubmissions() {
-			if (!confirm(t('forms', 'Are you sure you want to delete all responses of this form?'))) {
+			if (!confirm(t('forms', 'Are you sure you want to delete all responses of {title}?', { title: this.formTitle }))) {
 				return
 			}
 
@@ -228,7 +239,7 @@ export default {
 
 			const element = document.createElement('a')
 			element.setAttribute('href', 'data:text/csv;charset=utf-8,' + encodeURIComponent(parser.parse(formattedSubmissions)))
-			element.setAttribute('download', this.form.title + '.csv')
+			element.setAttribute('download', this.formTitle + '.csv')
 			element.style.display = 'none'
 			document.body.appendChild(element)
 			element.click()

--- a/src/views/Results.vue
+++ b/src/views/Results.vue
@@ -134,7 +134,7 @@ export default {
 			if (this.form.title) {
 				return this.form.title
 			}
-			return 'New form'
+			return t('forms', 'New form')
 		},
 	},
 

--- a/src/views/Submit.vue
+++ b/src/views/Submit.vue
@@ -119,7 +119,7 @@ export default {
 			if (this.form.title) {
 				return this.form.title
 			}
-			return 'New form'
+			return t('forms', 'New form')
 		},
 
 		validQuestions() {

--- a/src/views/Submit.vue
+++ b/src/views/Submit.vue
@@ -26,7 +26,7 @@
 			<!-- Forms title & description-->
 			<header>
 				<h2 id="form-title">
-					{{ form.title }}
+					{{ formTitle }}
 				</h2>
 				<p v-if="!loading && !success" class="form-desc">
 					{{ form.description }}
@@ -111,6 +111,17 @@ export default {
 	},
 
 	computed: {
+		/**
+		 * Return form title, or placeholder if not set
+		 * @returns {string}
+		 */
+		formTitle() {
+			if (this.form.title) {
+				return this.form.title
+			}
+			return 'New form'
+		},
+
 		validQuestions() {
 			return this.form.questions.filter(question => {
 				// All questions must have a valid title


### PR DESCRIPTION
People thought "New form" and "New question" were headings, not fields. This is fixed now by not prefilling them so the placeholders show, and fixing the wording.

Before | After
-|-
![Forms before](https://user-images.githubusercontent.com/925062/81461625-520a5500-91ad-11ea-8d90-8270915e4124.png) | ![Forms after](https://user-images.githubusercontent.com/925062/81461626-52a2eb80-91ad-11ea-9383-5874e27af7d4.png)
