### PR TITLE
Make new option return similar to new question and form

### DIFF
--- a/lib/Controller/ApiController.php
+++ b/lib/Controller/ApiController.php
@@ -596,9 +596,7 @@ class ApiController extends Controller {
 
 		$option = $this->optionMapper->insert($option);
 
-		return new DataResponse([
-			'id' => $option->getId()
-		]);
+		return new DataResponse($option->read());
 	}
 
 	/**

--- a/src/components/Questions/AnswerInput.vue
+++ b/src/components/Questions/AnswerInput.vue
@@ -145,7 +145,7 @@ export default {
 		async createAnswer(answer) {
 			try {
 				const response = await axios.post(generateOcsUrl('apps/forms/api/v1', 2) + 'option', {
-					questionId: answer.question_id,
+					questionId: answer.questionId,
 					text: answer.text,
 				})
 				console.debug('Created answer', answer)

--- a/src/components/Questions/QuestionDropdown.vue
+++ b/src/components/Questions/QuestionDropdown.vue
@@ -236,7 +236,7 @@ export default {
 			const options = this.options.slice()
 			options.push({
 				id: GenRandomId(),
-				question_id: this.id,
+				questionId: this.id,
 				text: '',
 				local: true,
 			})

--- a/src/components/Questions/QuestionMultiple.vue
+++ b/src/components/Questions/QuestionMultiple.vue
@@ -243,7 +243,7 @@ export default {
 			const options = this.options.slice()
 			options.push({
 				id: GenRandomId(),
-				question_id: this.id,
+				questionId: this.id,
 				text: '',
 				local: true,
 			})


### PR DESCRIPTION
- I was wondering about this while creating the docs: newOption only returned the new id, while question and form return the full object.
This adapts the newOption api to return the full object, just like newQuestion and newForm respectively do.

- Edit: Second thing i realised during tests: Due to the different naming, we had two questionId properties after creating a new answer. But that's more or less unrelated to the title, sorry for mixing this here. 🙈 