### PR TITLE
Translators info on multiple choice

### DIFF
--- a/src/models/AnswerTypes.js
+++ b/src/models/AnswerTypes.js
@@ -61,6 +61,7 @@ export default {
 	multiple_unique: {
 		component: QuestionMultiple,
 		icon: 'icon-answer-multiple',
+		// TRANSLATORS Take care, a translation by word might not match! The english called 'Multiple-Choice' only allows to select a single-option (basically single-choice)!
 		label: t('forms', 'Multiple choice'),
 		validate: question => question.options.length > 0,
 


### PR DESCRIPTION
I don't know if this works on js as on php, but just saw it on Community-chat & docs:
https://docs.nextcloud.com/server/latest/developer_manual/basics/front-end/l10n.html?highlight=translators#hints

-> Includes an info for translators on the multiple choice term problem.