### PR TITLE
Fix Sharing if deleted users are in list

### DIFF
--- a/lib/Service/FormsService.php
+++ b/lib/Service/FormsService.php
@@ -248,15 +248,18 @@ class FormsService {
 	 * @return array
 	 */
 	private function formatUsers(string $userId): array {
+		$displayName = '';
+
 		$user = $this->userManager->get($userId);
 		if ($user instanceof IUser) {
-			return [
-				'shareWith' => $userId,
-				'displayName' => $user->getDisplayName(),
-				'shareType' => IShare::TYPE_USER
-			];
+			$displayName = $user->getDisplayName();
 		}
-		return [];
+
+		return [
+			'shareWith' => $userId,
+			'displayName' => $displayName,
+			'shareType' => IShare::TYPE_USER
+		];
 	}
 
 	/**
@@ -266,14 +269,17 @@ class FormsService {
 	 * @return array
 	 */
 	private function formatGroups(string $groupId): array {
+		$displayName = '';
+
 		$group = $this->groupManager->get($groupId);
 		if ($group instanceof IGroup) {
-			return [
-				'shareWith' => $groupId,
-				'displayName' => $group->getDisplayName(),
-				'shareType' => IShare::TYPE_GROUP
-			];
+			$displayName = $group->getDisplayName();
 		}
-		return [];
+
+		return [
+			'shareWith' => $groupId,
+			'displayName' => $displayName,
+			'shareType' => IShare::TYPE_GROUP
+		];
 	}
 }


### PR DESCRIPTION
Returning an object with userId and empty Displayname results in a preserved share-array (not accidentially removing the missing users) and Question-Mark Avatar. Sharing-Options can be changed again.
Fix #788 

![grafik](https://user-images.githubusercontent.com/47433654/108788752-075d9c00-7579-11eb-866e-220e4b1c26fc.png)
