### PR TITLE
Change to vue classes

### DIFF
--- a/src/views/Create.vue
+++ b/src/views/Create.vue
@@ -399,7 +399,7 @@ export default {
 </script>
 
 <style lang="scss">
-#app-content-vue {
+.app-content {
 	display: flex;
 	align-items: center;
 	flex-direction: column;

--- a/src/views/Submit.vue
+++ b/src/views/Submit.vue
@@ -178,14 +178,14 @@ export default {
 }
 </script>
 <style lang="scss" scoped>
-#app-content-vue {
+.app-content {
 	display: flex;
 	align-items: center;
 	flex-direction: column;
 
 	// Force hide navigation toggle as there is no navigation
 	// stylelint-disable-next-line selector-pseudo-element-no-unknown
-	::v-deep #app-navigation-toggle {
+	::v-deep .app-navigation-toggle {
 		display: none !important;
 	}
 


### PR DESCRIPTION
Heading over to classes everywhere, instead of using ids makes it also reasonable to use the vue-classes, as given on the last release of vue-components.

>Please adjust your css styling to the new AppContent and AppNavigation. We're now independent from server styling by changing from:
    #app-content to .app-content
    #app-navigation to .app-navigation
    #app-sidebar to .app-sidebar
    #content to .content
