### PR TITLE
Adjust look of long text questions

### DIFF
--- a/src/components/Questions/QuestionLong.vue
+++ b/src/components/Questions/QuestionLong.vue
@@ -87,7 +87,7 @@ export default {
 		autoSizeText() {
 			const textarea = this.$refs.textarea
 			textarea.style.cssText = 'height:auto; padding:0'
-			textarea.style.cssText = `height: ${textarea.scrollHeight + 20}px`
+			textarea.style.cssText = `height: ${textarea.scrollHeight + 28}px`
 		},
 		onKeydownCtrlEnter(event) {
 			this.$emit('keydown', event)
@@ -98,19 +98,8 @@ export default {
 
 <style lang="scss" scoped>
 .question__text {
-	// make sure height calculations are correct
-	box-sizing: content-box !important;
 	width: 100%;
-	min-width: 100%;
-	max-width: 100%;
-	min-height: 44px;
-	margin: 0;
-	padding: 6px 0;
-	border: 0;
-	border-bottom: 1px dotted var(--color-text-maxcontrast);
-	border-radius: 0;
 	resize: none;
-	font-size: 14px;
 
 	&:disabled {
 		// Just overrides Server CSS-Styling for disabled inputs. -> Not Good??


### PR DESCRIPTION
Before:
![grafik](https://user-images.githubusercontent.com/16020496/192843156-39440377-7a5e-4c89-b961-64bbe073ca24.png)

After:
![grafik](https://user-images.githubusercontent.com/16020496/192843265-5a9cfa6d-941f-412b-b9bc-6cca97c76fb5.png)

Signed-off-by: Christian Hartmann <chris-hartmann@gmx.de>