### PR TITLE
Add UI to preview and fill out own forms

### DIFF
--- a/src/components/AppNavigationForm.vue
+++ b/src/components/AppNavigationForm.vue
@@ -40,6 +40,15 @@
 			{{ formSubtitle }}
 		</template>
 		<template v-if="!loading && !readOnly" #actions>
+			<NcActionRouter :close-after-click="true"
+				:exact="true"
+				:to="{ name: 'edit', params: { hash: form.hash } }"
+				@click="mobileCloseNavigation">
+				<template #icon>
+					<IconPencil :size="20" />
+				</template>
+				{{ t('forms', 'Edit form') }}
+			</NcActionRouter>
 			<NcActionButton :close-after-click="true" @click="onShareForm">
 				<template #icon>
 					<IconShareVariant :size="20" />
@@ -85,6 +94,7 @@ import moment from '@nextcloud/moment'
 import IconCheck from 'vue-material-design-icons/Check'
 import IconContentCopy from 'vue-material-design-icons/ContentCopy'
 import IconDelete from 'vue-material-design-icons/Delete'
+import IconPencil from 'vue-material-design-icons/Pencil'
 import IconMessageReplyText from 'vue-material-design-icons/MessageReplyText'
 import IconShareVariant from 'vue-material-design-icons/ShareVariant'
 
@@ -100,6 +110,7 @@ export default {
 		IconCheck,
 		IconContentCopy,
 		IconDelete,
+		IconPencil,
 		IconMessageReplyText,
 		IconShareVariant,
 		NcActionButton,

--- a/src/components/TopBar.vue
+++ b/src/components/TopBar.vue
@@ -26,6 +26,42 @@
 <template>
 	<div class="top-bar" role="toolbar">
 		<slot />
+		<NcButton v-if="canSubmit && $route.name !== 'submit'"
+			v-tooltip="t('forms', 'View form')"
+			:aria-label="t('forms', 'View form')"
+			type="tertiary"
+			@click="showSubmit">
+			<template #icon>
+				<IconEye :size="20" />
+			</template>
+		</NcButton>
+		<NcButton v-if="canEdit && $route.name !== 'edit'"
+			v-tooltip="t('forms', 'Edit form')"
+			:aria-label="t('forms', 'Edit form')"
+			type="tertiary"
+			@click="showEdit">
+			<template #icon>
+				<IconPencil :size="20" />
+			</template>
+		</NcButton>
+		<NcButton v-if="canSeeResults && $route.name !== 'results'"
+			v-tooltip="t('forms', 'Results')"
+			:aria-label="t('forms', 'Results')"
+			type="tertiary"
+			@click="showResults">
+			<template #icon>
+				<IconMessageReplyText :size="20" />
+			</template>
+		</NcButton>
+		<NcButton v-if="canShare && !sidebarOpened"
+			v-tooltip="t('forms', 'Share form')"
+			:aria-label="t('forms', 'Share form')"
+			type="tertiary"
+			@click="onShareForm">
+			<template #icon>
+				<IconShareVariant :size="20" />
+			</template>
+		</NcButton>
 		<NcButton v-if="showSidebarToggle"
 			v-tooltip="t('forms', 'Toggle settings')"
 			:aria-label="t('forms', 'Toggle settings')"
@@ -42,23 +78,51 @@
 <script>
 import NcButton from '@nextcloud/vue/dist/Components/NcButton'
 import IconMenuOpen from 'vue-material-design-icons/MenuOpen'
+import IconMessageReplyText from 'vue-material-design-icons/MessageReplyText'
+import IconEye from 'vue-material-design-icons/Eye'
+import IconPencil from 'vue-material-design-icons/Pencil'
+import IconShareVariant from 'vue-material-design-icons/ShareVariant'
+import PermissionTypes from '../mixins/PermissionTypes.js'
 
 export default {
 	name: 'TopBar',
 
 	components: {
+		IconEye,
 		IconMenuOpen,
+		IconMessageReplyText,
+		IconPencil,
+		IconShareVariant,
 		NcButton,
 	},
+
+	mixins: [PermissionTypes],
 
 	props: {
 		sidebarOpened: {
 			type: Boolean,
 			default: null,
 		},
+		permissions: {
+			type: Array,
+			default: () => [],
+		},
 	},
 
 	computed: {
+		canEdit() {
+			return this.permissions.includes(this.PERMISSION_TYPES.PERMISSION_EDIT)
+		},
+		canSubmit() {
+			return this.permissions.includes(this.PERMISSION_TYPES.PERMISSION_SUBMIT)
+		},
+		canSeeResults() {
+			return this.permissions.includes(this.PERMISSION_TYPES.PERMISSION_RESULTS)
+		},
+		canShare() {
+			// This probably can get a permission of itself
+			return this.canEdit || this.canSeeResults
+		},
 		showSidebarToggle() {
 			return this.sidebarOpened !== null
 		},
@@ -67,6 +131,40 @@ export default {
 	methods: {
 		toggleSidebar() {
 			this.$emit('update:sidebarOpened', !this.sidebarOpened)
+		},
+
+		/**
+		 * Router methods
+		 */
+		showEdit() {
+			this.$router.push({
+				name: 'edit',
+				params: {
+					hash: this.$route.params.hash,
+				},
+			})
+		},
+
+		showResults() {
+			this.$router.push({
+				name: 'results',
+				params: {
+					hash: this.$route.params.hash,
+				},
+			})
+		},
+
+		showSubmit() {
+			this.$router.push({
+				name: 'submit',
+				params: {
+					hash: this.$route.params.hash,
+				},
+			})
+		},
+
+		onShareForm() {
+			this.$emit('share-form')
 		},
 	},
 }

--- a/src/mixins/ViewsMixin.js
+++ b/src/mixins/ViewsMixin.js
@@ -59,6 +59,10 @@ export default {
 	},
 
 	methods: {
+		onShareForm() {
+			this.$emit('open-sharing', this.form.hash)
+		},
+
 		/**
 		 * Focus title after form load
 		 */

--- a/src/router.js
+++ b/src/router.js
@@ -48,7 +48,7 @@ export default new Router({
 		},
 		{
 			path: '/:hash',
-			redirect: { name: 'edit' },
+			redirect: { name: 'submit' },
 			name: 'formRoot',
 			props: true,
 		},

--- a/src/views/Create.vue
+++ b/src/views/Create.vue
@@ -33,27 +33,10 @@
 
 	<NcAppContent v-else>
 		<!-- Show results & sidebar button -->
-		<TopBar :sidebar-opened="sidebarOpened"
-			@update:sidebarOpened="onSidebarChange">
-			<NcButton v-tooltip="t('forms', 'Results')"
-				:aria-label="t('forms', 'Results')"
-				type="tertiary"
-				@click="showResults">
-				<template #icon>
-					<IconMessageReplyText :size="20" />
-				</template>
-			</NcButton>
-			<NcButton v-if="!sidebarOpened"
-				v-tooltip="t('forms', 'Share form')"
-				:aria-label="t('forms', 'Share form')"
-				type="tertiary"
-				@click="onShareForm">
-				<template #icon>
-					<IconShareVariant :size="20" />
-				</template>
-			</NcButton>
-		</TopBar>
-
+		<TopBar :permissions="form?.permissions"
+			:sidebar-opened="sidebarOpened"
+			@update:sidebarOpened="onSidebarChange"
+			@share-form="onShareForm" />
 		<!-- Forms title & description-->
 		<header>
 			<h2>
@@ -138,14 +121,11 @@ import { showError } from '@nextcloud/dialogs'
 import axios from '@nextcloud/axios'
 import debounce from 'debounce'
 import Draggable from 'vuedraggable'
-import IconMessageReplyText from 'vue-material-design-icons/MessageReplyText'
 import IconPlus from 'vue-material-design-icons/Plus'
-import IconShareVariant from 'vue-material-design-icons/ShareVariant'
 
 import NcActionButton from '@nextcloud/vue/dist/Components/NcActionButton'
 import NcActions from '@nextcloud/vue/dist/Components/NcActions'
 import NcAppContent from '@nextcloud/vue/dist/Components/NcAppContent'
-import NcButton from '@nextcloud/vue/dist/Components/NcButton'
 import NcEmptyContent from '@nextcloud/vue/dist/Components/NcEmptyContent'
 import NcLoadingIcon from '@nextcloud/vue/dist/Components/NcLoadingIcon'
 
@@ -166,13 +146,10 @@ export default {
 	name: 'Create',
 	components: {
 		Draggable,
-		IconMessageReplyText,
 		IconPlus,
-		IconShareVariant,
 		NcActionButton,
 		NcActions,
 		NcAppContent,
-		NcButton,
 		NcEmptyContent,
 		NcLoadingIcon,
 		Question,
@@ -296,10 +273,6 @@ export default {
 			this.saveFormProperty('description')
 		}, 200),
 
-		onShareForm() {
-			this.$emit('open-sharing', this.form.hash)
-		},
-
 		/**
 		 * Add a new question to the current form
 		 *
@@ -391,18 +364,6 @@ export default {
 					this.$refs.questionMenu.focusFirstAction()
 				})
 			}, 10)
-		},
-
-		/**
-		 * Topbar methods
-		 */
-		showResults() {
-			this.$router.push({
-				name: 'results',
-				params: {
-					hash: this.form.hash,
-				},
-			})
 		},
 
 		/**

--- a/src/views/Results.vue
+++ b/src/views/Results.vue
@@ -32,26 +32,7 @@
 	</NcAppContent>
 
 	<NcAppContent v-else>
-		<TopBar>
-			<NcButton v-tooltip="t('forms', 'Back to questions')"
-				:aria-label="t('forms', 'Back to questions')"
-				type="tertiary"
-				@click="showEdit">
-				<template #icon>
-					<IconReply :size="24" />
-				</template>
-			</NcButton>
-			<NcButton v-if="!noSubmissions"
-				v-tooltip="t('forms', 'Share form')"
-				:aria-label="t('forms', 'Share form')"
-				type="tertiary"
-				@click="onShareForm">
-				<template #icon>
-					<IconShareVariant :size="20" />
-				</template>
-			</NcButton>
-		</TopBar>
-
+		<TopBar :permissions="form?.permissions" @share-form="onShareForm" />
 		<header v-if="!noSubmissions">
 			<h2>{{ formTitle }}</h2>
 			<p>{{ t('forms', '{amount} responses', { amount: form.submissions.length }) }}</p>
@@ -161,7 +142,6 @@ import IconDelete from 'vue-material-design-icons/Delete'
 import IconDownload from 'vue-material-design-icons/Download'
 import IconFolder from 'vue-material-design-icons/Folder'
 import IconMessageReplyText from 'vue-material-design-icons/MessageReplyText.vue'
-import IconReply from 'vue-material-design-icons/Reply'
 import IconShareVariant from 'vue-material-design-icons/ShareVariant'
 
 import Summary from '../components/Results/Summary.vue'
@@ -188,7 +168,6 @@ export default {
 		IconDownload,
 		IconFolder,
 		IconMessageReplyText,
-		IconReply,
 		IconShareVariant,
 		NcActions,
 		NcActionButton,
@@ -251,19 +230,6 @@ export default {
 	},
 
 	methods: {
-		showEdit() {
-			this.$router.push({
-				name: 'edit',
-				params: {
-					hash: this.form.hash,
-				},
-			})
-		},
-
-		onShareForm() {
-			this.$emit('open-sharing', this.form.hash)
-		},
-
 		async loadFormResults() {
 			this.loadingResults = true
 			logger.debug(`Loading results for form ${this.form.hash}`)

--- a/src/views/Submit.vue
+++ b/src/views/Submit.vue
@@ -30,6 +30,8 @@
 	</NcAppContent>
 
 	<NcAppContent v-else>
+		<TopBar :permissions="form?.permissions" @share-form="onShareForm" />
+
 		<!-- Forms title & description-->
 		<header>
 			<h2 ref="title" class="form-title">
@@ -50,6 +52,13 @@
 		</NcEmptyContent>
 		<NcEmptyContent v-else-if="success || !form.canSubmit"
 			:title="t('forms', 'Thank you for completing the form!')">
+			<template #icon>
+				<IconCheck :size="64" />
+			</template>
+		</NcEmptyContent>
+		<NcEmptyContent v-else-if="isExpired"
+			:title="t('forms', 'Form expired')"
+			:description="t('forms', 'This form has expired and is no longer taking answers')">
 			<template #icon>
 				<IconCheck :size="64" />
 			</template>
@@ -88,10 +97,10 @@ import { loadState } from '@nextcloud/initial-state'
 import { generateOcsUrl } from '@nextcloud/router'
 import { showError } from '@nextcloud/dialogs'
 import axios from '@nextcloud/axios'
+import moment from '@nextcloud/moment'
 import NcAppContent from '@nextcloud/vue/dist/Components/NcAppContent'
 import NcEmptyContent from '@nextcloud/vue/dist/Components/NcEmptyContent'
 import NcLoadingIcon from '@nextcloud/vue/dist/Components/NcLoadingIcon'
-
 import IconCheck from 'vue-material-design-icons/Check'
 
 import answerTypes from '../models/AnswerTypes.js'
@@ -101,6 +110,7 @@ import Question from '../components/Questions/Question.vue'
 import QuestionLong from '../components/Questions/QuestionLong.vue'
 import QuestionShort from '../components/Questions/QuestionShort.vue'
 import QuestionMultiple from '../components/Questions/QuestionMultiple.vue'
+import TopBar from '../components/TopBar.vue'
 import SetWindowTitle from '../utils/SetWindowTitle.js'
 import ViewsMixin from '../mixins/ViewsMixin.js'
 
@@ -116,6 +126,7 @@ export default {
 		QuestionLong,
 		QuestionShort,
 		QuestionMultiple,
+		TopBar,
 	},
 
 	mixins: [ViewsMixin],
@@ -172,6 +183,13 @@ export default {
 
 		isRequiredUsed() {
 			return this.form.questions.reduce((isUsed, question) => isUsed || question.isRequired, false)
+		},
+
+		/**
+		 * Check if form is expired
+		 */
+		isExpired() {
+			return this.form.expires && moment().unix() > this.form.expires
 		},
 
 		infoMessage() {

--- a/webpack.js
+++ b/webpack.js
@@ -2,7 +2,7 @@ const path = require('path')
 const webpackConfig = require('@nextcloud/webpack-vue-config')
 
 webpackConfig.entry.emptyContent = path.resolve(path.join('src', 'emptyContent.js'))
-webpackConfig.entry.submit =  path.resolve(path.join('src', 'submit.js'))
+webpackConfig.entry.submit = path.resolve(path.join('src', 'submit.js'))
 webpackConfig.entry.settings = path.resolve(path.join('src', 'settings.js'))
 
 module.exports = webpackConfig


### PR DESCRIPTION
This implements #1023 by providing a button to switch to the submit view
of an owned form like suggested in the [issue comment](https://github.com/nextcloud/forms/issues/1023#issuecomment-972117908).

So basically this buttons are added:
![View form button in TopBar](https://user-images.githubusercontent.com/1855448/187906278-2f5566aa-5234-469f-8993-503355649b43.png)

![View form button in forms list context menu](https://user-images.githubusercontent.com/1855448/187906121-371d0228-e46c-4be9-9004-5cda84ce90cc.png)

This also adds the `TopBar` to the submit view (for owned forms) to make the UX more consistent.