### PR TITLE
Use `--gradient-primary-background` for summary

### DIFF
--- a/src/components/Results/Summary.vue
+++ b/src/components/Results/Summary.vue
@@ -232,12 +232,14 @@ export default {
 
 				// The pseudo-classes of -moz and -webkit have to stay separated even with SCSS, otherwise they don’t work
 				&::-webkit-meter-optimum-value {
-					background: linear-gradient(40deg, var(--color-primary-element) 0%, var(--color-primary-element-light) 100%);
+					// TODO switch to old gradient if it becomes available in server
+					background: var(--gradient-primary-background);
 					border-radius: var(--border-radius);
 				}
 
 				&::-moz-meter-bar {
-					background: linear-gradient(40deg, var(--color-primary-element) 0%, var(--color-primary-element-light) 100%);
+					// TODO switch to old gradient if it becomes available in server
+					background: var(--gradient-primary-background);
 					border-radius: var(--border-radius);
 				}
 			}


### PR DESCRIPTION
Fixes #1350 by using `--gradient-primary-background` variable for the results for now.

![grafik](https://user-images.githubusercontent.com/16020496/191822384-ec59696e-3cd3-4347-aac1-cb9eb89e873b.png)

Signed-off-by: Christian Hartmann <chris-hartmann@gmx.de>