### PR TITLE
Fix migration 20220414 not working on SQLite

### DIFF
--- a/lib/Migration/Version030000Date20220414203511.php
+++ b/lib/Migration/Version030000Date20220414203511.php
@@ -44,7 +44,7 @@ class Version030000Date20220414203511 extends SimpleMigrationStep {
 
 		if (!$table->hasColumn('description')) {
 			$table->addColumn('description', Types::TEXT, [
-				'notnull' => true,
+				'notnull' => false,
 				'length' => 4096,
 			]);
 


### PR DESCRIPTION
* Fixed #1333 

SQLite does not allow to add columns `notnull` without default value the default value is also not allowed to be an empty string.

`notnull` without a default is only allowed on table creation, not on modification later on.