### PR TITLE
Fix local CS-Check

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -11,6 +11,7 @@ $config
 	->getFinder()
 	->notPath('build')
 	->notPath('l10n')
+	->notPath('node_modules')
 	->notPath('src')
 	->notPath('vendor')
 	->in(__DIR__);


### PR DESCRIPTION
Some node-dependencies are not compliant with Nextclouds Coding-Standard, so a check on local machine with node-modules installed fails... 🤷‍♂️ 

![grafik](https://user-images.githubusercontent.com/47433654/109173443-20866880-7784-11eb-99d4-ba8a1471e3df.png)
