### PR TITLE
Put AppNavigationItems into proper Container

### DIFF
--- a/src/Forms.vue
+++ b/src/Forms.vue
@@ -25,11 +25,13 @@
 	<Content app-name="forms">
 		<AppNavigation>
 			<AppNavigationNew button-class="icon-add" :text="t('forms', 'New form')" @click="onNewForm" />
-			<AppNavigationForm v-for="form in forms"
-				:key="form.id"
-				:form="form"
-				@mobile-close-navigation="mobileCloseNavigation"
-				@delete="onDeleteForm" />
+			<template #list>
+				<AppNavigationForm v-for="form in forms"
+					:key="form.id"
+					:form="form"
+					@mobile-close-navigation="mobileCloseNavigation"
+					@delete="onDeleteForm" />
+			</template>
 		</AppNavigation>
 
 		<!-- No forms & loading emptycontents -->


### PR DESCRIPTION
Puts the App-NavigationItems into a list, therefore decoupling the navigation from Body.
Best visible when having a long list of forms, that now has its own scrollbar and does (for the first moment) not scroll with the content.

Depends on https://github.com/nextcloud/nextcloud-vue/pull/1107