### PR TITLE
Add Question Description

### DIFF
--- a/lib/Constants.php
+++ b/lib/Constants.php
@@ -25,6 +25,18 @@ namespace OCA\Forms;
 
 class Constants {
 	/**
+	 * Maximum String lengths, the database is set to store.
+	 */
+	public const MAX_STRING_LENGTHS = [
+		'formTitle' => 256,
+		'formDescription' => 8192,
+		'questionText' => 2048,
+		'questionDescription' => 4096,
+		'optionText' => 1024,
+		'answerText' => 4096,
+	];
+
+	/**
 	 * !! Keep in sync with src/models/AnswerTypes.js !!
 	 */
 

--- a/lib/Controller/ApiController.php
+++ b/lib/Controller/ApiController.php
@@ -492,6 +492,7 @@ class ApiController extends OCSController {
 		$question->setOrder($questionOrder);
 		$question->setType($type);
 		$question->setText($text);
+		$question->setDescription('');
 		$question->setIsRequired(false);
 
 		$question = $this->questionMapper->insert($question);

--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -26,6 +26,7 @@
 
 namespace OCA\Forms\Controller;
 
+use OCA\Forms\Constants;
 use OCA\Forms\Db\Form;
 use OCA\Forms\Db\FormMapper;
 use OCA\Forms\Service\FormsService;
@@ -89,19 +90,6 @@ class PageController extends Controller {
 	/** @var IUserSession */
 	private $userSession;
 
-	/** @var Array
-	 *
-	 * Maximum String lengths, the database is set to store.
-	 */
-	private $maxStringLengths = [
-		'formTitle' => 256,
-		'formDescription' => 8192,
-		'questionText' => 2048,
-		'questionDescription' => 4096,
-		'optionText' => 1024,
-		'answerText' => 4096,
-	];
-
 	public function __construct(string $appName,
 								IRequest $request,
 								FormMapper $formMapper,
@@ -142,7 +130,7 @@ class PageController extends Controller {
 		Util::addScript($this->appName, 'forms-main');
 		Util::addStyle($this->appName, 'forms');
 		$this->insertHeaderOnIos();
-		$this->initialStateService->provideInitialState($this->appName, 'maxStringLengths', $this->maxStringLengths);
+		$this->initialStateService->provideInitialState($this->appName, 'maxStringLengths', Constants::MAX_STRING_LENGTHS);
 		return new TemplateResponse($this->appName, self::TEMPLATE_MAIN);
 	}
 
@@ -196,7 +184,7 @@ class PageController extends Controller {
 		$this->insertHeaderOnIos();
 		$this->initialStateService->provideInitialState($this->appName, 'form', $this->formsService->getPublicForm($form->getId()));
 		$this->initialStateService->provideInitialState($this->appName, 'isLoggedIn', $this->userSession->isLoggedIn());
-		$this->initialStateService->provideInitialState($this->appName, 'maxStringLengths', $this->maxStringLengths);
+		$this->initialStateService->provideInitialState($this->appName, 'maxStringLengths', Constants::MAX_STRING_LENGTHS);
 		return $this->provideTemplate(self::TEMPLATE_MAIN, $form);
 	}
 

--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -97,6 +97,7 @@ class PageController extends Controller {
 		'formTitle' => 256,
 		'formDescription' => 8192,
 		'questionText' => 2048,
+		'questionDescription' => 4096,
 		'optionText' => 1024,
 		'answerText' => 4096,
 	];

--- a/lib/Db/Question.php
+++ b/lib/Db/Question.php
@@ -42,6 +42,8 @@ use OCP\AppFramework\Db\Entity;
  * @method void setType(string $value)
  * @method string getText()
  * @method void setText(string $value)
+ * @method string getDescription()
+ * @method void setDescription(string $value)
  */
 class Question extends Entity {
 	protected $formId;
@@ -49,6 +51,7 @@ class Question extends Entity {
 	protected $type;
 	protected $isRequired;
 	protected $text;
+	protected $description;
 
 	public function __construct() {
 		$this->addType('formId', 'integer');
@@ -56,6 +59,7 @@ class Question extends Entity {
 		$this->addType('type', 'string');
 		$this->addType('isRequired', 'bool');
 		$this->addType('text', 'string');
+		$this->addType('description', 'string');
 	}
 
 	public function read(): array {
@@ -66,6 +70,7 @@ class Question extends Entity {
 			'type' => htmlspecialchars_decode($this->getType()),
 			'isRequired' => $this->getIsRequired(),
 			'text' => htmlspecialchars_decode($this->getText()),
+			'description' => htmlspecialchars_decode($this->getDescription()),
 		];
 	}
 }

--- a/lib/Migration/Version030000Date20220414203511.php
+++ b/lib/Migration/Version030000Date20220414203511.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * @copyright Copyright (c) 2022 Jonas Rittershofer <jotoeri@users.noreply.github.com>
+ *
+ * @author Jonas Rittershofer <jotoeri@users.noreply.github.com>
+ *
+ * @license AGPL-3.0-or-later
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+namespace OCA\Forms\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\DB\Types;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+/**
+ * Auto-generated migration step: Please modify to your needs!
+ */
+class Version030000Date20220414203511 extends SimpleMigrationStep {
+	/**
+	 * @param IOutput $output
+	 * @param Closure $schemaClosure The `\Closure` returns a `ISchemaWrapper`
+	 * @param array $options
+	 * @return null|ISchemaWrapper
+	 */
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
+		/** @var ISchemaWrapper $schema */
+		$schema = $schemaClosure();
+		$table = $schema->getTable('forms_v2_questions');
+
+		if (!$table->hasColumn('description')) {
+			$table->addColumn('description', Types::TEXT, [
+				'notnull' => true,
+				'length' => 4096,
+			]);
+
+			return $schema;
+		}
+		
+		return null;
+	}
+}

--- a/src/components/Questions/QuestionDate.vue
+++ b/src/components/Questions/QuestionDate.vue
@@ -23,13 +23,15 @@
 <template>
 	<Question v-bind.sync="$attrs"
 		:text="text"
+		:description="description"
 		:is-required="isRequired"
 		:edit.sync="edit"
 		:read-only="readOnly"
-		:max-question-length="maxStringLengths.questionText"
+		:max-string-lengths="maxStringLengths"
 		:title-placeholder="answerType.titlePlaceholder"
 		:warning-invalid="answerType.warningInvalid"
 		@update:text="onTitleChange"
+		@update:description="onDescriptionChange"
 		@update:isRequired="onRequiredChange"
 		@delete="onDelete">
 		<div class="question__content">

--- a/src/components/Questions/QuestionDropdown.vue
+++ b/src/components/Questions/QuestionDropdown.vue
@@ -23,15 +23,17 @@
 <template>
 	<Question v-bind.sync="$attrs"
 		:text="text"
+		:description="description"
 		:is-required="isRequired"
 		:edit.sync="edit"
 		:read-only="readOnly"
-		:max-question-length="maxStringLengths.questionText"
+		:max-string-lengths="maxStringLengths"
 		:title-placeholder="answerType.titlePlaceholder"
 		:warning-invalid="answerType.warningInvalid"
 		:content-valid="contentValid"
 		:shift-drag-handle="shiftDragHandle"
 		@update:text="onTitleChange"
+		@update:description="onDescriptionChange"
 		@update:isRequired="onRequiredChange"
 		@delete="onDelete">
 		<select v-if="!edit"

--- a/src/components/Questions/QuestionLong.vue
+++ b/src/components/Questions/QuestionLong.vue
@@ -23,13 +23,15 @@
 <template>
 	<Question v-bind.sync="$attrs"
 		:text="text"
+		:description="description"
 		:is-required="isRequired"
 		:edit.sync="edit"
 		:read-only="readOnly"
-		:max-question-length="maxStringLengths.questionText"
+		:max-string-lengths="maxStringLengths"
 		:title-placeholder="answerType.titlePlaceholder"
 		:warning-invalid="answerType.warningInvalid"
 		@update:text="onTitleChange"
+		@update:description="onDescriptionChange"
 		@update:isRequired="onRequiredChange"
 		@delete="onDelete">
 		<div class="question__content">

--- a/src/components/Questions/QuestionMultiple.vue
+++ b/src/components/Questions/QuestionMultiple.vue
@@ -23,15 +23,17 @@
 <template>
 	<Question v-bind.sync="$attrs"
 		:text="text"
+		:description="description"
 		:is-required="isRequired"
 		:edit.sync="edit"
 		:read-only="readOnly"
-		:max-question-length="maxStringLengths.questionText"
+		:max-string-lengths="maxStringLengths"
 		:title-placeholder="answerType.titlePlaceholder"
 		:warning-invalid="answerType.warningInvalid"
 		:content-valid="contentValid"
 		:shift-drag-handle="shiftDragHandle"
 		@update:text="onTitleChange"
+		@update:description="onDescriptionChange"
 		@update:isRequired="onRequiredChange"
 		@delete="onDelete">
 		<ul class="question__content">

--- a/src/components/Questions/QuestionShort.vue
+++ b/src/components/Questions/QuestionShort.vue
@@ -23,13 +23,15 @@
 <template>
 	<Question v-bind.sync="$attrs"
 		:text="text"
+		:description="description"
 		:is-required="isRequired"
 		:edit.sync="edit"
 		:read-only="readOnly"
-		:max-question-length="maxStringLengths.questionText"
+		:max-string-lengths="maxStringLengths"
 		:title-placeholder="answerType.titlePlaceholder"
 		:warning-invalid="answerType.warningInvalid"
 		@update:text="onTitleChange"
+		@update:description="onDescriptionChange"
 		@update:isRequired="onRequiredChange"
 		@delete="onDelete">
 		<div class="question__content">

--- a/src/mixins/QuestionMixin.js
+++ b/src/mixins/QuestionMixin.js
@@ -47,6 +47,14 @@ export default {
 		},
 
 		/**
+		 * Question Description
+		 */
+		description: {
+			type: String,
+			required: true,
+		},
+
+		/**
 		 * Required-Setting
 		 */
 		isRequired: {
@@ -117,6 +125,15 @@ export default {
 		onTitleChange: debounce(function(text) {
 			this.$emit('update:text', text)
 			this.saveQuestionProperty('text', text)
+		}, 200),
+		/**
+		 * Forward the description change to the parent and store to db
+		 *
+		 * @param {string} description the description
+		 */
+		onDescriptionChange: debounce(function(description) {
+			this.$emit('update:description', description)
+			this.saveQuestionProperty('description', description)
 		}, 200),
 
 		/**

--- a/tests/Unit/Service/FormsServiceTest.php
+++ b/tests/Unit/Service/FormsServiceTest.php
@@ -147,6 +147,7 @@ class FormsServiceTest extends TestCase {
 						'type' => 'dropdown',
 						'isRequired' => false,
 						'text' => 'Question 1',
+						'description' => 'This is our first question.',
 						'options' => [
 							[
 								'id' => 1,
@@ -167,6 +168,7 @@ class FormsServiceTest extends TestCase {
 						'type' => 'short',
 						'isRequired' => true,
 						'text' => 'Question 2',
+						'description' => '',
 						'options' => []
 					]
 				]
@@ -228,6 +230,7 @@ class FormsServiceTest extends TestCase {
 		$question1->setType('dropdown');
 		$question1->setIsRequired(false);
 		$question1->setText('Question 1');
+		$question1->setDescription('This is our first question.');
 		$question2 = new Question();
 		$question2->setId(2);
 		$question2->setFormId(42);
@@ -235,6 +238,7 @@ class FormsServiceTest extends TestCase {
 		$question2->setType('short');
 		$question2->setIsRequired(true);
 		$question2->setText('Question 2');
+		$question2->setDescription('');
 		$this->questionMapper->expects($this->once())
 			->method('findByForm')
 			->with(42)


### PR DESCRIPTION
Adding a simple description to questions. Could somewhen be formattable, but for now implements #321 

One thing, that i personally dont like is that the scrollHeight of the textarea seems to have a minimum, that we cannot set. Thus, for short Descriptions, the textarea is relatively large and the content around jumps a bit when enabling/disabling edit-mode. So if sbdy has a good idea to solve that, please tell me, apart from that i think we can go for now with this...

![grafik](https://user-images.githubusercontent.com/47433654/164993030-bd7615a1-b8ca-4c8d-af6f-516cbb02b053.png)

<details>
<summary>Initial image</summary>

![grafik](https://user-images.githubusercontent.com/47433654/163682847-0f1899db-2347-4537-aef9-32ed2baf803c.png)

</details>