### PR TITLE
Prevent question menu icon and menu itself overlapping top right actions

### DIFF
--- a/src/components/TopBar.vue
+++ b/src/components/TopBar.vue
@@ -39,7 +39,7 @@ $top-bar-height: 60px;
 
 .top-bar {
 	position: sticky;
-	z-index: 10;
+	z-index: 100;
 	top: var(--header-height);
 	display: flex;
 	align-items: center;


### PR DESCRIPTION
The menu icon as well as the menu itself overlapped the top bar actions:

Before | After
-|-
![button overlap before](https://user-images.githubusercontent.com/925062/82698902-fa1f2400-9c6b-11ea-8d3c-3804c984b465.png) | ![button overlap after](https://user-images.githubusercontent.com/925062/82698900-f9868d80-9c6b-11ea-9f79-3f72eb18e9bc.png)