### PR TITLE
Correct fix window title

### DIFF
--- a/src/utils/SetWindowTitle.js
+++ b/src/utils/SetWindowTitle.js
@@ -19,14 +19,17 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-export default {
-	methods: {
-		setWindowTitle(formTitle) {
-			if (formTitle === '') {
-				window.document.title = t('forms', 'Forms') + ' - ' + OC.theme.title
-			} else {
-				window.document.title = formTitle + ' - ' + t('forms', 'Forms') + ' - ' + OC.theme.title
-			}
-		},
-	},
+/**
+ * Set the Window-Title to current FormTitle including suffix.
+ *
+ * @param {String} formTitle Title of current form to set on window.
+ */
+const SetWindowTitle = function(formTitle) {
+	if (formTitle === '') {
+		window.document.title = t('forms', 'Forms') + ' - ' + OC.theme.title
+	} else {
+		window.document.title = formTitle + ' - ' + t('forms', 'Forms') + ' - ' + OC.theme.title
+	}
 }
+
+export default SetWindowTitle

--- a/src/views/Create.vue
+++ b/src/views/Create.vue
@@ -137,7 +137,7 @@ import QuestionMultiple from '../components/Questions/QuestionMultiple'
 import QuestionShort from '../components/Questions/QuestionShort'
 import TopBar from '../components/TopBar'
 import ViewsMixin from '../mixins/ViewsMixin'
-import WindowTitleMixin from '../mixins/WindowTitleMixin'
+import SetWindowTitle from '../utils/SetWindowTitle'
 
 window.axios = axios
 
@@ -156,7 +156,7 @@ export default {
 		TopBar,
 	},
 
-	mixins: [ViewsMixin, WindowTitleMixin],
+	mixins: [ViewsMixin],
 
 	data() {
 		return {
@@ -175,13 +175,17 @@ export default {
 	},
 
 	computed: {
-		title() {
-			if (this.form.title === '') {
-				return t('forms', 'Create new form')
-			} else {
+		/**
+		 * Return form title, or placeholder if not set
+		 * @returns {string}
+		 */
+		formTitle() {
+			if (this.form.title) {
 				return this.form.title
 			}
+			return t('forms', 'New form')
 		},
+
 		hasQuestions() {
 			return this.form.questions && this.form.questions.length === 0
 		},
@@ -206,13 +210,13 @@ export default {
 
 		// Update Window-Title on title change
 		'form.title': function() {
-			this.setWindowTitle(this.form.title)
+			SetWindowTitle(this.formTitle)
 		},
 	},
 
 	beforeMount() {
 		this.fetchFullForm(this.form.id)
-		this.setWindowTitle(this.form.title)
+		SetWindowTitle(this.formTitle)
 	},
 
 	updated() {

--- a/src/views/Results.vue
+++ b/src/views/Results.vue
@@ -96,7 +96,7 @@ import EmptyContent from '../components/EmptyContent'
 import Submission from '../components/Results/Submission'
 import TopBar from '../components/TopBar'
 import ViewsMixin from '../mixins/ViewsMixin'
-import WindowTitleMixin from '../mixins/WindowTitleMixin'
+import SetWindowTitle from '../utils/SetWindowTitle'
 
 Vue.use(Clipboard)
 
@@ -112,7 +112,7 @@ export default {
 		TopBar,
 	},
 
-	mixins: [ViewsMixin, WindowTitleMixin],
+	mixins: [ViewsMixin],
 
 	data() {
 		return {
@@ -141,7 +141,7 @@ export default {
 
 	beforeMount() {
 		this.loadFormResults()
-		this.setWindowTitle(this.form.title)
+		SetWindowTitle(this.formTitle)
 	},
 
 	methods: {

--- a/src/views/Submit.vue
+++ b/src/views/Submit.vue
@@ -85,7 +85,7 @@ import Question from '../components/Questions/Question'
 import QuestionLong from '../components/Questions/QuestionLong'
 import QuestionShort from '../components/Questions/QuestionShort'
 import QuestionMultiple from '../components/Questions/QuestionMultiple'
-import WindowTitleMixin from '../mixins/WindowTitleMixin'
+import SetWindowTitle from '../utils/SetWindowTitle'
 
 export default {
 	name: 'Submit',
@@ -99,8 +99,6 @@ export default {
 		QuestionShort,
 		QuestionMultiple,
 	},
-
-	mixins: [WindowTitleMixin],
 
 	data() {
 		return {
@@ -152,7 +150,7 @@ export default {
 	},
 
 	beforeMount() {
-		this.setWindowTitle(this.form.title)
+		SetWindowTitle(this.formTitle)
 	},
 
 	methods: {


### PR DESCRIPTION
Like this, @skjnldsv ? ;)

- Also changed to the new computed formTitle property, that Jan introduced. Can one of you check, if the title()-property in Create.vue really was deprecated? I looked through and didn't find a usage, but just to make sure i didn't miss anything.