### PR TITLE
Init all answers from props

### DIFF
--- a/src/components/Questions/QuestionDate.vue
+++ b/src/components/Questions/QuestionDate.vue
@@ -92,6 +92,13 @@ export default {
 		},
 	},
 
+	mounted() {
+		// Init time from values prop
+		if (this.values) {
+			this.time = this.parse(this.values[0])
+		}
+	},
+
 	methods: {
 		/**
 		 * DateTimepicker show text in picker

--- a/src/components/Questions/QuestionDropdown.vue
+++ b/src/components/Questions/QuestionDropdown.vue
@@ -157,6 +157,14 @@ export default {
 		},
 	},
 
+	mounted() {
+		// Init selected options from values prop
+		if (this.values) {
+			const selected = this.values.map(id => this.options.find(option => option.id === id))
+			this.selectedOption = this.isMultiple ? selected : selected[0]
+		}
+	},
+
 	methods: {
 		onSelect(option) {
 			// Simple select


### PR DESCRIPTION
Before this only the text answers were initialized with the `values` property.
This now also initializes `Dropdown` and `Date` from the `values` property, which is required for loading a saved state of a form like in #1382