### PR TITLE
Fix newQuestions console error mandatory null

### DIFF
--- a/lib/Controller/ApiController.php
+++ b/lib/Controller/ApiController.php
@@ -307,6 +307,7 @@ class ApiController extends Controller {
 		$question->setOrder($questionOrder);
 		$question->setType($type);
 		$question->setText($text);
+		$question->setMandatory(false);
 
 		$question = $this->questionMapper->insert($question);
 


### PR DESCRIPTION
Fixing a small console-error, that appeared when creating a new Question. Mandatory was not read from Db, so returned Null instead of false.