### PR TITLE
Fix anonymous text

### DIFF
--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -178,6 +178,7 @@ class PageController extends Controller {
 		// Main Template to fill the form
 		Util::addScript($this->appName, 'forms-submit');
 		$this->initialStateService->provideInitialState($this->appName, 'form', $this->formsService->getPublicForm($form->getId()));
+		$this->initialStateService->provideInitialState($this->appName, 'isLoggedIn', $this->userSession->isLoggedIn());
 		$this->initialStateService->provideInitialState($this->appName, 'maxStringLengths', $this->maxStringLengths);
 		return $this->provideTemplate(self::TEMPLATE_MAIN, $form);
 	}

--- a/src/FormsSubmit.vue
+++ b/src/FormsSubmit.vue
@@ -24,7 +24,8 @@
 	<Content app-name="forms">
 		<Submit
 			:form="form"
-			:public-view="true" />
+			:public-view="true"
+			:is-logged-in="isLoggedIn" />
 	</Content>
 </template>
 
@@ -44,6 +45,7 @@ export default {
 	data() {
 		return {
 			form: loadState('forms', 'form'),
+			isLoggedIn: loadState('forms', 'isLoggedIn'),
 		}
 	},
 }

--- a/src/views/Create.vue
+++ b/src/views/Create.vue
@@ -212,12 +212,17 @@ export default {
 			let message = ''
 			if (this.form.isAnonymous) {
 				message += t('forms', 'Responses are anonymous.')
-			} else {
+			}
+
+			// On Submit, this is dependent on `isLoggedIn`. Create-view is always logged in and the variable isLoggedIn does not exist.
+			if (!this.form.isAnonymous && true) {
 				message += t('forms', 'Responses are connected to your Nextcloud account.')
 			}
+
 			if (this.isMandatoryUsed) {
 				message += ' ' + t('forms', 'An asterisk (*) indicates mandatory questions.')
 			}
+
 			return message
 		},
 	},

--- a/src/views/Submit.vue
+++ b/src/views/Submit.vue
@@ -107,6 +107,14 @@ export default {
 
 	mixins: [ViewsMixin],
 
+	props: {
+		isLoggedIn: {
+			type: Boolean,
+			required: false,
+			default: true,
+		},
+	},
+
 	data() {
 		return {
 			maxStringLengths: loadState('forms', 'maxStringLengths'),
@@ -152,12 +160,14 @@ export default {
 			let message = ''
 			if (this.form.isAnonymous) {
 				message += t('forms', 'Responses are anonymous.')
-			} else {
+			}
+			if (!this.form.isAnonymous && this.isLoggedIn) {
 				message += t('forms', 'Responses are connected to your Nextcloud account.')
 			}
 			if (this.isMandatoryUsed) {
 				message += ' ' + t('forms', 'An asterisk (*) indicates mandatory questions.')
 			}
+
 			return message
 		},
 	},


### PR DESCRIPTION
Now we have:
- Explicitely set Anonymous -> Anonymous Text
- NOT explicitely anonymous && Logged-In -> ConnectedToAccount Text
- NOT explicitely anonymous && NOT Logged-In -> No text.

This seems to me like beeing, what we actually explicitely do. Third case is not explictely wanted as Anonymous, we just call them `Anonymous user`, as we don't have a connected account. This also allows e.g. to create Public Forms with a Name Field (not anonymous), without the Anonymous-Text.

Fixes #782.