### PR TITLE
Fix variable-typo

### DIFF
--- a/lib/Controller/ApiController.php
+++ b/lib/Controller/ApiController.php
@@ -811,6 +811,6 @@ class ApiController extends Controller {
 		// Delete all submissions (incl. Answers)
 		$this->submissionMapper->deleteByForm($formId);
 
-		return new Http\JSONResponse($id);
+		return new Http\JSONResponse($formId);
 	}
 }


### PR DESCRIPTION
Just found a small variable-typo while testing. Function is called with `formId`, while the response still used `id`.