### PR TITLE
Fix compliance

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@ clean:
 	rm -rf $(build_dir)
 	rm -rf node_modules
 	rm -rf vendor
+	rm -rf js
 
 install-deps: install-composer-deps-dev install-npm-deps-dev
 

--- a/lib/Migration/Version010200Date20200323141300.php
+++ b/lib/Migration/Version010200Date20200323141300.php
@@ -341,7 +341,7 @@ class Version010200Date20200323141300 extends SimpleMigrationStep {
 			$cursor = $qb_fetch->execute();
 			while ($vote = $cursor->fetch()) {
 				//If the form changed, if the user changed or if vote_option_id became smaller than last one, then a new submission is interpreted.
-				if (($vote['form_id'] != $last_vote['form_id']) || ($vote['user_id'] != $last_vote['user_id']) || ($vote['vote_option_id'] < $last_vote['vote_option_id'])) {
+				if (($vote['form_id'] !== $last_vote['form_id']) || ($vote['user_id'] !== $last_vote['user_id']) || ($vote['vote_option_id'] < $last_vote['vote_option_id'])) {
 					$qb_restore->insert('forms_v2_submissions')
 						->values([
 							'form_id' => $qb_restore->createNamedParameter($id_mapping['events'][$vote['form_id']]['newId'], IQueryBuilder::PARAM_INT),
@@ -364,7 +364,7 @@ class Version010200Date20200323141300 extends SimpleMigrationStep {
 				 */
 				$oldQuestionId = $event_structure[$vote['form_id']]['questions'][$vote['vote_option_id'] - 1]['id'];
 				//Just throw an Error, if aboves QuestionId-Mapping went wrong. Double-Checked by Question-Text.
-				if ($event_structure[$vote['form_id']]['questions'][$vote['vote_option_id'] - 1]['form_question_text'] != $vote['vote_option_text']) {
+				if ($event_structure[$vote['form_id']]['questions'][$vote['vote_option_id'] - 1]['form_question_text'] !== $vote['vote_option_text']) {
 					$output->warning("Some Question-Mapping went wrong within Submission-Mapping to new Database. On 'vote_id': " . $vote['id'] . " - 'vote_option_text': '" . $vote['vote_option_text'] . "'");
 				}
 


### PR DESCRIPTION
Some smaller thing i realized today:
- `make clean` should also clean the `js`-folder

Forms was not compliant on the `occ app:code-check`:
- Fixes some old `!=` to `!==` on migration

~~Fixes the order (! 😄) of info.xml to be compliant.
Includes compliance as workflow to get notified in case it fails.~~

Edit: Realised on the first run, that the code-check got deprectated on NC22. so i removed the workflow and info.xml changes.