### PR TITLE
Fix some small MultipleInput issues

### DIFF
--- a/src/components/Questions/QuestionMultiple.vue
+++ b/src/components/Questions/QuestionMultiple.vue
@@ -73,7 +73,8 @@
 					:maxlength="maxStringLengths.optionText"
 					minlength="1"
 					type="text"
-					@click="addNewEntry">
+					@click="addNewEntry"
+					@focus="addNewEntry">
 			</li>
 		</ul>
 	</Question>
@@ -218,6 +219,9 @@ export default {
 		 * Add a new empty answer locally
 		 */
 		addNewEntry() {
+			// If entering from non-edit-mode (possible by click), activate edit-mode
+			this.edit = true
+
 			// Add local entry
 			const options = this.options.slice()
 			options.push({
@@ -255,22 +259,28 @@ export default {
 		 * @param {number} id the options id
 		 */
 		deleteOption(id) {
-			// Remove entry
 			const options = this.options.slice()
 			const optionIndex = options.findIndex(option => option.id === id)
-			const option = Object.assign({}, this.options[optionIndex])
 
-			// delete locally
-			options.splice(optionIndex, 1)
+			if (options.length === 1) {
+				// Clear Text, but don't remove. Will be removed, when leaving edit-mode
+				options[0].text = ''
+			} else {
+				// Remove entry
+				const option = Object.assign({}, this.options[optionIndex])
 
-			// delete from Db
-			this.deleteOptionFromDatabase(option)
+				// delete locally
+				options.splice(optionIndex, 1)
+
+				// delete from Db
+				this.deleteOptionFromDatabase(option)
+			}
 
 			// Update question
 			this.updateOptions(options)
 
 			this.$nextTick(() => {
-				this.focusIndex(optionIndex)
+				this.focusIndex(optionIndex - 1)
 			})
 		},
 


### PR DESCRIPTION
_This one is now based onto the delete empty options PR #388 , therefore i marked it as draft for now. I will rebase to master, when the other one is done._

Some small issues somehow nicely fall together in this commit.
- [x] When fastly deleting answers by keyboard, a few answers get deleted, then the backspace suddenly applies to the browser, therefore switching pages
- Navigating from Title to create options is now possible by tab-keys (Didn't find the issue?!)
- Pressing Backspace to delete an option now focuses on the element above, wich is imo the logical order to jump to the line above.
- Deleting the first Option Element is now prevented, just gets emptied. Still gets deleted, when leaving edit mode, but pressing backspace on the single empty answer twice does not completely navigate away anymore, as the focus stays on the text-field.