### PR TITLE
Keep focus when copy Share-Link

### DIFF
--- a/src/components/AppNavigationForm.vue
+++ b/src/components/AppNavigationForm.vue
@@ -184,7 +184,7 @@ export default {
 			}
 		},
 
-		async copyLink() {
+		async copyLink(event) {
 			if (this.$clipboard(this.formLink)) {
 				this.copySuccess = true
 				this.copied = true
@@ -193,6 +193,9 @@ export default {
 				this.copied = true
 				console.debug('Not possible to copy share link')
 			}
+			// Set back focus as clipboard removes focus
+			event.target.focus()
+
 			setTimeout(() => {
 				this.copySuccess = false
 				this.copied = false

--- a/src/views/Results.vue
+++ b/src/views/Results.vue
@@ -161,13 +161,15 @@ export default {
 			})
 		},
 
-		copyShareLink() {
+		copyShareLink(event) {
 			const $formLink = window.location.protocol + '//' + window.location.host + generateUrl(`/apps/forms/${this.form.hash}`)
 			if (this.$clipboard($formLink)) {
 				showSuccess(t('forms', 'Form link copied'))
 			} else {
 				showError(t('forms', 'Cannot copy, please copy the link manually'))
 			}
+			// Set back focus as clipboard removes focus
+			event.target.focus()
 		},
 
 		async loadFormResults() {

--- a/src/views/Sidebar.vue
+++ b/src/views/Sidebar.vue
@@ -323,12 +323,14 @@ export default {
 			return datetime < moment().add(1, 'hour').toDate()
 		},
 
-		copyShareLink() {
+		copyShareLink(event) {
 			if (this.$clipboard(this.shareLink)) {
 				showSuccess(t('forms', 'Form link copied'))
 			} else {
 				showError(t('forms', 'Cannot copy, please copy the link manually'))
 			}
+			// Set back focus as clipboard removes focus
+			event.target.focus()
 		},
 	},
 }


### PR DESCRIPTION
Just recognized, that while navigating around with keyboard, that when choosing copyLink in ActionsMenu, the focus got removed, so Keyboard-Navigation jumped to main-content. Fixed such, that action-element gets focused back.