### PR TITLE
Introduce php-constants, use for predefined answerTypes

### DIFF
--- a/lib/Constants.php
+++ b/lib/Constants.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * @copyright Copyright (c) 2021 Jonas Rittershofer <jotoeri@users.noreply.github.com>
+ *
+ * @author Jonas Rittershofer <jotoeri@users.noreply.github.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Forms;
+
+class Constants {
+	/**
+	 * !! Keep in sync with src/models/AnswerTypes.js !!
+	 */
+
+	// Available AnswerTypes
+	public const ANSWER_TYPE_MULTIPLE = 'multiple';
+	public const ANSWER_TYPE_MULTIPLEUNIQUE = 'multiple_unique';
+	public const ANSWER_TYPE_DROPDOWN = 'dropdown';
+	public const ANSWER_TYPE_SHORT = 'short';
+	public const ANSWER_TYPE_LONG = 'long';
+	public const ANSWER_TYPE_DATE = 'date';
+	public const ANSWER_TYPE_DATETIME = 'datetime';
+
+	// AnswerTypes, that need/have predefined Options
+	public const ANSWER_PREDEFINED = [self::ANSWER_TYPE_MULTIPLE, self::ANSWER_TYPE_MULTIPLEUNIQUE, self::ANSWER_TYPE_DROPDOWN];
+}

--- a/lib/Controller/ApiController.php
+++ b/lib/Controller/ApiController.php
@@ -30,6 +30,7 @@ namespace OCA\Forms\Controller;
 use DateTimeZone;
 use Exception;
 
+use OCA\Forms\Constants;
 use OCA\Forms\Db\Answer;
 use OCA\Forms\Db\AnswerMapper;
 use OCA\Forms\Db\Form;
@@ -940,10 +941,7 @@ class ApiController extends OCSController {
 
 			foreach ($answerArray as $answer) {
 				// Are we using answer ids as values
-				if ($question['type'] === 'multiple'
-					|| $question['type'] === 'multiple_unique'
-					|| $question['type'] === 'dropdown') {
-
+				if (in_array($question['type'], Constants::ANSWER_PREDEFINED)) {
 					// Search corresponding option, skip processing if not found
 					$optionIndex = array_search($answer, array_column($question['options'], 'id'));
 					if ($optionIndex === false) {

--- a/src/components/Results/Summary.vue
+++ b/src/components/Results/Summary.vue
@@ -28,7 +28,7 @@
 		</p>
 
 		<!-- Answers with countable results for visualization -->
-		<ol v-if="question.type === 'multiple' || question.type === 'multiple_unique' || question.type === 'dropdown'"
+		<ol v-if="question.type.predefined"
 			class="question-summary__statistic">
 			<li v-for="option in questionOptions"
 				:key="option.id">

--- a/src/models/AnswerTypes.js
+++ b/src/models/AnswerTypes.js
@@ -38,11 +38,13 @@ import QuestionDate from '../components/Questions/QuestionDate'
  */
 export default {
 	/**
+	 * !! Keep in SYNC with lib/Constants.php for props that are necessary on php !!
 	 * Specifying Question-Models in a common place
 	 * Further type-specific parameters are possible.
 	 * @prop component The vue-component this answer-type relies on
 	 * @prop icon The icon corresponding to this answer-type
 	 * @prop label The answer-type label, that users will see as answer-type.
+	 * @prop SYNC predefined This AnswerType has/needs predefined Options.
 	 * @prop validate *optional* Define conditions where this question is not ok
 	 *
 	 * @prop titlePlaceholder The placeholder users see as empty question-title in edit-mode
@@ -55,6 +57,7 @@ export default {
 		component: QuestionMultiple,
 		icon: 'icon-answer-checkbox',
 		label: t('forms', 'Checkboxes'),
+		predefined: true,
 		validate: question => question.options.length > 0,
 
 		titlePlaceholder: t('forms', 'Checkbox question title'),
@@ -66,6 +69,7 @@ export default {
 		icon: 'icon-answer-multiple',
 		// TRANSLATORS Take care, a translation by word might not match! The english called 'Multiple-Choice' only allows to select a single-option (basically single-choice)!
 		label: t('forms', 'Multiple choice'),
+		predefined: true,
 		validate: question => question.options.length > 0,
 
 		titlePlaceholder: t('forms', 'Multiple choice question title'),
@@ -79,6 +83,7 @@ export default {
 		component: QuestionDropdown,
 		icon: 'icon-answer-dropdown',
 		label: t('forms', 'Dropdown'),
+		predefined: true,
 		validate: question => question.options.length > 0,
 
 		titlePlaceholder: t('forms', 'Dropdown question title'),
@@ -91,6 +96,7 @@ export default {
 		component: QuestionShort,
 		icon: 'icon-answer-short',
 		label: t('forms', 'Short answer'),
+		predefined: false,
 
 		titlePlaceholder: t('forms', 'Short answer question title'),
 		createPlaceholder: t('forms', 'People can enter a short answer'),
@@ -102,6 +108,7 @@ export default {
 		component: QuestionLong,
 		icon: 'icon-answer-long',
 		label: t('forms', 'Long text'),
+		predefined: false,
 
 		titlePlaceholder: t('forms', 'Long text question title'),
 		createPlaceholder: t('forms', 'People can enter a long text'),
@@ -113,6 +120,7 @@ export default {
 		component: QuestionDate,
 		icon: 'icon-answer-date',
 		label: t('forms', 'Date'),
+		predefined: false,
 
 		titlePlaceholder: t('forms', 'Date question title'),
 		createPlaceholder: t('forms', 'People can pick a date'),
@@ -124,6 +132,7 @@ export default {
 		component: QuestionDate,
 		icon: 'icon-answer-datetime',
 		label: t('forms', 'Datetime'),
+		predefined: false,
 
 		titlePlaceholder: t('forms', 'Datetime question title'),
 		createPlaceholder: t('forms', 'People can pick a date and time'),


### PR DESCRIPTION
Fixes #524

Not ideal, to have now properties defined in two places. But i don't know a way to provide the constants from js to php, neither to provide arrow-functions as initialState.
So with this, we have everything on js now, and manually sync the necessary properties to php-constants. 🤷‍♂️ 