### PR TITLE
Fix Dependabot Auto-Approve

### DIFF
--- a/.github/workflows/dependabot-approve-merge.yml
+++ b/.github/workflows/dependabot-approve-merge.yml
@@ -1,5 +1,5 @@
 name: Dependabot
-on: pull_request
+on: pull_request_target
 
 jobs:
   auto-merge:
@@ -7,13 +7,15 @@ jobs:
     steps:
       # Default github action approve
       - uses: hmarr/auto-approve-action@v2.0.0
-        if: github.actor == 'dependabot[bot]' || github.actor == 'dependabot-preview[bot]'
+        if: github.ref == 'refs/heads/master' &&
+            (github.actor == 'dependabot[bot]' || github.actor == 'dependabot-preview[bot]')
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       # Nextcloud bot approve and merge request
-      - uses: ahmadnassri/action-dependabot-auto-merge@v1
-        if: github.actor == 'dependabot[bot]' || github.actor == 'dependabot-preview[bot]'
+      - uses: ahmadnassri/action-dependabot-auto-merge@v2
+        if: github.ref == 'refs/heads/master' &&
+            (github.actor == 'dependabot[bot]' || github.actor == 'dependabot-preview[bot]')
         with:
           target: minor
           github-token: ${{ secrets.DEPENDABOT_AUTOMERGE_TOKEN }}


### PR DESCRIPTION
So after reading through the [Blog Post regarding Action Changes](https://github.blog/changelog/2021-02-19-github-actions-workflows-triggered-by-dependabot-prs-will-run-with-read-only-permissions/) as well as this [Security Blog Post](https://securitylab.github.com/research/github-actions-preventing-pwn-requests), i think we should be save to use this trigger with write-access.
- These actions of course need write-access to the repo to approve and merge the PR (which is now only the case with `pull_request_target`).
- According to the linked Security-Post, the vulnerable Step is to checkout and build/install/run the new branch with write-access, as attackers could such execute their own code with write-access by just creating a pull-request. As we do not checkout the code at all within this action, this shouldn't be a problem.
> Generally speaking, when the **PR contents** are treated as passive data, i.e. not in a position of influence over the build/testing process, it is safe.
- So as long as we assume the bots as actor to be 'TakeOver'-safe and trust the two used actions to be safe having write access, this action should be safe to use.

---
- I further now included a check to run only if the base-branch is the master-branch. This is to avoid people creating a PR onto another PR, thus executing code with write-access-token (as i did on my previous tests). Just can't test that on this branch now.^^
- Further bumped the auto-merge action to v2, as it supports the `pull_requets_target` just since three days.^^
- On this PR the action is not visible now, as it will in future be executed within the master branch (target of the PR). But it seems to work in general with this trigger, some tests are within #855 (before including the master-branch restriction).

PS: Btw., seems like until now, people were able to approve their own PRs by just adding themselves as `github.actor` 🙈 