### PR TITLE
Adjust cut descenders on formtitle

### DIFF
--- a/src/views/Create.vue
+++ b/src/views/Create.vue
@@ -49,6 +49,7 @@
 				id="form-title"
 				ref="title"
 				v-model="form.title"
+				class="form-title"
 				:minlength="0"
 				:maxlength="maxStringLengths.formTitle"
 				:placeholder="t('forms', 'Form title')"
@@ -417,15 +418,17 @@ export default {
 		margin-top: 44px;
 		margin-bottom: 24px;
 
-		#form-title,
+		.form-title,
 		.form-desc {
 			width: 100%;
 			padding: 0 16px;
 			border: none;
 		}
-		#form-title {
+		.form-title {
 			font-size: 2em;
 			font-weight: bold;
+			color: var(--color-main-text);
+			min-height: 36px;
 			margin: 32px 0;
 			padding-left: 14px; // align with description (compensate font size diff)
 			overflow: hidden;
@@ -433,6 +436,7 @@ export default {
 			white-space: nowrap;
 		}
 		.form-desc {
+			font-size: 100%;
 			padding-bottom: 20px;
 			resize: none;
 		}

--- a/src/views/Create.vue
+++ b/src/views/Create.vue
@@ -431,6 +431,7 @@ export default {
 			min-height: 36px;
 			margin: 32px 0;
 			padding-left: 14px; // align with description (compensate font size diff)
+			padding-bottom: 6px; // align with h2 of .form-title on submit page
 			overflow: hidden;
 			text-overflow: ellipsis;
 			white-space: nowrap;

--- a/src/views/Create.vue
+++ b/src/views/Create.vue
@@ -44,20 +44,22 @@
 
 		<!-- Forms title & description-->
 		<header>
-			<label class="hidden-visually" for="form-title">{{ t('forms', 'Form title') }}</label>
-			<input
-				id="form-title"
-				ref="title"
-				v-model="form.title"
-				class="form-title"
-				:minlength="0"
-				:maxlength="maxStringLengths.formTitle"
-				:placeholder="t('forms', 'Form title')"
-				:required="true"
-				autofocus
-				type="text"
-				@click="selectIfUnchanged"
-				@keyup="onTitleChange">
+			<h2>
+				<label class="hidden-visually" for="form-title">{{ t('forms', 'Form title') }}</label>
+				<input
+					id="form-title"
+					ref="title"
+					v-model="form.title"
+					class="form-title"
+					:minlength="0"
+					:maxlength="maxStringLengths.formTitle"
+					:placeholder="t('forms', 'Form title')"
+					:required="true"
+					autofocus
+					type="text"
+					@click="selectIfUnchanged"
+					@keyup="onTitleChange">
+			</h2>
 			<label class="hidden-visually" for="form-desc">{{ t('forms', 'Description') }}</label>
 			<textarea
 				ref="description"
@@ -418,6 +420,10 @@ export default {
 		margin-top: 44px;
 		margin-bottom: 24px;
 
+		h2 {
+			margin-bottom: 0; // because the input field has enough padding
+		}
+
 		.form-title,
 		.form-desc {
 			width: 100%;
@@ -425,7 +431,7 @@ export default {
 			border: none;
 		}
 		.form-title {
-			font-size: 2em;
+			font-size: 28px;
 			font-weight: bold;
 			color: var(--color-main-text);
 			min-height: 36px;

--- a/src/views/Submit.vue
+++ b/src/views/Submit.vue
@@ -25,7 +25,7 @@
 		<AppContent>
 			<!-- Forms title & description-->
 			<header>
-				<h2 id="form-title">
+				<h2 class="form-title">
 					{{ formTitle }}
 				</h2>
 				<p v-if="!loading && !success" class="form-desc">
@@ -202,15 +202,17 @@ export default {
 		margin-top: 44px;
 		margin-bottom: 24px;
 
-		#form-title,
+		.form-title,
 		.form-desc {
 			width: 100%;
 			padding: 0 16px;
 			border: none;
 		}
-		#form-title {
+		.form-title {
 			font-size: 2em;
 			font-weight: bold;
+			color: var(--color-main-text);
+			min-height: 36px;
 			margin: 32px 0;
 			padding-left: 14px; // align with description (compensate font size diff)
 			overflow: hidden;
@@ -218,6 +220,7 @@ export default {
 			white-space: nowrap;
 		}
 		.form-desc {
+			font-size: 100%;
 			padding-bottom: 20px;
 			resize: none;
 		}

--- a/src/views/Submit.vue
+++ b/src/views/Submit.vue
@@ -209,7 +209,7 @@ export default {
 			border: none;
 		}
 		.form-title {
-			font-size: 2em;
+			font-size: 28px;
 			font-weight: bold;
 			color: var(--color-main-text);
 			min-height: 36px;


### PR DESCRIPTION
> - [x] Descenders of form title are cut, improve padding

- Making a class of form-title, as everything else is a class
- Adjust line-height of title. Using 36px to have least difference between submit & create view. (Input shows vertically centered text, while h2 shows top-aligned text)
- Force equal color on title and equal font-size on description between submit & create view.
