### PR TITLE
Rework Navigation

### DIFF
--- a/lib/Db/SubmissionMapper.php
+++ b/lib/Db/SubmissionMapper.php
@@ -107,6 +107,23 @@ class SubmissionMapper extends QBMapper {
 	}
 
 	/**
+	 * @throws DBException
+	 */
+	public function countSubmissions(int $formId): int {
+		$qb = $this->db->getQueryBuilder();
+
+		$qb->select($qb->func()->count('*', 'num_submissions'))
+			->from($this->getTableName())
+			->where($qb->expr()->eq('form_id', $qb->createNamedParameter($formId, IQueryBuilder::PARAM_INT)));
+
+		$result = $qb->executeQuery();
+		$row = $result->fetch();
+		$result->closeCursor();
+
+		return (int) ($row['num_submissions' ?? 0]);
+	}
+
+	/**
 	 * Delete the Submission, including answers.
 	 * @param int $id of the submission to delete
 	 */

--- a/lib/Service/FormsService.php
+++ b/lib/Service/FormsService.php
@@ -187,6 +187,11 @@ class FormsService {
 		// Append canSubmit, to be able to show proper EmptyContent on internal view.
 		$result['canSubmit'] = $this->canSubmit($form->getId());
 
+		// Append submissionCount if currentUser is owner
+		if ($this->currentUser && $form->getOwnerId() === $this->currentUser->getUID()) {
+			$result['submissionCount'] = $this->submissionMapper->countSubmissions($id);
+		}
+
 		return $result;
 	}
 
@@ -200,7 +205,7 @@ class FormsService {
 	public function getPartialFormArray(int $id): array {
 		$form = $this->formMapper->findById($id);
 
-		return [
+		$result = [
 			'id' => $form->getId(),
 			'hash' => $form->getHash(),
 			'title' => $form->getTitle(),
@@ -208,6 +213,13 @@ class FormsService {
 			'permissions' => $this->getPermissions($form->getId()),
 			'partial' => true
 		];
+
+		// Append submissionCount if currentUser is owner
+		if ($this->currentUser && $form->getOwnerId() === $this->currentUser->getUID()) {
+			$result['submissionCount'] = $this->submissionMapper->countSubmissions($id);
+		}
+
+		return $result;
 	}
 
 	/**

--- a/src/components/AppNavigationForm.vue
+++ b/src/components/AppNavigationForm.vue
@@ -21,14 +21,22 @@
   -->
 
 <template>
-	<AppNavigationItem ref="navigationItem"
-		:icon="icon"
+	<ListItem ref="navigationItem"
 		:title="formTitle"
 		:to="{
 			name: routerTarget,
 			params: { hash: form.hash }
 		}"
+		:counter-number="form.submissionCount"
+		:active="isActive"
+		:compact="true"
 		@click="mobileCloseNavigation">
+		<template #icon>
+			<div :class="icon" />
+		</template>
+		<template v-if="hasSubtitle" #subtitle>
+			{{ formSubtitle }}
+		</template>
 		<template v-if="!loading && !readOnly" #actions>
 			<ActionButton :close-after-click="true" icon="icon-share" @click="onShareForm">
 				{{ t('forms', 'Share form') }}
@@ -48,7 +56,7 @@
 				{{ t('forms', 'Delete form') }}
 			</ActionButton>
 		</template>
-	</AppNavigationItem>
+	</ListItem>
 </template>
 
 <script>
@@ -57,7 +65,7 @@ import { showError } from '@nextcloud/dialogs'
 import ActionButton from '@nextcloud/vue/dist/Components/ActionButton'
 import ActionRouter from '@nextcloud/vue/dist/Components/ActionRouter'
 import ActionSeparator from '@nextcloud/vue/dist/Components/ActionSeparator'
-import AppNavigationItem from '@nextcloud/vue/dist/Components/AppNavigationItem'
+import ListItem from '@nextcloud/vue/dist/Components/ListItem'
 import axios from '@nextcloud/axios'
 import moment from '@nextcloud/moment'
 
@@ -67,7 +75,7 @@ export default {
 	name: 'AppNavigationForm',
 
 	components: {
-		AppNavigationItem,
+		ListItem,
 		ActionButton,
 		ActionRouter,
 		ActionSeparator,
@@ -101,6 +109,16 @@ export default {
 			return 'icon-forms'
 		},
 
+		/**
+		 * Check if form is current form and set active
+		 */
+		isActive() {
+			return this.form.hash === this.$route.params.hash
+		},
+
+		/**
+		 * Check if form is expired
+		 */
 		isExpired() {
 			return this.form.expires && moment().unix() > this.form.expires
 		},
@@ -115,6 +133,27 @@ export default {
 				return this.form.title
 			}
 			return t('forms', 'New form')
+		},
+
+		/**
+		 * Return expiration details for subtitle
+		 */
+		formSubtitle() {
+			if (this.form.expires) {
+				const relativeDate = moment(this.form.expires, 'X').fromNow()
+				if (this.isExpired) {
+					return t('forms', 'Expired {relativeDate}', { relativeDate })
+				}
+				return t('forms', 'Expires {relativeDate}', { relativeDate })
+			}
+			return ''
+		},
+
+		/**
+		 * Return, if form has Subtitle
+		 */
+		hasSubtitle() {
+			return this.formSubtitle !== ''
 		},
 
 		/**
@@ -164,6 +203,11 @@ export default {
 			}
 		},
 	},
-
 }
 </script>
+
+<style lang="scss" scoped>
+.icon-forms {
+	background-size: 16px;
+}
+</style>


### PR DESCRIPTION
Closes #422 and closes #423

This will partially close the two issues: Sharing will be reworked so it won't be easy to classify. Showing the number of answers redundant in the sidebar and on the responses button won't make that much sense.

Signed-off-by: Christian Hartmann <chris-hartmann@gmx.de>