### PR TITLE
Replace deprecated String.prototype.substr()

### DIFF
--- a/src/utils/GenRandomId.js
+++ b/src/utils/GenRandomId.js
@@ -24,7 +24,7 @@ const GenRandomId = (length) => {
 	return Math.random()
 		.toString(36)
 		.replace(/[^a-z]+/g, '')
-		.substr(0, length || 5)
+		.slice(0, length || 5)
 }
 
 export default GenRandomId


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.