### PR TITLE
Feature: Allow to share forms with Circles

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -34,6 +34,13 @@ jobs:
           ref: ${{ matrix.server-versions }}
           submodules: true
 
+      - name: Checkout circles dependency
+        uses: actions/checkout@v3
+        with:
+          repository: nextcloud/circles
+          ref: ${{ matrix.server-versions }}
+          path: apps/circles
+
       - name: Checkout app
         uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608
         with:
@@ -119,6 +126,13 @@ jobs:
           ref: ${{ matrix.server-versions }}
           submodules: true
 
+      - name: Checkout circles dependency
+        uses: actions/checkout@v3
+        with:
+          repository: nextcloud/circles
+          ref: ${{ matrix.server-versions }}
+          path: apps/circles
+
       - name: Checkout app
         uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608
         with:
@@ -187,6 +201,13 @@ jobs:
           repository: nextcloud/server
           ref: ${{ matrix.server-versions }}
           submodules: true
+
+      - name: Checkout circles dependency
+        uses: actions/checkout@v3
+        with:
+          repository: nextcloud/circles
+          ref: ${{ matrix.server-versions }}
+          path: apps/circles
 
       - name: Checkout app
         uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608
@@ -266,6 +287,13 @@ jobs:
           repository: nextcloud/server
           ref: ${{ matrix.server-versions }}
           submodules: true
+
+      - name: Checkout circles dependency
+        uses: actions/checkout@v3
+        with:
+          repository: nextcloud/circles
+          ref: ${{ matrix.server-versions }}
+          path: apps/circles
 
       - name: Checkout app
         uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608

--- a/lib/Activity/ActivityConstants.php
+++ b/lib/Activity/ActivityConstants.php
@@ -55,6 +55,15 @@ class ActivityConstants {
 	public const SUBJECT_NEWGROUPSHARE = 'newgroupshare';
 
 	/**
+	 * Somebody shared a form to a selected circle
+	 * Needs Params:
+	 * "user": The userId of the user who shared.
+	 * 'circleId': The circleId, that was shared to.
+	 * "formTitle": The hash of the shared form.
+	 * "formHash": The hash of the shared form
+	 */
+	public const SUBJECT_NEWCIRCLESHARE = 'newcircleshare';
+	/**
 	 * Somebody submitted an answer to a form
 	 * Needs Params:
 	 * "user": The userId of the user who submitted. Can also be our 'anon-user-', which will be handled separately.

--- a/lib/Constants.php
+++ b/lib/Constants.php
@@ -105,7 +105,8 @@ class Constants {
 	public const SHARE_TYPES_USED = [
 		IShare::TYPE_USER,
 		IShare::TYPE_GROUP,
-		IShare::TYPE_LINK
+		IShare::TYPE_LINK,
+		IShare::TYPE_CIRCLE
 	];
 
 	/**

--- a/lib/Service/CirclesService.php
+++ b/lib/Service/CirclesService.php
@@ -1,0 +1,129 @@
+<?php
+/**
+ * @copyright Copyright (c) 2020 Julius Härtl <jus@bitgrid.net>
+ *
+ * @author Julius Härtl <jus@bitgrid.net>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+declare(strict_types=1);
+
+
+namespace OCA\Forms\Service;
+
+use OCA\Circles\CirclesManager;
+use OCA\Circles\Model\Circle;
+use OCA\Circles\Model\Member;
+use OCP\App\IAppManager;
+use Psr\Container\ContainerInterface;
+use Psr\Log\LoggerInterface;
+use Throwable;
+
+/**
+ * Wrapper around circles app API since it is not in a public namespace so we need to make sure that
+ * having the app disabled is properly handled
+ */
+class CirclesService {
+	private bool $circlesEnabled;
+
+	private $userCircleCache = [];
+
+	public function __construct(
+		IAppManager $appManager,
+		private ContainerInterface $container,
+		private LoggerInterface $logger,
+	) {
+		$this->circlesEnabled = $appManager->isEnabledForUser('circles');
+	}
+
+	public function isCirclesEnabled(): bool {
+		return $this->circlesEnabled;
+	}
+
+	public function getCircle(string $circleId): ?Circle {
+		if (!$this->circlesEnabled) {
+			return null;
+		}
+
+		try {
+			$circlesManager = $this->container->get(CirclesManager::class);
+			// Enforce current user condition since we always want the full list of members
+			$circlesManager->startSuperSession();
+			return $circlesManager->getCircle($circleId);
+		} catch (Throwable $e) {
+		}
+		return null;
+	}
+
+	public function isUserInCircle(string $circleId, string $userId): bool {
+		if (!$this->circlesEnabled) {
+			return false;
+		}
+
+		if (isset($this->userCircleCache[$circleId][$userId])) {
+			return $this->userCircleCache[$circleId][$userId];
+		}
+
+		try {
+			$circlesManager = $this->container->get(CirclesManager::class);
+			$federatedUser = $circlesManager->getFederatedUser($userId, Member::TYPE_USER);
+			$circlesManager->startSession($federatedUser);
+			$circle = $circlesManager->getCircle($circleId);
+			$member = $circle->getInitiator();
+			$isUserInCircle = $member !== null && $member->getLevel() >= Member::LEVEL_MEMBER;
+
+			if (!isset($this->userCircleCache[$circleId])) {
+				$this->userCircleCache[$circleId] = [];
+			}
+			$this->userCircleCache[$circleId][$userId] = $isUserInCircle;
+
+			return $isUserInCircle;
+		} catch (Throwable $e) {
+		}
+		return false;
+	}
+
+	/**
+	 * Get the ids of all user which are member of a given circle
+	 *
+	 * @param string circleId Id of the circle
+	 * @return string[]
+	 */
+	public function getCircleUsers(string $circleId): array {
+		if (!$this->circlesEnabled) {
+			$this->logger->debug('Circles app is disabled');
+			return [];
+		}
+
+		$circle = $this->getCircle($circleId);
+		if ($circle === null) {
+			return [];
+		}
+
+		$users = [];
+		try {
+			$members = $circle->getInheritedMembers();
+			$members = array_filter($members, fn ($member) => $member->getUserType() === Member::TYPE_USER);
+
+			$users = array_map(fn ($user) => $user->getUserId(), $members);
+		} catch (Throwable $error) {
+			$this->logger->debug('Could not fetch users of circle', ['error' => $error]);
+		}
+		return $users;
+	}
+}

--- a/psalm.xml
+++ b/psalm.xml
@@ -22,6 +22,13 @@
 		</ignoreFiles>
 	</extraFiles>
 	<issueHandlers>
+		<UndefinedClass>
+			<errorLevel type="suppress">
+				<referencedClass name="OCA\Circles\CirclesManager" />
+				<referencedClass name="OCA\Circles\Model\Circle" />
+				<referencedClass name="OCA\Circles\Model\Member" />
+			</errorLevel>
+		</UndefinedClass>
 		<UndefinedDocblockClass>
 			<errorLevel type="suppress">
 				<referencedClass name="Doctrine\DBAL\Schema\Schema" />

--- a/src/components/SidebarTabs/SharingSearchDiv.vue
+++ b/src/components/SidebarTabs/SharingSearchDiv.vue
@@ -28,7 +28,7 @@
 			:loading="showLoadingCircle"
 			:get-option-key="(option) => option.key"
 			:options="options"
-			:placeholder="t('forms', 'Search for user or group …')"
+			:placeholder="t('forms', 'Search for user, group or circle …')"
 			:user-select="true"
 			label="displayName"
 			@search="asyncSearch"

--- a/src/components/SidebarTabs/SharingShareDiv.vue
+++ b/src/components/SidebarTabs/SharingShareDiv.vue
@@ -24,6 +24,7 @@
 	<li class="share-div">
 		<NcAvatar :user="share.shareWith"
 			:disable-menu="true"
+			:display-name="displayName"
 			:is-no-user="isNoUser" />
 		<div class="share-div__desc">
 			<span>{{ displayName }}</span>
@@ -88,7 +89,14 @@ export default {
 			return !this.share.displayName ? this.share.shareWith : this.share.displayName
 		},
 		displayNameAppendix() {
-			return (this.share.shareType === this.SHARE_TYPES.SHARE_TYPE_GROUP) ? `(${t('forms', 'Group')})` : ''
+			switch (this.share.shareType) {
+			case this.SHARE_TYPES.SHARE_TYPE_GROUP:
+				return `(${t('forms', 'Group')})`
+			case this.SHARE_TYPES.SHARE_TYPE_CIRCLE:
+				return `(${t('forms', 'Circle')})`
+			default:
+				return ''
+			}
 		},
 	},
 

--- a/src/mixins/ShareTypes.js
+++ b/src/mixins/ShareTypes.js
@@ -42,6 +42,7 @@ export default {
 				OC.Share.SHARE_TYPE_USER,
 				OC.Share.SHARE_TYPE_GROUP,
 				OC.Share.SHARE_TYPE_LINK,
+				OC.Share.SHARE_TYPE_CIRCLE,
 			],
 		}
 	},

--- a/tests/Unit/Service/CirclesServiceTest.php
+++ b/tests/Unit/Service/CirclesServiceTest.php
@@ -1,0 +1,201 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * @copyright Copyright (c) 2023 Ferdinand Thiessen <rpm@fthiessen.de>
+ *
+ * @author Ferdinand Thiessen <rpm@fthiessen.de>
+ *
+ * @license AGPL-3.0-or-later
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+namespace OCA\Forms\Tests\Unit\Service;
+
+use OCA\Circles\CirclesManager;
+use OCA\Circles\Model\Circle;
+use OCA\Circles\Model\Member;
+use OCA\Forms\Service\CirclesService;
+use OCP\App\IAppManager;
+use PHPUnit\Framework\MockObject\MockObject;
+use Psr\Container\ContainerInterface;
+use Psr\Log\LoggerInterface;
+use Test\TestCase;
+use Throwable;
+
+class CirclesServiceText extends TestCase {
+	/** @var ContainerInterface|MockObject */
+	private $container;
+	/** @var IAppManager|MockObject */
+	private $appManager;
+	/** @var LoggerInterface|MockObject */
+	private $logger;
+
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->container = $this->createMock(ContainerInterface::class);
+		$this->logger = $this->createMock(LoggerInterface::class);
+		$this->appManager = $this->createMock(IAppManager::class);
+	}
+
+	public function dataIsEnabled() {
+		return [
+			'not-enabled' => [
+				false,
+				false
+			],
+			'enabled' => [
+				true,
+				true
+			]
+		];
+	}
+
+	/**
+	 * @dataProvider dataIsEnabled
+	 */
+	public function testIsEnabled($enabled, $expected) {
+		$this->appManager->expects($this->once())
+			->method('isEnabledForUser')
+			->with('circles')
+			->willReturn($enabled);
+		$circlesService = new CirclesService($this->appManager, $this->container, $this->logger);
+		$this->assertEquals($circlesService->isCirclesEnabled(), $expected);
+	}
+
+	public function dataGetCircle() {
+		$circle = $this->createMock(Circle::class);
+
+		return [
+			'valid-circle' => [
+				true,
+				false,
+				$circle,
+				$circle
+			],
+			'invalid-circle' => [
+				true,
+				true,
+				$circle,
+				null,
+			],
+			'disabled-app' => [
+				false,
+				false,
+				$circle,
+				null
+			]
+		];
+	}
+
+	/**
+	 * @dataProvider dataGetCircle
+	 */
+	public function testGetCircle($enabled, $throws, $circle, $expected) {
+		$this->appManager->expects($this->once())
+			->method('isEnabledForUser')
+			->with('circles')
+			->willReturn($enabled);
+
+		$circlesService = new CirclesService($this->appManager, $this->container, $this->logger);
+		$circlesManager = $this->createMock(CirclesManager::class);
+		$this->container->expects($enabled ? $this->once() : $this->never())
+			->method('get')
+			->with(CirclesManager::class)
+			->willReturn($circlesManager);
+		$e = $circlesManager->expects($enabled ? $this->once() : $this->never())
+			->method('getCircle')
+			->with('circle');
+		if ($throws) {
+			$e->will($this->throwException($this->createMock(Throwable::class)));
+		} else {
+			$e->willReturn($circle);
+		}
+
+		$this->assertEquals($circlesService->getCircle('circle'), $expected);
+	}
+
+	public function testGetCircleUsers_circlesDisabled() {
+		$this->appManager->expects($this->once())
+			->method('isEnabledForUser')
+			->with('circles')
+			->willReturn(false);
+
+		$circlesService = $this->getMockBuilder(CirclesService::class)
+			->onlyMethods(['getCircle'])
+			->setConstructorArgs([$this->appManager, $this->container, $this->logger])
+			->getMock();
+		
+		$circlesService->expects($this->never())
+			->method('getCircle');
+
+		$this->assertEquals($circlesService->getCircleUsers('some'), []);
+	}
+
+	public function testGetCircleUsers_circleNotFound() {
+		$this->appManager->expects($this->once())
+			->method('isEnabledForUser')
+			->with('circles')
+			->willReturn(true);
+
+		$circlesService = $this->getMockBuilder(CirclesService::class)
+			->onlyMethods(['getCircle'])
+			->setConstructorArgs([$this->appManager, $this->container, $this->logger])
+			->getMock();
+		
+		$circlesService->expects($this->once())
+			->method('getCircle')
+			->with('noCircle')
+			->willReturn(null);
+
+		$this->assertEquals($circlesService->getCircleUsers('noCircle'), []);
+	}
+
+	public function testGetCircleUsers() {
+		$userNames = ['user1', 'user2', 'user3'];
+
+		$member = $this->createMock(Member::class);
+		$member->expects($this->exactly(4))
+			->method('getUserType')
+			->willReturnOnConsecutiveCalls(Member::TYPE_USER, Member::TYPE_GROUP, Member::TYPE_USER, Member::TYPE_USER);
+		$member->expects($this->exactly(3))
+			->method('getUserId')
+			->willReturnOnConsecutiveCalls(...$userNames);
+
+		$members = [$member, $member, $member, $member];
+		$circle = $this->createMock(Circle::class);
+		$circle->expects($this->once())
+			->method('getInheritedMembers')
+			->willReturn($members);
+
+		$this->appManager->expects($this->once())
+			->method('isEnabledForUser')
+			->with('circles')
+			->willReturn(true);
+
+		$circlesService = $this->getMockBuilder(CirclesService::class)
+			->onlyMethods(['getCircle'])
+			->setConstructorArgs([$this->appManager, $this->container, $this->logger])
+			->getMock();
+		
+		$circlesService->expects($this->once())
+			->method('getCircle')
+			->with('circle')
+			->willReturn($circle);
+
+		$this->assertEqualsCanonicalizing($circlesService->getCircleUsers('circle'), $userNames);
+	}
+}


### PR DESCRIPTION
* Resolves #1012 

## Summary
This allows to share forms with circles.
The circle manager is not directly injected as it is possible that users disabled the circles app, so only the container is injected and then used to query the manager (if available).

The front end changes are minimal, just changed the placeholder and added the `display-name` property to the `NcAvatar` to fix circle avatars (if not added the avatar would be generated from the ID which would have wrong initials).