### PR TITLE
Move to button component & first material icons

### DIFF
--- a/src/Forms.vue
+++ b/src/Forms.vue
@@ -28,7 +28,7 @@
 				:text="t('forms', 'New form')"
 				@click="onNewForm">
 				<template #icon>
-					<IconPlus size="20" decorative />
+					<IconPlus :size="20" decorative />
 				</template>
 			</NcAppNavigationNew>
 			<template #list>
@@ -61,9 +61,9 @@
 			<EmptyContent v-else-if="!hasForms">
 				{{ t('forms', 'No forms created yet') }}
 				<template v-if="canCreateForms" #action>
-					<button class="primary" @click="onNewForm">
+					<NcButton type="primary" @click="onNewForm">
 						{{ t('forms', 'Create a form') }}
-					</button>
+					</NcButton>
 				</template>
 			</EmptyContent>
 
@@ -71,9 +71,9 @@
 				<span v-if="canCreateForms">{{ t('forms', 'Select a form or create a new one') }}</span>
 				<span v-else>{{ t('forms', 'Please select a form') }}</span>
 				<template v-if="canCreateForms" #action>
-					<button class="primary" @click="onNewForm">
+					<NcButton type="primary" @click="onNewForm">
 						{{ t('forms', 'Create new form') }}
-					</button>
+					</NcButton>
 				</template>
 			</EmptyContent>
 		</NcAppContent>
@@ -103,6 +103,7 @@ import NcAppContent from '@nextcloud/vue/dist/Components/NcAppContent'
 import NcAppNavigation from '@nextcloud/vue/dist/Components/NcAppNavigation'
 import NcAppNavigationCaption from '@nextcloud/vue/dist/Components/NcAppNavigationCaption'
 import NcAppNavigationNew from '@nextcloud/vue/dist/Components/NcAppNavigationNew'
+import NcButton from '@nextcloud/vue/dist/Components/NcButton'
 import NcContent from '@nextcloud/vue/dist/Components/NcContent'
 import isMobile from '@nextcloud/vue/dist/Mixins/isMobile'
 
@@ -125,6 +126,7 @@ export default {
 		NcAppNavigation,
 		NcAppNavigationCaption,
 		NcAppNavigationNew,
+		NcButton,
 		NcContent,
 	},
 

--- a/src/components/TopBar.vue
+++ b/src/components/TopBar.vue
@@ -26,14 +26,49 @@
 <template>
 	<div class="top-bar" role="toolbar">
 		<slot />
-		<div class="top-bar__small">
-			<slot name="small" />
-		</div>
+		<NcButton v-if="showSidebarToggle"
+			v-tooltip="t('forms', 'Toggle settings')"
+			:aria-label="t('forms', 'Toggle settings')"
+			type="tertiary"
+			@click="toggleSidebar">
+			<template #icon>
+				<IconMenuOpen :size="24"
+					:class="{ 'icon--flipped' : sidebarOpened }" />
+			</template>
+		</NcButton>
 	</div>
 </template>
+
 <script>
+import NcButton from '@nextcloud/vue/dist/Components/NcButton'
+import IconMenuOpen from 'vue-material-design-icons/MenuOpen'
+
 export default {
 	name: 'TopBar',
+
+	components: {
+		IconMenuOpen,
+		NcButton,
+	},
+
+	props: {
+		sidebarOpened: {
+			type: Boolean,
+			default: null,
+		},
+	},
+
+	computed: {
+		showSidebarToggle() {
+			return this.sidebarOpened !== null
+		},
+	},
+
+	methods: {
+		toggleSidebar() {
+			this.$emit('update:sidebarOpened', !this.sidebarOpened)
+		},
+	},
 }
 </script>
 
@@ -51,31 +86,9 @@ $top-bar-height: 60px;
 	height: var(--top-bar-height);
 	margin-top: calc(var(--top-bar-height) * -1);
 	padding: 0 6px;
-
-	button {
-		cursor: pointer;
-		margin-left: 4px;
-		flex-shrink: 0;
-
-		> span {
-			cursor: pointer;
-			opacity: 1;
-			background-size: 16px;
-		}
-	}
-
-	&__small {
-		button {
-			width: 44px;
-			height: 44px;
-			margin-left: 0px;
-			border: none;
-			background-color: transparent;
-			&:hover, a:active, a:focus {
-				background-color: var(--color-background-darker);
-			}
-		}
-	}
 }
 
+.icon--flipped {
+	transform: scaleX(-1);
+}
 </style>

--- a/src/views/Create.vue
+++ b/src/views/Create.vue
@@ -31,24 +31,25 @@
 
 	<NcAppContent v-else>
 		<!-- Show results & sidebar button -->
-		<TopBar>
-			<template #default>
-				<button @click="showResults">
-					<span class="icon-comment" role="img" />
-					<!-- TRANSLATORS Button to switch to the Result-View -->
-					{{ t('forms', 'Results') }}
-				</button>
-				<button v-if="!sidebarOpened" @click="onShareForm">
-					<span class="icon-share" role="img" />
-					{{ t('forms', 'Share form') }}
-				</button>
-			</template>
-			<template #small>
-				<button v-tooltip="t('forms', 'Toggle settings')"
-					@click="toggleSidebar">
-					<span class="icon-menu-sidebar" role="img" />
-				</button>
-			</template>
+		<TopBar :sidebar-opened="sidebarOpened"
+			@update:sidebarOpened="onSidebarChange">
+			<NcButton v-tooltip="t('forms', 'Results')"
+				:aria-label="t('forms', 'Results')"
+				type="tertiary"
+				@click="showResults">
+				<template #icon>
+					<IconMessageReplyText :size="20" />
+				</template>
+			</NcButton>
+			<NcButton v-if="!sidebarOpened"
+				v-tooltip="t('forms', 'Share form')"
+				:aria-label="t('forms', 'Share form')"
+				type="tertiary"
+				@click="onShareForm">
+				<template #icon>
+					<IconShareVariant :size="20" />
+				</template>
+			</NcButton>
 		</TopBar>
 
 		<!-- Forms title & description-->
@@ -130,10 +131,13 @@ import { showError } from '@nextcloud/dialogs'
 import axios from '@nextcloud/axios'
 import debounce from 'debounce'
 import Draggable from 'vuedraggable'
+import IconMessageReplyText from 'vue-material-design-icons/MessageReplyText'
+import IconShareVariant from 'vue-material-design-icons/ShareVariant'
 
 import NcActionButton from '@nextcloud/vue/dist/Components/NcActionButton'
 import NcActions from '@nextcloud/vue/dist/Components/NcActions'
 import NcAppContent from '@nextcloud/vue/dist/Components/NcAppContent'
+import NcButton from '@nextcloud/vue/dist/Components/NcButton'
 
 import answerTypes from '../models/AnswerTypes.js'
 import EmptyContent from '../components/EmptyContent.vue'
@@ -154,9 +158,12 @@ export default {
 	components: {
 		Draggable,
 		EmptyContent,
+		IconMessageReplyText,
+		IconShareVariant,
 		NcActionButton,
 		NcActions,
 		NcAppContent,
+		NcButton,
 		Question,
 		QuestionLong,
 		QuestionShort,
@@ -263,6 +270,9 @@ export default {
 		onDescChange() {
 			this.autoSizeDescription()
 			this.saveDescription()
+		},
+		onSidebarChange(newState) {
+			this.$emit('update:sidebarOpened', newState)
 		},
 
 		/**
@@ -383,9 +393,6 @@ export default {
 				},
 			})
 		},
-		toggleSidebar() {
-			this.$emit('update:sidebarOpened', !this.sidebarOpened)
-		},
 
 		/**
 		 * Auto adjust the title height based on lines number
@@ -472,15 +479,6 @@ export default {
 			margin-top: 4px;
 			resize: none;
 			color: var(--color-text-maxcontrast);
-		}
-	}
-
-	.empty-content__button {
-		margin: 5px;
-		> span {
-			margin-right: 5px;
-			cursor: pointer;
-			opacity: 1;
 		}
 	}
 

--- a/src/views/Results.vue
+++ b/src/views/Results.vue
@@ -31,14 +31,23 @@
 
 	<NcAppContent v-else>
 		<TopBar>
-			<button @click="showEdit">
-				<span class="icon-forms" role="img" />
-				{{ t('forms', 'Back to questions') }}
-			</button>
-			<button v-if="!noSubmissions" @click="onShareForm">
-				<span class="icon-share" role="img" />
-				{{ t('forms', 'Share form') }}
-			</button>
+			<NcButton v-tooltip="t('forms', 'Back to questions')"
+				:aria-label="t('forms', 'Back to questions')"
+				type="tertiary"
+				@click="showEdit">
+				<template #icon>
+					<IconReply :size="24" />
+				</template>
+			</NcButton>
+			<NcButton v-if="!noSubmissions"
+				v-tooltip="t('forms', 'Share form')"
+				:aria-label="t('forms', 'Share form')"
+				type="tertiary"
+				@click="onShareForm">
+				<template #icon>
+					<IconShareVariant :size="20" />
+				</template>
+			</NcButton>
 		</TopBar>
 
 		<header v-if="!noSubmissions">
@@ -95,10 +104,12 @@
 					{{ t('forms', 'Results of submitted forms will show up here') }}
 				</template>
 				<template #action>
-					<button class="primary" @click="onShareForm">
-						<span class="icon-share-primary" role="img" />
+					<NcButton type="primary" @click="onShareForm">
+						<template #icon>
+							<IconShareVariant :size="20" decorative />
+						</template>
 						{{ t('forms', 'Share form') }}
-					</button>
+					</NcButton>
 				</template>
 			</EmptyContent>
 		</section>
@@ -129,8 +140,12 @@ import NcActions from '@nextcloud/vue/dist/Components/NcActions'
 import NcActionButton from '@nextcloud/vue/dist/Components/NcActionButton'
 import NcActionLink from '@nextcloud/vue/dist/Components/NcActionLink'
 import NcAppContent from '@nextcloud/vue/dist/Components/NcAppContent'
+import NcButton from '@nextcloud/vue/dist/Components/NcButton'
 import axios from '@nextcloud/axios'
 import moment from '@nextcloud/moment'
+
+import IconShareVariant from 'vue-material-design-icons/ShareVariant'
+import IconReply from 'vue-material-design-icons/Reply'
 
 import EmptyContent from '../components/EmptyContent.vue'
 import Summary from '../components/Results/Summary.vue'
@@ -154,10 +169,13 @@ export default {
 
 	components: {
 		EmptyContent,
+		IconReply,
+		IconShareVariant,
 		NcActions,
 		NcActionButton,
 		NcActionLink,
 		NcAppContent,
+		NcButton,
 		Summary,
 		Submission,
 		TopBar,


### PR DESCRIPTION
Moving to NcButton instead of manually styled ones.

New Toolbar is icon-only with tooltip 🙂:

![grafik](https://user-images.githubusercontent.com/47433654/185709663-4afd4d28-2a81-44fc-9949-148626e05453.png)
![grafik](https://user-images.githubusercontent.com/47433654/185709604-8d111f7a-41f3-4f27-8d1c-b35cd7471f42.png)
