### PR TITLE
Fix `setExtraSettings` to accept same type as `getExtraSettings`

### DIFF
--- a/lib/Controller/ApiController.php
+++ b/lib/Controller/ApiController.php
@@ -482,7 +482,7 @@ class ApiController extends OCSController {
 		$question->setText($text);
 		$question->setDescription('');
 		$question->setIsRequired(false);
-		$question->setExtraSettings([]);
+		$question->setExtraSettings((object)[]);
 
 		$question = $this->questionMapper->insert($question);
 

--- a/lib/Db/Question.php
+++ b/lib/Db/Question.php
@@ -44,8 +44,8 @@ use OCP\AppFramework\Db\Entity;
  * @method void setText(string $value)
  * @method string getDescription()
  * @method void setDescription(string $value)
- * @method array getExtraSettings()
- * @method void setExtraSettings(array $value)
+ * @method object getExtraSettings()
+ * @method void setExtraSettings(object $value)
  */
 class Question extends Entity {
 	protected $formId;
@@ -69,8 +69,11 @@ class Question extends Entity {
 		return json_decode($this->getExtraSettingsJson() ?: '{}');
 	}
 
-	public function setExtraSettings(array $extraSettings) {
-		// Make sure to be an object (empty assoc. array)
+	/**
+	 * @param object|array $extraSettings
+	 */
+	public function setExtraSettings($extraSettings) {
+		// TODO: When the php requirement is >= 8.0 change parameter typing to `object|array` to allow assoc. arrays from `Question::fromParams`
 		$this->setExtraSettingsJson(json_encode($extraSettings, JSON_FORCE_OBJECT));
 	}
 

--- a/tests/Unit/Service/FormsServiceTest.php
+++ b/tests/Unit/Service/FormsServiceTest.php
@@ -254,7 +254,7 @@ class FormsServiceTest extends TestCase {
 		$question1->setOrder(1);
 		$question1->setType('dropdown');
 		$question1->setIsRequired(false);
-		$question1->setExtraSettings([
+		$question1->setExtraSettings((object)[
 			'shuffleOptions' => true
 		]);
 		$question1->setText('Question 1');
@@ -267,7 +267,7 @@ class FormsServiceTest extends TestCase {
 		$question2->setIsRequired(true);
 		$question2->setText('Question 2');
 		$question2->setDescription('');
-		$question2->setExtraSettings([]);
+		$question2->setExtraSettings((object)[]);
 		$this->questionMapper->expects($this->once())
 			->method('findByForm')
 			->with(42)


### PR DESCRIPTION
* Resolves: #1386

## Summary
This fixes the extra settings setter to accept the same parameter type as the getter emits.
So this resolves an issue where a form can not be cloned.