### PR TITLE
Fix router naming conflict

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -25,11 +25,11 @@
 
 return [
 	'routes' => [
-		// Before /{hash}/{action} to avoid conflict
+		// Before /{hash}/{view} to avoid conflict
 		['name' => 'page#goto_form', 'url' => '/{hash}', 'verb' => 'GET'],
 
 		// As parameters have defaults, this catches all routes from '/' to '/hash/edit'
-		['name' => 'page#index', 'url' => '/{hash}/{action}', 'verb' => 'GET', 'defaults' => ['hash' => '', 'action' => '']],
+		['name' => 'page#index', 'url' => '/{hash}/{view}', 'verb' => 'GET', 'defaults' => ['hash' => '', 'view' => '']],
 	],
 	'ocs' => [
 		// Forms

--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -164,7 +164,7 @@ class PageController extends Controller {
 
 		// If not link-shared, redirect to internal route
 		if ($form->getAccess()['type'] !== 'public') {
-			$internalLink = $this->urlGenerator->linkToRoute('forms.page.index', ['hash' => $hash, 'action' => 'submit']);
+			$internalLink = $this->urlGenerator->linkToRoute('forms.page.index', ['hash' => $hash, 'view' => 'submit']);
 
 			if ($this->userSession->isLoggedIn()) {
 				// Directly internal view


### PR DESCRIPTION
Seems like there was a naming conflict with server, which uses the term `action` as some specific parameter on routes.
The conflict persists on 20/21, but however does not throw the error...^^

![grafik](https://user-images.githubusercontent.com/47433654/110613264-5d455d00-8191-11eb-88f5-e70205601ced.png)

Fixes #832 and #831 