### PR TITLE
Use NcAppNavigationItem instead of NcListItem for app navigation

### DIFF
--- a/src/components/AppNavigationForm.vue
+++ b/src/components/AppNavigationForm.vue
@@ -21,7 +21,7 @@
   -->
 
 <template>
-	<NcListItem ref="navigationItem"
+	<NcAppNavigationItem ref="navigationItem"
 		:title="formTitle"
 		:to="{
 			name: routerTarget,
@@ -78,7 +78,7 @@
 				{{ t('forms', 'Delete form') }}
 			</NcActionButton>
 		</template>
-	</NcListItem>
+	</NcAppNavigationItem>
 </template>
 
 <script>
@@ -87,7 +87,7 @@ import { showError } from '@nextcloud/dialogs'
 import NcActionButton from '@nextcloud/vue/dist/Components/NcActionButton'
 import NcActionRouter from '@nextcloud/vue/dist/Components/NcActionRouter'
 import NcActionSeparator from '@nextcloud/vue/dist/Components/NcActionSeparator'
-import NcListItem from '@nextcloud/vue/dist/Components/NcListItem'
+import NcAppNavigationItem from '@nextcloud/vue/dist/Components/NcAppNavigationItem'
 import NcLoadingIcon from '@nextcloud/vue/dist/Components/NcLoadingIcon'
 import axios from '@nextcloud/axios'
 import moment from '@nextcloud/moment'
@@ -116,7 +116,7 @@ export default {
 		NcActionButton,
 		NcActionRouter,
 		NcActionSeparator,
-		NcListItem,
+		NcAppNavigationItem,
 		NcLoadingIcon,
 	},
 


### PR DESCRIPTION
This fixes icons not being placed correctly within the list items, see following example (focus on the left spacing of the icons).

**Currently:**
![icons are placed without any spacing](https://user-images.githubusercontent.com/1855448/191359935-06e3077e-b106-476f-975d-4a09431b0e77.png)


**With this PR**
![icons are centered within the 44px](https://user-images.githubusercontent.com/1855448/191359878-9e7fc96e-d471-4f6e-a4ae-4093f871194c.png)