### PR TITLE
Fix sharing icons

### DIFF
--- a/src/components/SidebarTabs/SharingSidebarTab.vue
+++ b/src/components/SidebarTabs/SharingSidebarTab.vue
@@ -289,7 +289,7 @@ export default {
 <style lang="scss" scoped>
 .share-div {
 	display: flex;
-	height: 44px;
+	min-height: 44px;
 	align-items: center;
 
 	&--link {
@@ -305,19 +305,20 @@ export default {
 	&__avatar {
 		height: 32px;
 		width: 32px;
+		flex-shrink: 0;
 		border-radius: 50%;
 		background-color: var(--color-background-dark);
 		background-size: 16px;
 	}
 
 	&__desc {
-		padding: 8px;
+		padding: 0px 8px;
 		flex-grow: 1;
 
 		&--twoline {
 			span {
 				display: block;
-				height: 18px;
+				min-height: 18px;
 				line-height: 1.2em;
 			}
 			:last-child {

--- a/src/components/TopBar.vue
+++ b/src/components/TopBar.vue
@@ -55,6 +55,7 @@ $top-bar-height: 60px;
 	button {
 		cursor: pointer;
 		margin-left: 4px;
+		flex-shrink: 0;
 
 		> span {
 			cursor: pointer;


### PR DESCRIPTION
Fixing some css for smartphones, desktop still looks alike.

| before | after |
|---|---|
| ![grafik](https://user-images.githubusercontent.com/47433654/177777711-d4ff00f5-898a-4365-a23d-73c5860119a7.png) | ![grafik](https://user-images.githubusercontent.com/47433654/177777583-bc05ba00-22db-4f9c-9897-b20038650c7e.png) |