### PR TITLE
Clarify translations

### DIFF
--- a/lib/Activity/Provider.php
+++ b/lib/Activity/Provider.php
@@ -186,6 +186,7 @@ class Provider implements IProvider {
 			return [
 				'type' => 'highlight',
 				'id' => $userId,
+				// TRANSLATORS Shown as a users display-name
 				'name' => $this->l10n->t('Anonymous user')
 			];
 		}

--- a/lib/Controller/ApiController.php
+++ b/lib/Controller/ApiController.php
@@ -289,6 +289,7 @@ class ApiController extends OCSController {
 			16,
 			ISecureRandom::CHAR_HUMAN_READABLE
 		);
+		// TRANSLATORS Appendix to the form Title of a duplicated/copied form.
 		$formData['title'] .= ' - ' . $this->l10n->t('Copy');
 
 		$newForm = Form::fromParams($formData);
@@ -880,6 +881,7 @@ class ApiController extends OCSController {
 			// Append Display Name
 			if (substr($submission['userId'], 0, 10) === 'anon-user-') {
 				// Anonymous User
+				// TRANSLATORS On Results when listing the single Responses to the form, this text is shown as heading of the Response.
 				$submission['userDisplayName'] = $this->l10n->t('Anonymous response');
 			} else {
 				$userEntity = $this->userManager->get($submission['userId']);

--- a/lib/Service/SubmissionService.php
+++ b/lib/Service/SubmissionService.php
@@ -175,6 +175,7 @@ class SubmissionService {
 			// User
 			$user = $this->userManager->get($submission->getUserId());
 			if ($user === null) {
+				// TRANSLATORS Shown on export if no Display-Name is available.
 				$row[] = $this->l10n->t('Anonymous user');
 			} else {
 				$row[] = $user->getDisplayName();
@@ -198,6 +199,7 @@ class SubmissionService {
 			$data[] = $row;
 		}
 
+		// TRANSLATORS Appendix for CSV-Export: 'Form Title (responses).csv'
 		$fileName = $form->getTitle() . ' (' . $this->l10n->t('responses') . ').csv';
 
 		return [

--- a/src/components/AppNavigationForm.vue
+++ b/src/components/AppNavigationForm.vue
@@ -43,7 +43,7 @@
 				icon="icon-comment"
 				:to="{ name: 'results', params: { hash: form.hash } }"
 				@click="mobileCloseNavigation">
-				{{ t('forms', 'Responses') }}
+				{{ t('forms', 'Results') }}
 			</ActionRouter>
 			<ActionButton :close-after-click="true" icon="icon-clone" @click="onCloneForm">
 				{{ t('forms', 'Copy form') }}
@@ -145,6 +145,8 @@ export default {
 					? t('forms', 'Form link copied')
 					: t('forms', 'Cannot copy, please copy the link manually')
 			}
+
+			// TRANSLATORS Button copies the Share Link to clipboard.
 			return t('forms', 'Share link')
 		},
 

--- a/src/components/Questions/Question.vue
+++ b/src/components/Questions/Question.vue
@@ -53,6 +53,7 @@
 			<Actions v-if="!readOnly" class="question__header-menu" :force-menu="true">
 				<ActionCheckbox :checked="mandatory"
 					@update:checked="onMandatoryChange">
+					<!-- TRANSLATORS Making this question necessary to be answered when submitting to a form -->
 					{{ t('forms', 'Required') }}
 				</ActionCheckbox>
 				<ActionButton icon="icon-delete" @click="onDelete">

--- a/src/components/Results/Summary.vue
+++ b/src/components/Results/Summary.vue
@@ -93,6 +93,7 @@ export default {
 
 			// Also record 'No response'
 			questionOptionsStats.unshift({
+				// TRANSLATORS Counts on Results-Summary, how many users did not respond to this question.
 				text: t('forms', 'No response'),
 				count: 0,
 				percentage: 0,

--- a/src/views/Create.vue
+++ b/src/views/Create.vue
@@ -35,7 +35,8 @@
 			<template #default>
 				<button @click="showResults">
 					<span class="icon-comment" role="img" />
-					{{ t('forms', 'Responses') }}
+					<!-- TRANSLATORS Button to switch to the Result-View -->
+					{{ t('forms', 'Results') }}
 				</button>
 				<button v-if="!sidebarOpened" @click="copyShareLink">
 					<span class="icon-clippy" role="img" />

--- a/src/views/Sidebar.vue
+++ b/src/views/Sidebar.vue
@@ -85,6 +85,7 @@
 					class="checkbox"
 					@change="onAnonChange">
 				<label for="isAnonymous">
+					<!-- TRANSLATORS Checkbox to select whether responses will be stored anonymously or not -->
 					{{ t('forms', 'Anonymous responses') }}
 				</label>
 			</li>


### PR DESCRIPTION
Mostly changing the Responses-Button to "Results", to have a different wording than on the Summary/Responses-Tabs. This enables Translators to have different translations for the Responses-Button and the Responses-Tab. Fixes #794.
@jancborchardt Are you ok with this change 🤔?

Further i included some comments for translators, where i think it could be useful.
@rakekniven Do you have some more points, where you struggle on translations due to a missing context?


![grafik](https://user-images.githubusercontent.com/47433654/109417091-6fb9dc80-79c2-11eb-8b6e-e2157a471045.png)
![grafik](https://user-images.githubusercontent.com/47433654/109417119-8829f700-79c2-11eb-8f71-a81d7dcc8762.png)
![grafik](https://user-images.githubusercontent.com/47433654/109417103-7c3e3500-79c2-11eb-827a-8d09a5d5e85d.png)
