### PR TITLE
Fix question header title for extra long text

### DIFF
--- a/src/components/Questions/Question.vue
+++ b/src/components/Questions/Question.vue
@@ -328,11 +328,12 @@ export default {
 
 		&__title {
 			display: flex;
-			height: 44px;
+			min-height: 44px;
 
 			&__text {
 				flex: 1 1 100%;
 				font-size: 16px !important;
+				padding: 10px 0px;
 				font-weight: bold;
 				margin: auto !important;
 


### PR DESCRIPTION
* Resolves: #1392
---

Currently the title is set to a height of 44px (used 14px padding top, 16px text height, 14px padding bottom) to fit the menu button on the right.
This allows the header to have multiple lines of text by setting only a minimum height of 30px + a fixed padding of 14px on the bottom.