### PR TITLE
Show info message only if available

### DIFF
--- a/src/views/Submit.vue
+++ b/src/views/Submit.vue
@@ -45,7 +45,7 @@
 			<!-- eslint-disable-next-line -->
 			<p v-if="!loading && !success" class="form-desc">{{ form.description }}</p>
 			<!-- Generate form information message-->
-			<p class="info-message" v-text="infoMessage" />
+			<p v-if="infoMessage" class="info-message" v-text="infoMessage" />
 		</header>
 
 		<NcEmptyContent v-if="loading"


### PR DESCRIPTION
Removes dead space between description and questions, the space gets even worse if we add new messages like with #1432, this only affects the public view if the current user is not logged in.

For comparison, this is how it looks (with or without this) logged in:
![submit form, logged in view](https://user-images.githubusercontent.com/1855448/210360826-54bf2f33-1a60-45da-b245-77e68e40e5e0.png)

And this is how it looks like if the user is not logged in:
| :framed_picture: Before | :framed_picture: :sparkles:  After |
| ---------------------------------- | ------------------------------------------------ |
| ![submit form, current, lot dead space](https://user-images.githubusercontent.com/1855448/210361110-d6275107-6ad8-4675-913c-ef94e950292c.png) | ![submit form, changed, only the needed margin is used](https://user-images.githubusercontent.com/1855448/210361161-a4c61199-e225-4413-8597-1d07f47ba701.png) |
