### PR TITLE
Fix expiration editable

### DIFF
--- a/src/views/Sidebar.vue
+++ b/src/views/Sidebar.vue
@@ -70,6 +70,7 @@
 					:clearable="false"
 					:disabled-date="notBeforeToday"
 					:disabled-time="notBeforeNow"
+					:editable="false"
 					:format="format"
 					:minute-step="5"
 					:placeholder="t('forms', 'Expiration date')"


### PR DESCRIPTION
> -[x] Disable typing on expiration field. When manually changing the text, expires falls back to 1970.