### PR TITLE
Fix header-height for NC19

### DIFF
--- a/css/forms.scss
+++ b/css/forms.scss
@@ -22,6 +22,7 @@
 
 // Various variables used by this app
 :root {
+	--header-height: 50px; // TODO Remove this line, when minversion is set to 20
 	--top-bar-height: 60px;
 }
 


### PR DESCRIPTION
Don't know if this is the first time somebody tests forms on NC19... 😄 
These variables were not defined on NC19 yet, so our top-bar is completely hidden and people can't open the sidebar.