### PR TITLE
Include TopBar Share-button

### DIFF
--- a/src/Forms.vue
+++ b/src/Forms.vue
@@ -60,9 +60,12 @@
 
 		<!-- No errors show router content -->
 		<template v-else>
-			<router-view :form.sync="selectedForm" />
+			<router-view
+				:form.sync="selectedForm"
+				:sidebar-opened.sync="sidebarOpened" />
 			<router-view v-if="!selectedForm.partial"
 				:form="selectedForm"
+				:opened.sync="sidebarOpened"
 				name="sidebar" />
 		</template>
 	</Content>
@@ -101,6 +104,7 @@ export default {
 	data() {
 		return {
 			loading: true,
+			sidebarOpened: true,
 			forms: [],
 		}
 	},

--- a/src/components/TopBar.vue
+++ b/src/components/TopBar.vue
@@ -26,6 +26,9 @@
 <template>
 	<div class="top-bar" role="toolbar">
 		<slot />
+		<div class="top-bar__small">
+			<slot name="small" />
+		</div>
 	</div>
 </template>
 <script>
@@ -51,22 +54,25 @@ $top-bar-height: 60px;
 
 	button {
 		cursor: pointer;
-
-		// Fix button having too little spacing left and right of text
-		&:not(:first-child) {
-			width: 44px;
-			height: 44px;
-			border: none;
-			background-color: transparent;
-			&:hover, a:active, a:focus {
-				background-color: var(--color-background-darker);
-			}
-		}
+		margin-left: 4px;
 
 		> span {
 			cursor: pointer;
 			opacity: 1;
 			background-size: 16px;
+		}
+	}
+
+	&__small {
+		button {
+			width: 44px;
+			height: 44px;
+			margin-left: 0px;
+			border: none;
+			background-color: transparent;
+			&:hover, a:active, a:focus {
+				background-color: var(--color-background-darker);
+			}
 		}
 	}
 }

--- a/src/mixins/ViewsMixin.js
+++ b/src/mixins/ViewsMixin.js
@@ -19,9 +19,13 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { generateOcsUrl } from '@nextcloud/router'
-import { showError } from '@nextcloud/dialogs'
+import { generateUrl, generateOcsUrl } from '@nextcloud/router'
+import { showError, showSuccess } from '@nextcloud/dialogs'
 import axios from '@nextcloud/axios'
+import Clipboard from 'v-clipboard'
+import Vue from 'vue'
+
+Vue.use(Clipboard)
 
 export default {
 	props: {
@@ -49,6 +53,17 @@ export default {
 				showError(t('forms', 'Error while saving form'))
 				console.error(error)
 			}
+		},
+
+		copyShareLink(event) {
+			const $shareLink = window.location.protocol + '//' + window.location.host + generateUrl(`/apps/forms/${this.form.hash}`)
+			if (this.$clipboard($shareLink)) {
+				showSuccess(t('forms', 'Form link copied'))
+			} else {
+				showError(t('forms', 'Cannot copy, please copy the link manually'))
+			}
+			// Set back focus as clipboard removes focus
+			event.target.focus()
 		},
 	},
 }

--- a/src/views/Create.vue
+++ b/src/views/Create.vue
@@ -37,7 +37,7 @@
 					<span class="icon-comment" role="img" />
 					{{ t('forms', 'Responses') }}
 				</button>
-				<button @click="copyShareLink">
+				<button v-if="!sidebarOpened" @click="copyShareLink">
 					<span class="icon-clippy" role="img" />
 					{{ t('forms', 'Share link') }}
 				</button>
@@ -126,7 +126,6 @@
 </template>
 
 <script>
-import { emit } from '@nextcloud/event-bus'
 import { generateOcsUrl } from '@nextcloud/router'
 import { loadState } from '@nextcloud/initial-state'
 import { showError } from '@nextcloud/dialogs'
@@ -168,6 +167,13 @@ export default {
 	},
 
 	mixins: [ViewsMixin],
+
+	props: {
+		sidebarOpened: {
+			type: Boolean,
+			required: true,
+		},
+	},
 
 	data() {
 		return {
@@ -408,7 +414,7 @@ export default {
 			})
 		},
 		toggleSidebar() {
-			emit('toggleSidebar')
+			this.$emit('update:sidebarOpened', !this.sidebarOpened)
 		},
 
 		/**

--- a/src/views/Create.vue
+++ b/src/views/Create.vue
@@ -32,14 +32,22 @@
 	<AppContent v-else>
 		<!-- Show results & sidebar button -->
 		<TopBar>
-			<button @click="showResults">
-				<span class="icon-comment" role="img" />
-				{{ t('forms', 'Responses') }}
-			</button>
-			<button v-tooltip="t('forms', 'Toggle settings')"
-				@click="toggleSidebar">
-				<span class="icon-menu-sidebar" role="img" />
-			</button>
+			<template #default>
+				<button @click="showResults">
+					<span class="icon-comment" role="img" />
+					{{ t('forms', 'Responses') }}
+				</button>
+				<button @click="copyShareLink">
+					<span class="icon-clippy" role="img" />
+					{{ t('forms', 'Share link') }}
+				</button>
+			</template>
+			<template #small>
+				<button v-tooltip="t('forms', 'Toggle settings')"
+					@click="toggleSidebar">
+					<span class="icon-menu-sidebar" role="img" />
+				</button>
+			</template>
 		</TopBar>
 
 		<!-- Forms title & description-->

--- a/src/views/Results.vue
+++ b/src/views/Results.vue
@@ -35,6 +35,10 @@
 				<span class="icon-forms" role="img" />
 				{{ t('forms', 'Back to questions') }}
 			</button>
+			<button v-if="!noSubmissions" @click="copyShareLink">
+				<span class="icon-clippy" role="img" />
+				{{ t('forms', 'Share link') }}
+			</button>
 		</TopBar>
 
 		<header v-if="!noSubmissions">
@@ -117,15 +121,13 @@
 </template>
 
 <script>
-import { generateUrl, generateOcsUrl } from '@nextcloud/router'
-import { showError, showSuccess } from '@nextcloud/dialogs'
+import { generateOcsUrl } from '@nextcloud/router'
+import { showError } from '@nextcloud/dialogs'
 import Actions from '@nextcloud/vue/dist/Components/Actions'
 import ActionButton from '@nextcloud/vue/dist/Components/ActionButton'
 import ActionLink from '@nextcloud/vue/dist/Components/ActionLink'
 import AppContent from '@nextcloud/vue/dist/Components/AppContent'
 import axios from '@nextcloud/axios'
-import Clipboard from 'v-clipboard'
-import Vue from 'vue'
 
 import EmptyContent from '../components/EmptyContent'
 import Summary from '../components/Results/Summary'
@@ -134,8 +136,6 @@ import TopBar from '../components/TopBar'
 import ViewsMixin from '../mixins/ViewsMixin'
 import SetWindowTitle from '../utils/SetWindowTitle'
 import OcsResponse2Data from '../utils/OcsResponse2Data'
-
-Vue.use(Clipboard)
 
 export default {
 	name: 'Results',
@@ -205,17 +205,6 @@ export default {
 					hash: this.form.hash,
 				},
 			})
-		},
-
-		copyShareLink(event) {
-			const $formLink = window.location.protocol + '//' + window.location.host + generateUrl(`/apps/forms/${this.form.hash}`)
-			if (this.$clipboard($formLink)) {
-				showSuccess(t('forms', 'Form link copied'))
-			} else {
-				showError(t('forms', 'Cannot copy, please copy the link manually'))
-			}
-			// Set back focus as clipboard removes focus
-			event.target.focus()
 		},
 
 		async loadFormResults() {

--- a/src/views/Sidebar.vue
+++ b/src/views/Sidebar.vue
@@ -126,7 +126,6 @@
 </template>
 
 <script>
-import { subscribe, unsubscribe } from '@nextcloud/event-bus'
 import AppSidebar from '@nextcloud/vue/dist/Components/AppSidebar'
 import DatetimePicker from '@nextcloud/vue/dist/Components/DatetimePicker'
 import moment from '@nextcloud/moment'
@@ -144,9 +143,15 @@ export default {
 	},
 	mixins: [ViewsMixin],
 
+	props: {
+		opened: {
+			type: Boolean,
+			required: true,
+		},
+	},
+
 	data() {
 		return {
-			opened: false,
 			lang: {
 				placeholder: {
 					date: t('forms', 'Select expiration date'),
@@ -205,24 +210,15 @@ export default {
 		},
 	},
 
-	beforeMount() {
-		// Watch for Sidebar toggle
-		subscribe('toggleSidebar', this.onToggle)
-	},
-
-	beforeDestroy() {
-		unsubscribe('toggleSidebar')
-	},
-
 	methods: {
 		/**
 		 * Sidebar state methods
 		 */
 		onClose() {
-			this.opened = false
+			this.$emit('update:opened', false)
 		},
 		onToggle() {
-			this.opened = !this.opened
+			this.$emit('update:opened', !this.opened)
 		},
 
 		/**

--- a/src/views/Sidebar.vue
+++ b/src/views/Sidebar.vue
@@ -126,9 +126,7 @@
 </template>
 
 <script>
-import { generateUrl } from '@nextcloud/router'
 import { subscribe, unsubscribe } from '@nextcloud/event-bus'
-import { showError, showSuccess } from '@nextcloud/dialogs'
 import AppSidebar from '@nextcloud/vue/dist/Components/AppSidebar'
 import DatetimePicker from '@nextcloud/vue/dist/Components/DatetimePicker'
 import moment from '@nextcloud/moment'
@@ -162,10 +160,6 @@ export default {
 	},
 
 	computed: {
-		shareLink() {
-			return window.location.protocol + '//' + window.location.host + generateUrl(`/apps/forms/${this.form.hash}`)
-		},
-
 		// Inverting submitOnce for UI here. Adapt downto Db for V3, if this imposes for longterm.
 		submitMultiple: {
 			get() {
@@ -297,16 +291,6 @@ export default {
 		 */
 		notBeforeNow(datetime) {
 			return datetime < moment().add(1, 'hour').toDate()
-		},
-
-		copyShareLink(event) {
-			if (this.$clipboard(this.shareLink)) {
-				showSuccess(t('forms', 'Form link copied'))
-			} else {
-				showError(t('forms', 'Cannot copy, please copy the link manually'))
-			}
-			// Set back focus as clipboard removes focus
-			event.target.focus()
 		},
 	},
 }


### PR DESCRIPTION
One more small thing - fixes #581 
On Result-View the new button will **not** show up, if the empty-content is shown, as the empty content already includes this button. I'd like to do this also on Create-View, if the sidebar is open which contains the same button again.
![grafik](https://user-images.githubusercontent.com/47433654/108274811-b2cfb080-7175-11eb-9f63-135e4499d485.png)
![grafik](https://user-images.githubusercontent.com/47433654/108274857-c1b66300-7175-11eb-9f09-d055f81b6f1b.png)


Two things to clarify:
- @skjnldsv As said above, i would like to show the button only, if the sidebar is closed. So we don't have it twice directly next to each other. Do you have a simple way to examine that on Create-View? Unfortunately i don't know how to access the sidebar-open property across the router... 🤔 
- @skjnldsv @jancborchardt Is one of you aware of the current state of `@nextcloud/dialogs`? It seems the `toasts.scss` is built twice, once on forms, once somewhere else. My browser shows me two Inline-Stylesheets with the same content, except the last change on dialogs (dark-mode icon). However the build on forms seems not to be able to resolve the path to the close-icon, so this is not visible.
![grafik](https://user-images.githubusercontent.com/47433654/108274324-07bef700-7175-11eb-9151-b979cb70b6ef.png)
![grafik](https://user-images.githubusercontent.com/47433654/108274382-19a09a00-7175-11eb-8158-8e2ced27076e.png)

