### PR TITLE
Focus title after form load

### DIFF
--- a/src/views/Create.vue
+++ b/src/views/Create.vue
@@ -47,6 +47,7 @@
 			<label class="hidden-visually" for="form-title">{{ t('forms', 'Form title') }}</label>
 			<input
 				id="form-title"
+				ref="title"
 				v-model="form.title"
 				:minlength="0"
 				:maxlength="maxStringLengths.formTitle"
@@ -229,7 +230,19 @@ export default {
 				this.errorForm = true
 			} finally {
 				this.isLoadingForm = false
+				if (this.form.title === '') {
+					this.focusTitle()
+				}
 			}
+		},
+
+		/**
+		 * Focus title after form load
+		 */
+		focusTitle() {
+			this.$nextTick(() => {
+				this.$refs.title.focus()
+			})
 		},
 
 		/**


### PR DESCRIPTION
Makes it even more obvious that you can fill it, especially in combination with **Do not prefill form or question title for less confusion #367**.