### PR TITLE
Import form question extra settings

### DIFF
--- a/lib/FormsMigrator.php
+++ b/lib/FormsMigrator.php
@@ -198,7 +198,7 @@ class FormsMigrator implements IMigrator {
 				$form->setExpires($formData['expires']);
 				$form->setIsAnonymous($formData['isAnonymous']);
 				$form->setSubmitMultiple($formData['submitMultiple']);
-		
+
 				$this->formMapper->insert($form);
 
 				$questionIdMap = [];
@@ -210,6 +210,7 @@ class FormsMigrator implements IMigrator {
 					$question->setIsRequired($questionData['isRequired']);
 					$question->setText($questionData['text']);
 					$question->setDescription($questionData['description']);
+					$question->setExtraSettings($questionData['extraSettings']);
 
 					$this->questionMapper->insert($question);
 

--- a/tests/Unit/FormsMigratorTest.php
+++ b/tests/Unit/FormsMigratorTest.php
@@ -114,7 +114,7 @@ class FormsMigratorTest extends TestCase {
 	public function dataExport() {
 		return [
 			'exactlyOneOfEach' => [
-				'expectedJson' => '[{"title":"Link","description":"","created":1646251830,"access":{"permitAllUsers":false,"showToAllUsers":false},"expires":0,"isAnonymous":false,"submitMultiple":false,"questions":[{"id":14,"order":2,"type":"multiple","isRequired":false,"text":"checkbox","description":"huhu","options":[{"text":"ans1"}]}],"submissions":[{"userId":"anyUser@localhost","timestamp":1651354059,"answers":[{"questionId":14,"text":"ans1"}]}]}]'
+				'expectedJson' => '[{"title":"Link","description":"","created":1646251830,"access":{"permitAllUsers":false,"showToAllUsers":false},"expires":0,"isAnonymous":false,"submitMultiple":false,"questions":[{"id":14,"order":2,"type":"multiple","isRequired":false,"text":"checkbox","description":"huhu","extraSettings":{},"options":[{"text":"ans1"}]}],"submissions":[{"userId":"anyUser@localhost","timestamp":1651354059,"answers":[{"questionId":14,"text":"ans1"}]}]}]'
 			]
 		];
 	}
@@ -162,6 +162,7 @@ class FormsMigratorTest extends TestCase {
 					"isRequired" => false,
 					"text" => "checkbox",
 					"description" => "huhu",
+					"extraSettings" => (object)[],
 					"options" => [
 						[
 							'id' => 35,
@@ -218,7 +219,7 @@ class FormsMigratorTest extends TestCase {
 	public function dataImport() {
 		return [
 			'exactlyOneOfEach' => [
-				'$inputJson' => '[{"title":"Link","description":"","created":1646251830,"access":{"permitAllUsers":false,"showToAllUsers":false},"expires":0,"isAnonymous":false,"submitMultiple":false,"questions":[{"id":14,"order":2,"type":"multiple","isRequired":false,"text":"checkbox","description":"huhu","options":[{"text":"ans1"}]}],"submissions":[{"userId":"anyUser@localhost","timestamp":1651354059,"answers":[{"questionId":14,"text":"ans1"}]}]}]'
+				'$inputJson' => '[{"title":"Link","description":"","created":1646251830,"access":{"permitAllUsers":false,"showToAllUsers":false},"expires":0,"isAnonymous":false,"submitMultiple":false,"questions":[{"id":14,"order":2,"type":"multiple","isRequired":false,"text":"checkbox","description":"huhu","extraSettings":{},"options":[{"text":"ans1"}]}],"submissions":[{"userId":"anyUser@localhost","timestamp":1651354059,"answers":[{"questionId":14,"text":"ans1"}]}]}]'
 			]
 		];
 	}


### PR DESCRIPTION
Fixes #1439 

### Bug Reproduction Steps

1. Have environment on NC25, with "User Migration" and "Forms" apps enabled
2. Create a form that has a question with extra settings, such as a multiple choice question with "Shuffle options" extra setting selected
3. Perform an export of the Forms app data
4. Verify the export data JSON contains the extra setting value
5. Delete the form created in step 2
6. Import the exported data from step 3
7. Verify the multiple choice question does NOT have "Shuffle options" selected (as the extra settings did not import)

### Bug Fix Validation

1. Apply the code change in this PR to the "Forms" app
2. Perform steps 2-6 in the reproduction steps above
3. Verify the form created from the import has the "Shuffle options" selected (the extra settings have imported successfully)