### PR TITLE
Fix Navigation active on results

### DIFF
--- a/src/components/AppNavigationForm.vue
+++ b/src/components/AppNavigationForm.vue
@@ -23,10 +23,9 @@
 <template>
 	<AppNavigationItem
 		ref="navigationItem"
-		:exact="true"
 		:icon="icon"
 		:title="formTitle"
-		:to="{ name: 'edit', params: { hash: form.hash } }"
+		:to="{ name: 'formRoot', params: { hash: form.hash } }"
 		@click="mobileCloseNavigation">
 		<template v-if="!loading" #actions>
 			<ActionLink

--- a/src/router.js
+++ b/src/router.js
@@ -46,6 +46,12 @@ export default new Router({
 			name: 'root',
 		},
 		{
+			path: '/:hash',
+			redirect: { name: 'edit' },
+			name: 'formRoot',
+			props: true,
+		},
+		{
 			path: '/:hash/edit',
 			components: {
 				default: Create,


### PR DESCRIPTION
- [x] The active class on the navigation is cleared when you are in the response view, but should keep having the relevant form highlighted as active.

I just gave it a try, as i was on to learn new stuff about routes anyway. ;) I didn't find another way to tell the router-link a different active-path than the link, so i chose the form-root, here. Shouldn't interfer with the submission route, as this is done on php already, but will be interesting again, when we want to include the submission-view into the logged-in navigation...

I don't know if this is the proper or best way, so feedback is appreciated, @skjnldsv ;)