### PR TITLE
Adjust styling for NC25 & Update `@nextcloud/vue`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
 				"@nextcloud/logger": "^2.3.0",
 				"@nextcloud/moment": "^1.2.1",
 				"@nextcloud/router": "^2.0.0",
-				"@nextcloud/vue": "^6.0.0-beta.7",
+				"@nextcloud/vue": "^7.0.0-beta.3",
 				"core-js": "^3.25.1",
 				"crypto-js": "^4.1.1",
 				"debounce": "^1.2.1",
@@ -34,8 +34,8 @@
 			},
 			"devDependencies": {
 				"@nextcloud/babel-config": "^1.0.0",
-				"@nextcloud/browserslist-config": "^2.2.0",
-				"@nextcloud/eslint-config": "^8.0.0",
+				"@nextcloud/browserslist-config": "^2.3.0",
+				"@nextcloud/eslint-config": "8.0.0",
 				"@nextcloud/stylelint-config": "^2.2.0",
 				"@nextcloud/webpack-vue-config": "^5.3.0"
 			},
@@ -2037,10 +2037,14 @@
 			}
 		},
 		"node_modules/@nextcloud/browserslist-config": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/@nextcloud/browserslist-config/-/browserslist-config-2.2.0.tgz",
-			"integrity": "sha512-kC42RQW5rZjZZsRaEjVlIQpp6aW/yxm+zZdETnrRQnUzcPwBgF4wO4makfGT63Ckd+LkgUW+geesPiPRqxFVew==",
-			"dev": true
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/@nextcloud/browserslist-config/-/browserslist-config-2.3.0.tgz",
+			"integrity": "sha512-1Tpkof2e9Q0UicHWahQnXXrubJoqyiaqsH9G52v3cjGeVeH3BCfa1FOa41eBwBSFe2/Jxj/wCH2YVLgIXpWbBg==",
+			"dev": true,
+			"engines": {
+				"node": "^16.0.0",
+				"npm": "^7.0.0 || ^8.0.0"
+			}
 		},
 		"node_modules/@nextcloud/calendar-js": {
 			"version": "3.0.0",
@@ -2270,9 +2274,9 @@
 			}
 		},
 		"node_modules/@nextcloud/vue": {
-			"version": "6.0.0-beta.7",
-			"resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-6.0.0-beta.7.tgz",
-			"integrity": "sha512-wRXnTSMm55CElCu5W0XUtMf32BmtMG4aiFAYDY9PpT19pru2blLXu0LzjVPNkRZ5bFISpp83H9YVYrNFbbkwBA==",
+			"version": "7.0.0-beta.3",
+			"resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-7.0.0-beta.3.tgz",
+			"integrity": "sha512-lnEVzPPt4eGLHrSwsft5oBg7pEqVZA2DteWR/Bq02+jptqE7at6W8sV7PMBR0N5VRI2yNsm7sMIJLsHXvxmpfg==",
 			"dependencies": {
 				"@nextcloud/auth": "^2.0.0",
 				"@nextcloud/axios": "^2.0.0",
@@ -13349,9 +13353,9 @@
 			}
 		},
 		"@nextcloud/browserslist-config": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/@nextcloud/browserslist-config/-/browserslist-config-2.2.0.tgz",
-			"integrity": "sha512-kC42RQW5rZjZZsRaEjVlIQpp6aW/yxm+zZdETnrRQnUzcPwBgF4wO4makfGT63Ckd+LkgUW+geesPiPRqxFVew==",
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/@nextcloud/browserslist-config/-/browserslist-config-2.3.0.tgz",
+			"integrity": "sha512-1Tpkof2e9Q0UicHWahQnXXrubJoqyiaqsH9G52v3cjGeVeH3BCfa1FOa41eBwBSFe2/Jxj/wCH2YVLgIXpWbBg==",
 			"dev": true
 		},
 		"@nextcloud/calendar-js": {
@@ -13529,9 +13533,9 @@
 			}
 		},
 		"@nextcloud/vue": {
-			"version": "6.0.0-beta.7",
-			"resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-6.0.0-beta.7.tgz",
-			"integrity": "sha512-wRXnTSMm55CElCu5W0XUtMf32BmtMG4aiFAYDY9PpT19pru2blLXu0LzjVPNkRZ5bFISpp83H9YVYrNFbbkwBA==",
+			"version": "7.0.0-beta.3",
+			"resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-7.0.0-beta.3.tgz",
+			"integrity": "sha512-lnEVzPPt4eGLHrSwsft5oBg7pEqVZA2DteWR/Bq02+jptqE7at6W8sV7PMBR0N5VRI2yNsm7sMIJLsHXvxmpfg==",
 			"requires": {
 				"@nextcloud/auth": "^2.0.0",
 				"@nextcloud/axios": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
 		"@nextcloud/logger": "^2.3.0",
 		"@nextcloud/moment": "^1.2.1",
 		"@nextcloud/router": "^2.0.0",
-		"@nextcloud/vue": "^6.0.0-beta.7",
+		"@nextcloud/vue": "^7.0.0-beta.3",
 		"core-js": "^3.25.1",
 		"crypto-js": "^4.1.1",
 		"debounce": "^1.2.1",
@@ -55,7 +55,7 @@
 	},
 	"devDependencies": {
 		"@nextcloud/babel-config": "^1.0.0",
-		"@nextcloud/browserslist-config": "^2.2.0",
+		"@nextcloud/browserslist-config": "^2.3.0",
 		"@nextcloud/eslint-config": "^8.0.0",
 		"@nextcloud/stylelint-config": "^2.2.0",
 		"@nextcloud/webpack-vue-config": "^5.3.0"

--- a/src/components/TopBar.vue
+++ b/src/components/TopBar.vue
@@ -171,19 +171,15 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-$top-bar-height: 60px;
-
 .top-bar {
-	position: sticky;
+	top: 0;
 	z-index: 100;
-	top: var(--header-height);
 	display: flex;
+	position: sticky;
 	align-items: center;
 	align-self: flex-end;
 	justify-content: flex-end;
-	height: $top-bar-height;
-	margin-top: calc($top-bar-height * -1);
-	padding: 0 6px;
+	padding: calc(var(--default-grid-baseline, 4px) * 2);
 }
 
 .icon--flipped {

--- a/src/views/Create.vue
+++ b/src/views/Create.vue
@@ -410,7 +410,6 @@ export default {
 	header {
 		display: flex;
 		flex-direction: column;
-		margin-top: 44px;
 		margin-bottom: 24px;
 
 		h2 {

--- a/src/views/Submit.vue
+++ b/src/views/Submit.vue
@@ -307,7 +307,6 @@ export default {
 
 	// Title & description header
 	header {
-		margin-top: 44px;
 		margin-bottom: 24px;
 
 		.form-title,


### PR DESCRIPTION
Currently forms is somewhat broken for the current NC master (or 25 beta), as the topbar is rendered inside the navigation menu.
This fixes the compatibility with the upcoming NC, but probably breaks the compatibility with anything below 25.

* Update `@nextcloud/vue` to version 7.0.0-beta.3 to support the latest changes of the nc frontend in `server` (`appcontent` as scroll container)
* Adjusted the styling of the TopBar and views accordingly

Without this it looks like this on NC25 (especially the toolbar on the top right):
![toolbar is overlapping the navigation](https://user-images.githubusercontent.com/1855448/190264683-46112fe5-d139-4f98-8a57-5960afcebb5d.png)
