### PR TITLE
Make date/time answers consistent

### DIFF
--- a/css/icons.scss
+++ b/css/icons.scss
@@ -31,6 +31,7 @@
 @include icon-black-white('answer-long', 'forms', 1);
 @include icon-black-white('answer-date', 'forms', 1);
 @include icon-black-white('answer-datetime', 'forms', 1);
+@include icon-black-white('answer-time', 'forms', 1);
 @include icon-black-white('drag-handle', 'forms', 1);
 
 .icon-yes {

--- a/docs/DataStructure.md
+++ b/docs/DataStructure.md
@@ -172,4 +172,5 @@ Currently supported Question-Types are:
 | `short`         | A short text answer. Single text line |
 | `long`          | A long text answer. Multi-line supported |
 | `date`          | Showing a dropdown calendar to select a date. |
-| `datetime`      | Showing a dropdown calendar to select a date **and** a time. |
+| _`datetime`_      | _deprecated: No longer available for new questions. Showing a dropdown calendar to select a date **and** a time._ |
+| `time`          | Showing a dropdown menu to select a time. |

--- a/img/answer-time.svg
+++ b/img/answer-time.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16">
+  <rect style="marker:none" width="11.678" height="11.469" x="2.161" y="2.266" ry="5.734" rx="5.734" color="#000" overflow="visible" fill="none" stroke="#000" stroke-width="1.358" stroke-linecap="square" paint-order="fill markers stroke"/>
+  <path d="M6.893 4.811l.822 3.516 3.795 2.023" fill="none" stroke="#000"/>
+</svg>

--- a/lib/Constants.php
+++ b/lib/Constants.php
@@ -36,6 +36,7 @@ class Constants {
 	public const ANSWER_TYPE_LONG = 'long';
 	public const ANSWER_TYPE_DATE = 'date';
 	public const ANSWER_TYPE_DATETIME = 'datetime';
+	public const ANSWER_TYPE_TIME = 'time';
 
 	// AnswerTypes, that need/have predefined Options
 	public const ANSWER_PREDEFINED = [self::ANSWER_TYPE_MULTIPLE, self::ANSWER_TYPE_MULTIPLEUNIQUE, self::ANSWER_TYPE_DROPDOWN];

--- a/lib/Constants.php
+++ b/lib/Constants.php
@@ -40,4 +40,10 @@ class Constants {
 
 	// AnswerTypes, that need/have predefined Options
 	public const ANSWER_PREDEFINED = [self::ANSWER_TYPE_MULTIPLE, self::ANSWER_TYPE_MULTIPLEUNIQUE, self::ANSWER_TYPE_DROPDOWN];
+
+	// AnswerTypes for date/time questions
+	public const ANSWER_DATETIME = [self::ANSWER_TYPE_DATE, self::ANSWER_TYPE_DATETIME, self::ANSWER_TYPE_TIME];
+
+	// Formats for AnswerTypes date/datetime/time
+	public const ANSWER_PHPDATETIME_FORMAT = [self::ANSWER_TYPE_DATE => 'Y-m-d', self::ANSWER_TYPE_DATETIME => 'Y-m-d H:i', self::ANSWER_TYPE_TIME => 'H:i'];
 }

--- a/lib/Controller/ApiController.php
+++ b/lib/Controller/ApiController.php
@@ -459,6 +459,12 @@ class ApiController extends OCSController {
 			throw new OCSBadRequestException('Invalid type');
 		}
 
+		// Block creation of datetime questions
+		if ($type === 'datetime') {
+			$this->logger->debug('Datetime question type no longer supported');
+			throw new OCSBadRequestException('Datetime question type no longer supported');
+		}
+
 		try {
 			$form = $this->formMapper->findById($formId);
 		} catch (IMapperException $e) {

--- a/lib/Db/Question.php
+++ b/lib/Db/Question.php
@@ -58,6 +58,7 @@ class Question extends Entity {
 		'dropdown',
 		'date',
 		'datetime',
+		'time',
 	];
 
 	public function __construct() {

--- a/src/components/Questions/QuestionDate.vue
+++ b/src/components/Questions/QuestionDate.vue
@@ -74,7 +74,13 @@ export default {
 	computed: {
 		// Allow picking time or not, depending on variable in answerType.
 		datetimePickerType() {
-			return this.answerType.includeTime ? 'datetime' : 'date'
+			if (this.answerType.includeTime) {
+				return 'datetime'
+			}
+			if (this.answerType.onlyTime) {
+				return 'time'
+			}
+			return 'date'
 		},
 
 		datetimePickerPlaceholder() {
@@ -92,6 +98,9 @@ export default {
 		getMomentFormat() {
 			if (this.datetimePickerType === 'datetime') {
 				return 'LLL'
+			}
+			if (this.datetimePickerType === 'time') {
+				return 'LT'
 			}
 			return 'LL'
 		},

--- a/src/components/Questions/QuestionDate.vue
+++ b/src/components/Questions/QuestionDate.vue
@@ -34,7 +34,6 @@
 		@delete="onDelete">
 		<div class="question__content">
 			<DatetimePicker v-model="time"
-				value-type="format"
 				:disabled="!readOnly"
 				:formatter="formatter"
 				:placeholder="datetimePickerPlaceholder"
@@ -106,6 +105,21 @@ export default {
 		},
 
 		/**
+		 * Calculating the format, that moment should use for storing the values to the Database
+		 *
+		 * @return {string}
+		 */
+		getStorageFormat() {
+			if (this.datetimePickerType === 'datetime') {
+				return 'YYYY-MM-DD HH:mm'
+			}
+			if (this.datetimePickerType === 'time') {
+				return 'HH:mm'
+			}
+			return 'YYYY-MM-DD'
+		},
+
+		/**
 		 * All non-exposed props onto datepicker input-element.
 		 *
 		 * @return {object}
@@ -119,7 +133,7 @@ export default {
 
 	methods: {
 		/**
-		 * DateTimepicker show date-text
+		 * DateTimepicker show text in picker
 		 * Format depends on component-type date/datetime
 		 *
 		 * @param {Date} date the selected datepicker Date
@@ -129,22 +143,22 @@ export default {
 			return moment(date).format(this.getMomentFormat)
 		},
 		/**
-		 * Reinterpret the stringified date
+		 * Reinterpret a stored date
 		 *
 		 * @param {string} dateString Stringified date
 		 * @return {Date}
 		 */
 		parse(dateString) {
-			return moment(dateString, this.getMomentFormat).toDate()
+			return moment(dateString, this.getStorageFormat).toDate()
 		},
 
 		/**
 		 * Store Value
 		 *
-		 * @param {string} dateString The parsed string to store
+		 * @param {Date} date The date to store
 		 */
-		onValueChange(dateString) {
-			this.$emit('update:values', [dateString])
+		onValueChange(date) {
+			this.$emit('update:values', [moment(date).format(this.getStorageFormat)])
 		},
 	},
 }

--- a/src/components/Questions/QuestionDate.vue
+++ b/src/components/Questions/QuestionDate.vue
@@ -38,7 +38,7 @@
 				:formatter="formatter"
 				:placeholder="datetimePickerPlaceholder"
 				:show-second="false"
-				:type="datetimePickerType"
+				:type="answerType.pickerType"
 				:input-attr="inputAttr"
 				@change="onValueChange" />
 		</div>
@@ -71,52 +71,11 @@ export default {
 	},
 
 	computed: {
-		// Allow picking time or not, depending on variable in answerType.
-		datetimePickerType() {
-			if (this.answerType.includeTime) {
-				return 'datetime'
-			}
-			if (this.answerType.onlyTime) {
-				return 'time'
-			}
-			return 'date'
-		},
-
 		datetimePickerPlaceholder() {
 			if (this.readOnly) {
 				return this.answerType.submitPlaceholder
 			}
 			return this.answerType.createPlaceholder
-		},
-
-		/**
-		 * Calculating the format, that moment should use. With or without time.
-		 *
-		 * @return {string}
-		 */
-		getMomentFormat() {
-			if (this.datetimePickerType === 'datetime') {
-				return 'LLL'
-			}
-			if (this.datetimePickerType === 'time') {
-				return 'LT'
-			}
-			return 'LL'
-		},
-
-		/**
-		 * Calculating the format, that moment should use for storing the values to the Database
-		 *
-		 * @return {string}
-		 */
-		getStorageFormat() {
-			if (this.datetimePickerType === 'datetime') {
-				return 'YYYY-MM-DD HH:mm'
-			}
-			if (this.datetimePickerType === 'time') {
-				return 'HH:mm'
-			}
-			return 'YYYY-MM-DD'
 		},
 
 		/**
@@ -140,7 +99,7 @@ export default {
 		 * @return {string}
 		 */
 		stringify(date) {
-			return moment(date).format(this.getMomentFormat)
+			return moment(date).format(this.answerType.momentFormat)
 		},
 		/**
 		 * Reinterpret a stored date
@@ -149,7 +108,7 @@ export default {
 		 * @return {Date}
 		 */
 		parse(dateString) {
-			return moment(dateString, this.getStorageFormat).toDate()
+			return moment(dateString, this.answerType.storageFormat).toDate()
 		},
 
 		/**
@@ -158,7 +117,7 @@ export default {
 		 * @param {Date} date The date to store
 		 */
 		onValueChange(date) {
-			this.$emit('update:values', [moment(date).format(this.getStorageFormat)])
+			this.$emit('update:values', [moment(date).format(this.answerType.storageFormat)])
 		},
 	},
 }

--- a/src/models/AnswerTypes.js
+++ b/src/models/AnswerTypes.js
@@ -35,6 +35,7 @@ import QuestionDate from '../components/Questions/QuestionDate'
  * @property {string} long Long Text Answer
  * @property {string} date Date Answer
  * @property {string} datetime Date and Time Answer
+ * @property {string} time Time Answer
  */
 export default {
 	/**
@@ -137,6 +138,21 @@ export default {
 		titlePlaceholder: t('forms', 'Datetime question title'),
 		createPlaceholder: t('forms', 'People can pick a date and time'),
 		submitPlaceholder: t('forms', 'Pick a date and time'),
+		warningInvalid: t('forms', 'This question needs a title!'),
+
+		// Using the same vue-component as date, this specifies that the component renders as datetime.
+		includeTime: true,
+	},
+
+	time: {
+		component: QuestionDate,
+		icon: 'icon-answer-time',
+		label: t('forms', 'Time'),
+		predefined: false,
+
+		titlePlaceholder: t('forms', 'Time question title'),
+		createPlaceholder: t('forms', 'People can pick a time'),
+		submitPlaceholder: t('forms', 'Pick a time'),
 		warningInvalid: t('forms', 'This question needs a title!'),
 
 		// Using the same vue-component as date, this specifies that the component renders as datetime.

--- a/src/models/AnswerTypes.js
+++ b/src/models/AnswerTypes.js
@@ -155,7 +155,7 @@ export default {
 		submitPlaceholder: t('forms', 'Pick a time'),
 		warningInvalid: t('forms', 'This question needs a title!'),
 
-		// Using the same vue-component as date, this specifies that the component renders as datetime.
-		includeTime: true,
+		// Using the same vue-component as date, this specifies that the component renders as time.
+		onlyTime: true,
 	},
 }

--- a/src/models/AnswerTypes.js
+++ b/src/models/AnswerTypes.js
@@ -127,6 +127,10 @@ export default {
 		createPlaceholder: t('forms', 'People can pick a date'),
 		submitPlaceholder: t('forms', 'Pick a date'),
 		warningInvalid: t('forms', 'This question needs a title!'),
+
+		pickerType: 'date',
+		storageFormat: 'YYYY-MM-DD',
+		momentFormat: 'LL',
 	},
 
 	datetime: {
@@ -140,8 +144,9 @@ export default {
 		submitPlaceholder: t('forms', 'Pick a date and time'),
 		warningInvalid: t('forms', 'This question needs a title!'),
 
-		// Using the same vue-component as date, this specifies that the component renders as datetime.
-		includeTime: true,
+		pickerType: 'datetime',
+		storageFormat: 'YYYY-MM-DD HH:mm',
+		momentFormat: 'LLL',
 	},
 
 	time: {
@@ -155,7 +160,8 @@ export default {
 		submitPlaceholder: t('forms', 'Pick a time'),
 		warningInvalid: t('forms', 'This question needs a title!'),
 
-		// Using the same vue-component as date, this specifies that the component renders as time.
-		onlyTime: true,
+		pickerType: 'time',
+		storageFormat: 'HH:mm',
+		momentFormat: 'LT',
 	},
 }

--- a/src/views/Create.vue
+++ b/src/views/Create.vue
@@ -229,7 +229,7 @@ export default {
 			// Extract property datetime from answerTypes and copy rest to filteredAnswerTypes
 			const { datetime, ...filteredAnswerTypes } = answerTypes
 			return filteredAnswerTypes
-		}
+		},
 	},
 
 	watch: {

--- a/src/views/Create.vue
+++ b/src/views/Create.vue
@@ -108,7 +108,7 @@
 					:menu-title="t('forms', 'Add a question')"
 					:primary="true"
 					:default-icon="isLoadingQuestions ? 'icon-loading-small' : 'icon-add-primary'">
-					<ActionButton v-for="(answer, type) in answerTypes"
+					<ActionButton v-for="(answer, type) in answerTypesFilter"
 						:key="answer.label"
 						:close-after-click="true"
 						:disabled="isLoadingQuestions"
@@ -223,6 +223,13 @@ export default {
 
 			return message
 		},
+
+		// Remove properties from answerTypes for create button
+		answerTypesFilter() {
+			// Extract property datetime from answerTypes and copy rest to filteredAnswerTypes
+			const { datetime, ...filteredAnswerTypes } = answerTypes
+			return filteredAnswerTypes
+		}
 	},
 
 	watch: {

--- a/src/views/Results.vue
+++ b/src/views/Results.vue
@@ -137,6 +137,7 @@ import Summary from '../components/Results/Summary'
 import Submission from '../components/Results/Submission'
 import TopBar from '../components/TopBar'
 import ViewsMixin from '../mixins/ViewsMixin'
+import answerTypes from '../models/AnswerTypes'
 import SetWindowTitle from '../utils/SetWindowTitle'
 import OcsResponse2Data from '../utils/OcsResponse2Data'
 
@@ -290,38 +291,6 @@ export default {
 			} finally {
 				this.loadingResults = false
 			}
-		},
-
-		/**
-		 * Calculating the format, that moment should use to localize the date/time
-		 *
-		 * @param {string} questionType string from question.type
-		 * @return {string}
-		 */
-		getMomentFormat(questionType) {
-			if (questionType === 'datetime') {
-				return 'LLL'
-			}
-			if (questionType === 'time') {
-				return 'LT'
-			}
-			return 'LL'
-		},
-
-		/**
-		 * Calculating the format, that moment should use for reading the values from the Database
-		 *
-		 * @param {string} questionType string from question.type
-		 * @return {string}
-		 */
-		getStorageFormat(questionType) {
-			if (questionType === 'datetime') {
-				return 'YYYY-MM-DD HH:mm'
-			}
-			if (questionType === 'time') {
-				return 'HH:mm'
-			}
-			return 'YYYY-MM-DD'
 		},
 
 		formatDateAnswers(submissions, questions) {

--- a/tests/Unit/Service/SubmissionServiceTest.php
+++ b/tests/Unit/Service/SubmissionServiceTest.php
@@ -531,6 +531,18 @@ class SubmissionServiceTest extends TestCase {
 				// Expected Result
 				false
 			],
+			'invalid-date-question' => [
+				// Questions
+				[
+					['id' => 1, 'type' => 'date', 'isRequired' => false]
+				],
+				// Answers
+				[
+					'1' => ['31.12.2022']
+				],
+				// Expected Result
+				false
+			],
 			'full-good-submission' => [
 				// Questions
 				[
@@ -550,16 +562,18 @@ class SubmissionServiceTest extends TestCase {
 						['id' => 5],
 						['id' => 6]
 					]],
+					['id' => 8, 'type' => 'time', 'isRequired' => false],
 				],
 				// Answers
 				[
 					'1' => ['answer'],
 					'2' => ['answerABitLonger'],
-					'3' => ['28. April 2021'],
-					'4' => ['20. April 2021 04:40'],
+					'3' => ['2021-04-28'],
+					'4' => ['2021-04-30 04:40'],
 					'5' => [1,2],
 					'6' => [4],
 					'7' => [5],
+					'8' => ['17:45']
 				],
 				// Expected Result
 				true


### PR DESCRIPTION
Make date/time answers consistent, this fixes #736 

- [x] Add time answer type
- [x] Store date as 'YYYY-MM-DD'
- [x] Store time as 'HH:mm'
- [x] Remove datetime (backward compatibility?)
- [x] Adjust result views
- [x] Adjust exports?
- [x] Add validation
- [x] Block creation of new datetime-questions on API.

Signed-off-by: Christian Hartmann <chris-hartmann@gmx.de>