### PR TITLE
Show deleted userid on export

### DIFF
--- a/lib/Service/SubmissionService.php
+++ b/lib/Service/SubmissionService.php
@@ -177,12 +177,21 @@ class SubmissionService {
 
 			// User
 			$user = $this->userManager->get($submission->getUserId());
+
+			// If user not found...
 			if ($user === null) {
-				// Give empty userId
-				$row[] = '';
-				// TRANSLATORS Shown on export if no Display-Name is available.
-				$row[] = $this->l10n->t('Anonymous user');
+				// ..due to anonymous user. Give empty uid, show anonymous displayName
+				if (substr($submission->getUserId(), 0, 10) === 'anon-user-') {
+					$row[] = '';
+					// TRANSLATORS Shown on export for anonymous Submissions
+					$row[] = $this->l10n->t('Anonymous user');
+				} else {
+					// ... due to other reason (like deleted user). Show uid, but no displayname
+					$row[] = $submission->getUserId();
+					$row[] = '';
+				}
 			} else {
+				// User found, so provide both, uid and DisplayName
 				$row[] = $user->getUID();
 				$row[] = $user->getDisplayName();
 			}

--- a/tests/Unit/Service/SubmissionServiceTest.php
+++ b/tests/Unit/Service/SubmissionServiceTest.php
@@ -281,6 +281,27 @@ class SubmissionServiceTest extends TestCase {
 				"","Anonymous user","01.01.01, 01:01","Q1A1"
 				'
 			],
+			'deleted-user' => [
+				// Questions
+				[
+					['id' => 1, 'text' => 'Question 1']
+				],
+				// Array of Submissions incl. Answers
+				[
+					[
+						'id' => 1,
+						'userId' => 'deleted_userId',
+						'answers' => [
+							['questionId' => 1, 'text' => 'Q1A1'],
+						]
+					],
+				],
+				// Expected CSV-Result
+				'
+				"User ID","User display name","Timestamp","Question 1"
+				"deleted_userId","","01.01.01, 01:01","Q1A1"
+				'
+			],
 			'questions-not-answered' => [
 				// Questions
 				[


### PR DESCRIPTION
Once a user is not found by the userManager, it is currently shown as anonymous.

This changes the behaviour such:
- For true anonymous users, old behaviour - no uid but DisplayName 'Anonymous user' is shown
- For users whose uid has been stored, but they are currently not found on the instance (e.g. deleted users), the uid is exported, just the displayName remains empty.