### PR TITLE
Use icon-add in primary-text color

### DIFF
--- a/css/icons.scss
+++ b/css/icons.scss
@@ -49,3 +49,10 @@
 .icon-maybe {
 	@include icon-color('maybe-vote-variant', 'forms', $color-warning);
 }
+
+.icon-add-primary::before {
+	content: '';
+	background-image: url(icon-color-path('add', 'actions', $color-primary-text, 1, true));
+	width: 16px;
+	height: 16px;
+}

--- a/src/views/Create.vue
+++ b/src/views/Create.vue
@@ -103,7 +103,7 @@
 					:open.sync="questionMenuOpened"
 					:menu-title="t('forms', 'Add a question')"
 					:primary="true"
-					:default-icon="isLoadingQuestions ? 'icon-loading-small' : 'icon-add-white'">
+					:default-icon="isLoadingQuestions ? 'icon-loading-small' : 'icon-add-primary'">
 					<ActionButton v-for="(answer, type) in answerTypes"
 						:key="answer.label"
 						:close-after-click="true"


### PR DESCRIPTION
> * [x] Icon of "Add a question" button should be white in the dark theme as well, as otherwise it's not enough contrast. (But also honor theming color.)

Fixes the icon for now, maybe somewhen can be solved a bit nicer on vue directly: https://github.com/nextcloud/nextcloud-vue/issues/1128