### PR TITLE
Fix Routing

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -25,11 +25,12 @@
 
 return [
 	'routes' => [
-		// Before /{hash}/{view} to avoid conflict
+		// Internal views
+		['name' => 'page#views', 'url' => '/{hash}/{view}', 'verb' => 'GET'],
+		// Share-Link & public submit
 		['name' => 'page#goto_form', 'url' => '/{hash}', 'verb' => 'GET'],
-
-		// As parameters have defaults, this catches all routes from '/' to '/hash/edit'
-		['name' => 'page#index', 'url' => '/{hash}/{view}', 'verb' => 'GET', 'defaults' => ['hash' => '', 'view' => '']],
+		// App Root
+		['name' => 'page#index', 'url' => '/', 'verb' => 'GET'],
 	],
 	'ocs' => [
 		// Forms

--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -148,6 +148,16 @@ class PageController extends Controller {
 	/**
 	 * @NoAdminRequired
 	 * @NoCSRFRequired
+	 *
+	 * @return TemplateResponse
+	 */
+	public function views(): TemplateResponse {
+		return $this->index();
+	}
+
+	/**
+	 * @NoAdminRequired
+	 * @NoCSRFRequired
 	 * @PublicPage
 	 * @param string $hash
 	 * @return RedirectResponse|TemplateResponse Redirect for logged-in users, public template otherwise.
@@ -164,7 +174,7 @@ class PageController extends Controller {
 
 		// If not link-shared, redirect to internal route
 		if ($form->getAccess()['type'] !== 'public') {
-			$internalLink = $this->urlGenerator->linkToRoute('forms.page.index', ['hash' => $hash, 'view' => 'submit']);
+			$internalLink = $this->urlGenerator->linkToRoute('forms.page.views', ['hash' => $hash, 'view' => 'submit']);
 
 			if ($this->userSession->isLoggedIn()) {
 				// Directly internal view


### PR DESCRIPTION
Seems like nginx appends a dash to the base-route, which always was a problem on apache. Don't know why we never ran into these problems.
This way now indeed feels a bit hacky on the page-controller, but the routes seem to be logical and it seems to work on both nginx/apache. 🤷‍♂️ 