### PR TITLE
More usable and accessible navigation between View/Edit/Results

### DIFF
--- a/src/Forms.vue
+++ b/src/Forms.vue
@@ -49,6 +49,7 @@
 					:key="form.id"
 					:form="form"
 					:read-only="true"
+					@open-sharing="openSharing"
 					@mobile-close-navigation="mobileCloseNavigation" />
 			</template>
 		</NcAppNavigation>
@@ -92,9 +93,9 @@
 			<router-view :form.sync="selectedForm"
 				:sidebar-opened.sync="sidebarOpened"
 				@open-sharing="openSharing" />
-			<router-view v-if="!selectedForm.partial"
+			<router-view v-if="!selectedForm.partial && canEdit"
 				:form="selectedForm"
-				:opened.sync="sidebarOpened"
+				:sidebar-opened.sync="sidebarOpened"
 				:active.sync="sidebarActive"
 				name="sidebar" />
 		</template>
@@ -158,6 +159,9 @@ export default {
 	},
 
 	computed: {
+		canEdit() {
+			return this.selectedForm.permissions.includes(this.PERMISSION_TYPES.PERMISSION_EDIT)
+		},
 		hasForms() {
 			return !this.noOwnedForms || !this.noSharedForms
 		},
@@ -236,7 +240,7 @@ export default {
 		 * @param {string} hash the hash of the form to load
 		 */
 		openSharing(hash) {
-			if (hash !== this.routeHash || this.$route.name !== 'edit') {
+			if (hash !== this.routeHash) {
 				this.$router.push({ name: 'edit', params: { hash } })
 			}
 			this.sidebarActive = 'forms-sharing'

--- a/src/components/TopBar.vue
+++ b/src/components/TopBar.vue
@@ -25,41 +25,50 @@
   -->
 <template>
 	<div class="top-bar" role="toolbar">
-		<slot />
-		<NcButton v-if="canSubmit && $route.name !== 'submit'"
-			v-tooltip="t('forms', 'View form')"
-			:aria-label="t('forms', 'View form')"
-			type="tertiary"
-			@click="showSubmit">
-			<template #icon>
-				<IconEye :size="20" />
-			</template>
-		</NcButton>
-		<NcButton v-if="canEdit && $route.name !== 'edit'"
-			v-tooltip="t('forms', 'Edit form')"
-			:aria-label="t('forms', 'Edit form')"
-			type="tertiary"
-			@click="showEdit">
-			<template #icon>
-				<IconPencil :size="20" />
-			</template>
-		</NcButton>
-		<NcButton v-if="canSeeResults && $route.name !== 'results'"
-			v-tooltip="t('forms', 'Results')"
-			:aria-label="t('forms', 'Results')"
-			type="tertiary"
-			@click="showResults">
-			<template #icon>
-				<IconPoll :size="20" />
-			</template>
-		</NcButton>
+		<div v-if="!canOnlySubmit" class="top-bar__view-select">
+			<NcButton v-if="canSubmit"
+				:aria-label="isMobile ? t('forms', 'View form') : null"
+				:type="$route.name === 'submit' ? 'secondary' : 'tertiary'"
+				@click="showSubmit">
+				<template #icon>
+					<IconEye :size="20" />
+				</template>
+				<template v-if="!isMobile">
+					{{ t('forms', 'View') }}
+				</template>
+			</NcButton>
+			<NcButton v-if="canEdit"
+				:aria-label="isMobile ? t('forms', 'Edit form') : null"
+				:type="$route.name === 'edit' ? 'secondary' : 'tertiary'"
+				@click="showEdit">
+				<template #icon>
+					<IconPencil :size="20" />
+				</template>
+				<template v-if="!isMobile">
+					{{ t('forms', 'Edit') }}
+				</template>
+			</NcButton>
+			<NcButton v-if="canSeeResults"
+				:aria-label="isMobile ? t('forms', 'Show results') : null"
+				:type="$route.name === 'results' ? 'secondary' : 'tertiary'"
+				@click="showResults">
+				<template #icon>
+					<IconPoll :size="20" />
+				</template>
+				<template v-if="!isMobile">
+					{{ t('forms', 'Results') }}
+				</template>
+			</NcButton>
+		</div>
 		<NcButton v-if="canShare && !sidebarOpened"
-			v-tooltip="t('forms', 'Share form')"
-			:aria-label="t('forms', 'Share form')"
+			:aria-label="isMobile ? t('forms', 'Share form') : null"
 			type="tertiary"
 			@click="onShareForm">
 			<template #icon>
 				<IconShareVariant :size="20" />
+			</template>
+			<template v-if="!isMobile">
+				{{ t('forms', 'Share') }}
 			</template>
 		</NcButton>
 		<NcButton v-if="showSidebarToggle"
@@ -77,6 +86,7 @@
 
 <script>
 import NcButton from '@nextcloud/vue/dist/Components/NcButton.js'
+import isMobile from '@nextcloud/vue/dist/Mixins/isMobile.js'
 import IconEye from 'vue-material-design-icons/Eye.vue'
 import IconMenuOpen from 'vue-material-design-icons/MenuOpen.vue'
 import IconPencil from 'vue-material-design-icons/Pencil.vue'
@@ -96,7 +106,7 @@ export default {
 		NcButton,
 	},
 
-	mixins: [PermissionTypes],
+	mixins: [isMobile, PermissionTypes],
 
 	props: {
 		sidebarOpened: {
@@ -123,8 +133,11 @@ export default {
 			// This probably can get a permission of itself
 			return this.canEdit || this.canSeeResults
 		},
+		canOnlySubmit() {
+			return this.permissions.length === 1 && this.permissions.includes(this.PERMISSION_TYPES.PERMISSION_SUBMIT)
+		},
 		showSidebarToggle() {
-			return this.sidebarOpened !== null
+			return this.canEdit && this.sidebarOpened !== null
 		},
 	},
 
@@ -137,30 +150,36 @@ export default {
 		 * Router methods
 		 */
 		showEdit() {
-			this.$router.push({
-				name: 'edit',
-				params: {
-					hash: this.$route.params.hash,
-				},
-			})
+			if (this.$route.name !== 'edit') {
+				this.$router.push({
+					name: 'edit',
+					params: {
+						hash: this.$route.params.hash,
+					},
+				})
+			}
 		},
 
 		showResults() {
-			this.$router.push({
-				name: 'results',
-				params: {
-					hash: this.$route.params.hash,
-				},
-			})
+			if (this.$route.name !== 'results') {
+				this.$router.push({
+					name: 'results',
+					params: {
+						hash: this.$route.params.hash,
+					},
+				})
+			}
 		},
 
 		showSubmit() {
-			this.$router.push({
-				name: 'submit',
-				params: {
-					hash: this.$route.params.hash,
-				},
-			})
+			if (this.$route.name !== 'submit') {
+				this.$router.push({
+					name: 'submit',
+					params: {
+						hash: this.$route.params.hash,
+					},
+				})
+			}
 		},
 
 		onShareForm() {
@@ -180,6 +199,17 @@ export default {
 	align-self: flex-end;
 	justify-content: flex-end;
 	padding: calc(var(--default-grid-baseline, 4px) * 2);
+
+	&__view-select {
+		display: flex;
+		height: 44px;
+		align-items: center;
+		align-self: flex-end;
+		justify-content: flex-end;
+		background: var(--color-main-background);
+		border: 2px solid var(--color-border);
+		border-radius: var(--border-radius-pill);
+	}
 }
 
 .icon--flipped {

--- a/src/mixins/ViewsMixin.js
+++ b/src/mixins/ViewsMixin.js
@@ -46,6 +46,10 @@ export default {
 			type: Boolean,
 			default: false,
 		},
+		sidebarOpened: {
+			type: Boolean,
+			required: true,
+		},
 	},
 
 	data() {
@@ -61,6 +65,10 @@ export default {
 	methods: {
 		onShareForm() {
 			this.$emit('open-sharing', this.form.hash)
+		},
+
+		onSidebarChange(newState) {
+			this.$emit('update:sidebarOpened', newState)
 		},
 
 		/**

--- a/src/router.js
+++ b/src/router.js
@@ -63,15 +63,21 @@ export default new Router({
 		},
 		{
 			path: '/:hash/results',
-			component: Results,
+			components: {
+				default: Results,
+				sidebar: Sidebar,
+			},
 			name: 'results',
-			props: true,
+			props: { default: true },
 		},
 		{
 			path: '/:hash/submit',
-			component: Submit,
+			components: {
+				default: Submit,
+				sidebar: Sidebar,
+			},
 			name: 'submit',
-			props: true,
+			props: { default: true },
 		},
 	],
 })

--- a/src/views/Create.vue
+++ b/src/views/Create.vue
@@ -161,13 +161,6 @@ export default {
 
 	mixins: [ViewsMixin],
 
-	props: {
-		sidebarOpened: {
-			type: Boolean,
-			required: true,
-		},
-	},
-
 	data() {
 		return {
 			maxStringLengths: loadState('forms', 'maxStringLengths'),
@@ -258,9 +251,6 @@ export default {
 		onDescChange() {
 			this.autoSizeDescription()
 			this.saveDescription()
-		},
-		onSidebarChange(newState) {
-			this.$emit('update:sidebarOpened', newState)
 		},
 
 		/**

--- a/src/views/Results.vue
+++ b/src/views/Results.vue
@@ -32,7 +32,10 @@
 	</NcAppContent>
 
 	<NcAppContent v-else>
-		<TopBar :permissions="form?.permissions" @share-form="onShareForm" />
+		<TopBar :permissions="form?.permissions"
+			:sidebar-opened="sidebarOpened"
+			@update:sidebarOpened="onSidebarChange"
+			@share-form="onShareForm" />
 		<header v-if="!noSubmissions">
 			<h2>{{ formTitle }}</h2>
 			<p>{{ t('forms', '{amount} responses', { amount: form.submissions.length }) }}</p>

--- a/src/views/Sidebar.vue
+++ b/src/views/Sidebar.vue
@@ -21,7 +21,7 @@
  -->
 
 <template>
-	<NcAppSidebar v-show="opened"
+	<NcAppSidebar v-show="sidebarOpened"
 		:active="active"
 		:title="t('forms', 'Form settings')"
 		@close="onClose"
@@ -71,16 +71,13 @@ export default {
 		SharingSidebarTab,
 		SettingsSidebarTab,
 	},
+
 	mixins: [ViewsMixin],
 
 	props: {
 		active: {
 			type: String,
 			default: 'forms-sharing',
-		},
-		opened: {
-			type: Boolean,
-			required: true,
 		},
 	},
 
@@ -89,10 +86,10 @@ export default {
 		 * Sidebar state methods
 		 */
 		onClose() {
-			this.$emit('update:opened', false)
+			this.$emit('update:sidebarOpened', false)
 		},
 		onToggle() {
-			this.$emit('update:opened', !this.opened)
+			this.$emit('update:sidebarOpened', !this.sidebarOpened)
 		},
 		onUpdateActive(active) {
 			this.$emit('update:active', active)

--- a/src/views/Submit.vue
+++ b/src/views/Submit.vue
@@ -32,6 +32,8 @@
 	<NcAppContent v-else :class="{'app-content--public': publicView}">
 		<TopBar v-if="!publicView"
 			:permissions="form?.permissions"
+			:sidebar-opened="sidebarOpened"
+			@update:sidebarOpened="onSidebarChange"
 			@share-form="onShareForm" />
 
 		<!-- Forms title & description-->


### PR DESCRIPTION
The icon-only navigation on the top right is not super visible and not understandable, so I worked on some improvements sort-of inspired by our mockups for the new tabs (which we can also eventually use once it’s updated in the component) https://github.com/nextcloud/nextcloud-vue/issues/603

## Before
- Lots of icons
- Some icons show only in some context

https://user-images.githubusercontent.com/925062/195996592-ec09cdde-ca2d-4c1f-95fc-3f1d7be9d979.mp4

## After
- Everything has text
- View/Edit/Results is grouped
- All buttons show always

https://user-images.githubusercontent.com/925062/195996589-2614b829-cd5c-4efd-aedc-ef93ff4d97e7.mp4


## To do
Issues which still need fixing and some of which I need help with @jotoeri @Chartman123 :)
- [x] Sidebar toggle only works in "Edit" mode ("Share" button always switches to "Edit" mode too). This should be possible from everywhere.
- [x] Mobile responsiveness, buttons could be icon-only on mobile
- [x] Test if it works in all views like sharing
- [ ] Loading overlay makes the buttons flash (not essential)