### PR TITLE
Fix saving options on fast proceed

### DIFF
--- a/src/components/Questions/AnswerInput.vue
+++ b/src/components/Questions/AnswerInput.vue
@@ -59,6 +59,11 @@ export default {
 	data() {
 		return {
 			queue: new PQueue({ concurrency: 1 }),
+
+			// As data instead of Method, to have a separate debounce per AnswerInput
+			debounceUpdateAnswer: pDebounce(function(answer) {
+				return this.queue.add(() => this.updateAnswer(answer))
+			}, 500),
 		}
 	},
 
@@ -179,9 +184,6 @@ export default {
 				console.error(error)
 			}
 		},
-		debounceUpdateAnswer: pDebounce(function(answer) {
-			return this.queue.add(() => this.updateAnswer(answer))
-		}, 500),
 	},
 }
 </script>


### PR DESCRIPTION
> - [x] Sometimes last response option is not saved when using Tab-key to advance to next field

Fastly entering answers, didn't save to Db, as the same debounce applied for all answers. Having a separate debounce for each answer solves that.