### PR TITLE
Improve Question Text

### DIFF
--- a/src/models/AnswerTypes.js
+++ b/src/models/AnswerTypes.js
@@ -100,7 +100,7 @@ export default {
 
 		titlePlaceholder: t('forms', 'Short answer question title'),
 		createPlaceholder: t('forms', 'People can enter a short answer'),
-		submitPlaceholder: t('forms', 'Enter a short answer'),
+		submitPlaceholder: t('forms', 'Enter your answer'),
 		warningInvalid: t('forms', 'This question needs a title!'),
 	},
 
@@ -112,7 +112,7 @@ export default {
 
 		titlePlaceholder: t('forms', 'Long text question title'),
 		createPlaceholder: t('forms', 'People can enter a long text'),
-		submitPlaceholder: t('forms', 'Enter a long text'),
+		submitPlaceholder: t('forms', 'Enter your answer'),
 		warningInvalid: t('forms', 'This question needs a title!'),
 	},
 


### PR DESCRIPTION
>  the bigger issue is that "Short Answer" and "Long Answer" is not a great text string to show to the user as it makes them think they are encouraged to keep the text short or long, which should not happen. Changing the default text to "Your answer" would mitigate this or at least improve it.

@elioqoshi https://github.com/nextcloud/forms/issues/1041#issuecomment-1046217662