### PR TITLE
Properly Scroll for required question

### DIFF
--- a/css/forms.scss
+++ b/css/forms.scss
@@ -25,6 +25,13 @@
 	--top-bar-height: 60px;
 }
 
+/* Padding for Auto-Scroll if a required question is not filled.
+ * 60px matches around the height of two lines of question-text
+ */
+html {
+	scroll-padding-top: calc(var(--header-height) + 60px);
+}
+
 /* Fix for action-popover alignment
  * TODO: Can be removed, as soon as the issue is solved in server or vue-components.
  * Ref.: https://github.com/nextcloud/nextcloud-vue/issues/1384


### PR DESCRIPTION
Small css, that defines the ideal viewing region for automatic scrolling.
We need to keep the distance that the NC-Top-Bar introduces, as well as the distance to see the question, as the input-element will be the reference. The now set 60px correspond around to two lines of question-title. So two lines are still visible, longer question-texts then get cut.
Fixes #449 

![grafik](https://user-images.githubusercontent.com/47433654/108644247-8afe8680-74ae-11eb-9893-b2d26f5a9095.png)
![grafik](https://user-images.githubusercontent.com/47433654/108644218-6dc9b800-74ae-11eb-9257-ff31dc21cfe9.png)