### PR TITLE
Fix half access objects

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -11,7 +11,7 @@
 - **🔒 Data under your control!** Unlike in Google Forms, Typeform, Doodle and others, the survey info and responses are kept private on your instance.
 - **🙋 Get involved!** We have lots of stuff planned like more question types, collaboration on forms, [and much more](https://github.com/nextcloud/forms/milestones)!
     ]]></description>
-    <version>2.2.1</version>
+    <version>2.2.2</version>
     <licence>agpl</licence>
 
     <author>Affan Hussain</author>

--- a/lib/Controller/ApiController.php
+++ b/lib/Controller/ApiController.php
@@ -240,7 +240,9 @@ class ApiController extends OCSController {
 		$form->setTitle('');
 		$form->setDescription('');
 		$form->setAccess([
-			'type' => 'public'
+			'type' => 'public',
+			'users' => [],
+			'groups' => []
 		]);
 		$form->setSubmitOnce(true);
 

--- a/lib/Migration/Version020202Date20210311150843.php
+++ b/lib/Migration/Version020202Date20210311150843.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright Copyright (c) 2021 Jonas Rittershofer <jotoeri@users.noreply.github.com>
+ *
+ * @author Jonas Rittershofer <jotoeri@users.noreply.github.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+namespace OCA\Forms\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\DB\QueryBuilder\IQueryBuilder;
+use OCP\IDBConnection;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+class Version020202Date20210311150843 extends SimpleMigrationStep {
+	/** @var IDBConnection */
+	protected $connection;
+
+	/**
+	 * @param IDBConnection $connection
+	 */
+	public function __construct(IDBConnection $connection) {
+		$this->connection = $connection;
+	}
+
+	/**
+	 * Update old Access-Objects to be full objects containing (empty) user- and group-key.
+	 * @param IOutput $output
+	 * @param Closure $schemaClosure The `\Closure` returns a `ISchemaWrapper`
+	 * @param array $options
+	 */
+	public function preSchemaChange(IOutput $output, Closure $schemaClosure, array $options) {
+		$qb_fetch = $this->connection->getQueryBuilder();
+		$qb_update = $this->connection->getQueryBuilder();
+
+		$qb_fetch->select('id', 'access_json')
+			->from('forms_v2_forms');
+		$cursor = $qb_fetch->execute();
+
+		$qb_update->update('forms_v2_forms')
+			->set('access_json', $qb_update->createParameter('access_json'))
+			->where($qb_update->expr()->eq('id', $qb_update->createParameter('id')));
+
+		while ($row = $cursor->fetch()) {
+			// Decode access to array (param assoc=true)
+			$access = json_decode($row['access_json'], true);
+			$update_necessary = false;
+
+			// Add empty Arrays, if they do not exist
+			if (!array_key_exists('users', $access)) {
+				$access['users'] = [];
+				$update_necessary = true;
+			}
+			if (!array_key_exists('groups', $access)) {
+				$access['groups'] = [];
+				$update_necessary = true;
+			}
+
+			// If it was necessary, to insert users or groups, update the table
+			if ($update_necessary) {
+				$qb_update->setParameter('id', $row['id'], IQueryBuilder::PARAM_INT)
+					->setParameter('access_json', json_encode($access), IQueryBuilder::PARAM_STR);
+				$qb_update->execute();
+			}
+		}
+		$cursor->closeCursor();
+	}
+}


### PR DESCRIPTION
Huhh, so. Found some errors on my instance.
Forms, that never got any change on the access-settings did only contain the share type. As soon as there was one change on the access-object, the two arrays got inserted. No problem until now, but on comparing the oldAccess-Array with the new Access-Array for Activity-Creation, the `users` and `groups` keys now are necessary.

I first thought about implementing a fix on the activity-creation, but that seemed to me like some unnecessary code, that we need now, but getting less in time. However we could never really remove it, as there might still be some forms having this problem.... Therefore, i think this is now the cleaner solution:

- Future forms get created, including the users/groups arrays
- Old Forms will be updated on a migration, so all forms now should have the full object.

![grafik](https://user-images.githubusercontent.com/47433654/110843900-1e0a2f80-82a9-11eb-8dc0-43636ff3f20b.png)
