### PR TITLE
Fix question movement

### DIFF
--- a/src/components/Questions/AnswerInput.vue
+++ b/src/components/Questions/AnswerInput.vue
@@ -1,15 +1,14 @@
 <template>
 	<li class="question__item">
-		<div class="question__item__pseudoInput"
-			:class="{
-				'question__item__pseudoInput--unique':isUnique,
-				'question__item__pseudoInput--dropdown':isDropdown
-			}" />
+		<div :is="pseudoIcon"
+			v-if="!isDropdown"
+			class="question__item__pseudoInput" />
 		<input ref="input"
 			:aria-label="t('forms', 'An answer for the {index} option', { index: index + 1 })"
 			:placeholder="t('forms', 'Answer number {index}', { index: index + 1 })"
 			:value="answer.text"
 			class="question__input"
+			:class="{ 'question__input--shifted' : !isDropdown }"
 			:maxlength="maxOptionLength"
 			minlength="1"
 			type="text"
@@ -40,6 +39,8 @@ import PQueue from 'p-queue'
 import NcActions from '@nextcloud/vue/dist/Components/NcActions'
 import NcActionButton from '@nextcloud/vue/dist/Components/NcActionButton'
 import IconClose from 'vue-material-design-icons/Close'
+import IconCheckboxBlankOutline from 'vue-material-design-icons/CheckboxBlankOutline.vue'
+import IconRadioboxBlank from 'vue-material-design-icons/RadioboxBlank.vue'
 
 import OcsResponse2Data from '../../utils/OcsResponse2Data.js'
 import logger from '../../utils/Logger.js'
@@ -49,6 +50,8 @@ export default {
 
 	components: {
 		IconClose,
+		IconCheckboxBlankOutline,
+		IconRadioboxBlank,
 		NcActions,
 		NcActionButton,
 	},
@@ -85,6 +88,12 @@ export default {
 				return this.queue.add(() => this.updateAnswer(answer))
 			}, 500),
 		}
+	},
+
+	computed: {
+		pseudoIcon() {
+			return this.isUnique ? IconRadioboxBlank : IconCheckboxBlankOutline
+		},
 	},
 
 	methods: {
@@ -202,39 +211,23 @@ export default {
 	display: inline-flex;
 	min-height: 44px;
 
-	// Taking styles from server radio-input items
 	&__pseudoInput {
-		flex-shrink: 0;
-		display: inline-block;
-		height: 18px;
-		width: 18px !important;
-		vertical-align: middle;
-		margin: 7px 8px 0 1px;
-		border: 2px solid var(--color-primary-element);
-		border-radius: 2px;
-		// Adjust position manually to match input-checkbox
+		color: var(--color-primary-element);
+		margin-left: -2px;
+		z-index: 1;
+	}
+
+	.question__input {
+		width: 100%;
 		position: relative;
-		top: 6px;
+		margin-right: 2px !important;
 
-		// Show round for Pseudo-Radio-Button
-		&--unique {
-			height: 20px;
-			width: 20px !important;
-			margin: 6px 8px 0 0;
-			border-radius: 50%;
-		}
-
-		// Do not show pseudo-icon for dropdowns
-		&--dropdown {
-			display: none;
+		&--shifted {
+			left: -30px;
+			top: 1px;
+			margin-right: -30px !important;
+			padding-left: 32px !important;
 		}
 	}
 }
-
-// Using type to have a higher order than the input styling of server
-.question__input[type=text] {
-	width: 100%;
-	position: relative;
-}
-
 </style>

--- a/src/components/Questions/Question.vue
+++ b/src/components/Questions/Question.vue
@@ -42,7 +42,7 @@
 					:placeholder="titlePlaceholder"
 					:aria-label="t('forms', 'Title of question number {index}', {index})"
 					:value="text"
-					class="question__header__title__text"
+					class="question__header__title__text question__header__title__text__input"
 					type="text"
 					minlength="1"
 					:maxlength="maxStringLengths.questionText"
@@ -78,7 +78,7 @@
 					</NcActionButton>
 				</NcActions>
 			</div>
-			<div class="question__header__description">
+			<div v-if="hasDescription || edit || !questionValid" class="question__header__description">
 				<textarea v-if="edit || !questionValid"
 					ref="description"
 					rows="1"
@@ -201,6 +201,10 @@ export default {
 		actionsId() {
 			return 'q' + this.index + '_actions'
 		},
+
+		hasDescription() {
+			return this.description !== ''
+		},
 	},
 
 	methods: {
@@ -316,31 +320,28 @@ export default {
 
 	&__header {
 		display: block;
-		padding-bottom: 10px;
+		padding-bottom: 8px;
 		align-items: center;
 		flex: 1 1 100%;
 		justify-content: space-between;
 		width: auto;
 
-		// Using type to have a higher order than the input styling of server
 		&__title {
 			display: flex;
 			height: 44px;
 
-			&__text,
-			&__text[type=text] {
+			&__text {
 				flex: 1 1 100%;
-				min-height: 22px;
-				margin: 0;
-				padding: 0;
-				padding-top: 14px;
-				color: var(--color-text-light);
-				border: 0;
-				border-bottom: 1px dotted transparent;
-				border-radius: 0;
-				font-size: 16px;
+				font-size: 16px !important;
 				font-weight: bold;
-				line-height: 22px;
+				margin: auto !important;
+
+				&__input {
+					position: relative;
+					left: -10px;
+					margin-right: -8px !important;
+					padding-left: 8px !important;
+				}
 			}
 
 			&__warning {
@@ -359,6 +360,8 @@ export default {
 		&__description {
 			display: flex;
 			white-space: pre-wrap;
+			margin-top: 4px;
+			margin-bottom: 4px;
 
 			&__input {
 				margin: 0px;

--- a/src/components/Questions/QuestionDropdown.vue
+++ b/src/components/Questions/QuestionDropdown.vue
@@ -308,11 +308,11 @@ export default {
 	position: relative;
 	display: inline-flex;
 	min-height: 44px;
-}
 
-// Using type to have a higher order than the input styling of server
-.question__input[type=text] {
-	width: 100%;
-	position: relative;
+	.question__input {
+		width: 100%;
+		position: relative;
+		margin-right: 46px !important;
+	}
 }
 </style>

--- a/src/components/Questions/QuestionMultiple.vue
+++ b/src/components/Questions/QuestionMultiple.vue
@@ -70,7 +70,9 @@
 				</template>
 
 				<li v-if="(edit && !isLastEmpty) || hasNoAnswer" class="question__item">
-					<div class="question__item__pseudoInput" :class="{'question__item__pseudoInput--unique':isUnique}" />
+					<div :is="pseudoIcon"
+						v-if="!isDropdown"
+						class="question__item__pseudoInput" />
 					<input :aria-label="t('forms', 'Add a new answer')"
 						:placeholder="t('forms', 'Add a new answer')"
 						class="question__input"
@@ -90,6 +92,8 @@ import { generateOcsUrl } from '@nextcloud/router'
 import { showError } from '@nextcloud/dialogs'
 import axios from '@nextcloud/axios'
 import NcCheckboxRadioSwitch from '@nextcloud/vue/dist/Components/NcCheckboxRadioSwitch'
+import IconCheckboxBlankOutline from 'vue-material-design-icons/CheckboxBlankOutline.vue'
+import IconRadioboxBlank from 'vue-material-design-icons/RadioboxBlank.vue'
 
 import AnswerInput from './AnswerInput.vue'
 import QuestionMixin from '../../mixins/QuestionMixin.js'
@@ -101,6 +105,8 @@ export default {
 
 	components: {
 		AnswerInput,
+		IconCheckboxBlankOutline,
+		IconRadioboxBlank,
 		NcCheckboxRadioSwitch,
 	},
 
@@ -136,6 +142,9 @@ export default {
 
 		shiftDragHandle() {
 			return this.edit && this.options.length !== 0 && !this.isLastEmpty
+		},
+		pseudoIcon() {
+			return this.isUnique ? IconRadioboxBlank : IconCheckboxBlankOutline
 		},
 	},
 
@@ -339,27 +348,19 @@ export default {
 	display: inline-flex;
 	min-height: 44px;
 
-	// Taking styles from server radio-input items
 	&__pseudoInput {
-		flex-shrink: 0;
-		display: inline-block;
-		height: 18px;
-		width: 18px !important;
-		vertical-align: middle;
-		margin: 7px 8px 0 1px;
-		border: 2px solid var(--color-primary-element);
-		border-radius: 2px;
-		// Adjust position manually to match input-checkbox
-		position: relative;
-		top: 6px;
+		color: var(--color-primary-element);
+		margin-left: -2px;
+		z-index: 1;
+	}
 
-		// Show round for Pseudo-Radio-Button
-		&--unique {
-			height: 20px;
-			width: 20px !important;
-			margin: 6px 8px 0 0;
-			border-radius: 50%;
-		}
+	.question__input {
+		width: 100%;
+		position: relative;
+		left: -30px;
+		top: 1px;
+		margin-right: 14px !important;
+		padding-left: 32px !important;
 	}
 
 	.question__label {
@@ -386,11 +387,4 @@ export default {
 		}
 	}
 }
-
-// Using type to have a higher order than the input styling of server
-.question__input[type=text] {
-	width: 100%;
-	position: relative;
-}
-
 </style>


### PR DESCRIPTION
@Chartman123 How about this one to reduce the text jumping? :blush:
(Also i found that the label uses Material Icons meanwhile. So using these instead of the pseudoInput.)

![image](https://user-images.githubusercontent.com/47433654/192582718-8aba833e-93f3-4498-bbbc-1fe309cf7b55.png)

