### PR TITLE
Fix toast svg

### DIFF
--- a/webpack.js
+++ b/webpack.js
@@ -7,14 +7,6 @@ const config = {
 	entry: {
 		submit: path.resolve(path.join('src', 'submit.js')),
 	},
-	module: {
-		rules: [
-			{
-				test: /\.svg$/,
-				use: 'url-loader',
-			},
-		],
-	},
 }
 
 module.exports = merge(config, webpackConfig)


### PR DESCRIPTION
Having the url-loader twice results in the handling of its own result.
Toasts now work again:

![grafik](https://user-images.githubusercontent.com/47433654/108642597-803ff380-74a6-11eb-9928-a4e1623d7b92.png)
