### PR TITLE
Fix Results initalState missing

### DIFF
--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -171,6 +171,7 @@ class PageController extends Controller {
 	public function getResult(): TemplateResponse {
 		Util::addScript($this->appName, 'forms');
 		Util::addStyle($this->appName, 'forms');
+		$this->initialStateService->provideInitialState($this->appName, 'maxStringLengths', $this->maxStringLengths);
 		return new TemplateResponse($this->appName, 'main');
 	}
 


### PR DESCRIPTION
No big thing, the initialState normally is not used in Results. Just when opening results directly on the link (as i kept the tab open e.g. to watch results) and then changing back to edit-mode, then the initalState was missing and nothing worked until reloading the page.