### PR TITLE
Set max-version to 20 for new development version of Nextcloud

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -39,7 +39,7 @@
 	<screenshot>https://raw.githubusercontent.com/nextcloud/forms/master/screenshots/Results.PNG</screenshot>
 
     <dependencies>
-        <nextcloud min-version="17" max-version="19" />
+        <nextcloud min-version="17" max-version="20" />
     </dependencies>
 
 	<navigations>


### PR DESCRIPTION
Quick review @nextcloud/forms – this also might fix CI which said:

> Nextcloud was successfully installed
> App "Forms" cannot be installed because it is not compatible with this version of the server.

See https://github.com/nextcloud/forms/pull/367/checks?check_run_id=659162028