### PR TITLE
Fix time-formatting

### DIFF
--- a/src/views/Sidebar.vue
+++ b/src/views/Sidebar.vue
@@ -127,7 +127,6 @@
 
 <script>
 import { generateUrl } from '@nextcloud/router'
-import { getLocale, getDayNamesShort, getMonthNamesShort } from '@nextcloud/l10n'
 import { subscribe, unsubscribe } from '@nextcloud/event-bus'
 import { showError, showSuccess } from '@nextcloud/dialogs'
 import AppSidebar from '@nextcloud/vue/dist/Components/AppSidebar'
@@ -151,13 +150,10 @@ export default {
 		return {
 			opened: false,
 			lang: {
-				days: getDayNamesShort(),
-				months: getMonthNamesShort(),
 				placeholder: {
 					date: t('forms', 'Select expiration date'),
 				},
 			},
-			locale: 'en',
 			formatter: {
 				stringify: this.stringify,
 				parse: this.parse,
@@ -215,32 +211,6 @@ export default {
 		},
 	},
 
-	async created() {
-		// Load the locale
-		// convert format like en_GB to en-gb for `moment.js`
-		let locale = getLocale().replace('_', '-').toLowerCase()
-		try {
-			// default load e.g. fr-fr
-			await import(/* webpackChunkName: 'moment' */'moment/locale/' + locale)
-			this.locale = locale
-		} catch (e) {
-			try {
-				// failure: fallback to fr
-				locale = locale.split('-')[0]
-				await import(/* webpackChunkName: 'moment' */'moment/locale/' + locale)
-			} catch (e) {
-				// failure, fallback to english
-				console.debug('Fallback to locale', 'en')
-				locale = 'en'
-			}
-		} finally {
-			// force locale change to update
-			// the component once done loading
-			this.locale = locale
-			console.debug('Locale used', locale)
-		}
-	},
-
 	beforeMount() {
 		// Watch for Sidebar toggle
 		subscribe('toggleSidebar', this.onToggle)
@@ -294,7 +264,7 @@ export default {
 		 * @returns {string}
 		 */
 		stringify(datetime) {
-			const date = moment(datetime).locale(this.locale).format('LLL')
+			const date = moment(datetime).format('LLL')
 
 			if (this.isExpired) {
 				return t('forms', 'Expired on {date}', { date })

--- a/webpack.js
+++ b/webpack.js
@@ -15,9 +15,6 @@ const config = {
 			},
 		],
 	},
-	plugins: [
-		new webpack.IgnorePlugin(/^\.\/locale$/, /moment$/),
-	],
 }
 
 module.exports = merge(config, webpackConfig)


### PR DESCRIPTION
This reincludes the moment-locales into the forms-bundle, so @nexctloud/moment can use it.
- Allows moment to format the date on Results - Fix #606 
- Allows moment on the new Date-QuestionType to format the date #672
- Allows moment on sidebar to format automatically, no manual loading necessary anymore.
- Indeed, this increases `forms-main` bundle size from `1.95MiB` to `2.15MiB`, but compared to other apps (Mail `4.3MiB`, Deck `2.72MiB`, Contacts `2.6MiB`), that still seems ok to me. However one could probably find other ways to further reduce the single-package-size.