### PR TITLE
Remove css variables

### DIFF
--- a/css/forms.css
+++ b/css/forms.css
@@ -20,8 +20,6 @@
  *
  */
 
-@import 'variables';
-
 /* Padding for Auto-Scroll if a required question is not filled.
  * 60px matches around the height of two lines of question-text
  */


### PR DESCRIPTION
Removing `404 Not found` to `forms/css/variables`.
Variables are loaded by server, not by us here.