### PR TITLE
Fix Popover-Reference

### DIFF
--- a/css/forms.scss
+++ b/css/forms.scss
@@ -26,5 +26,14 @@
 	--top-bar-height: 60px;
 }
 
+/* Fix for action-popover alignment
+ * TODO: Can be removed, as soon as the issue is solved in server or vue-components.
+ * Ref.: https://github.com/nextcloud/nextcloud-vue/issues/1384
+ */
+body {
+	min-height: 100%;
+	height: auto;
+}
+
 @import 'variables';
 @import 'icons';


### PR DESCRIPTION
Just the fix proposed by raimund-schluessler in https://github.com/nextcloud/nextcloud-vue/issues/1384
Thought mainly as a short-term fix here until it is solved in server or vue-components.
- Mainly for a backport-fix and a release of v2.0.5 @skjnldsv ? Might need a separate branch `stable2.0`?

Fixes #609 