### PR TITLE
feat: Add slot for additional actions to the question component

### DIFF
--- a/src/components/Questions/Question.vue
+++ b/src/components/Questions/Question.vue
@@ -65,11 +65,7 @@
 						<!-- TRANSLATORS Making this question necessary to be answered when submitting to a form -->
 						{{ t('forms', 'Required') }}
 					</NcActionCheckbox>
-					<NcActionCheckbox v-if="shuffleOptions !== undefined"
-						:checked="shuffleOptions"
-						@update:checked="onShuffleOptionsChange">
-						{{ t('forms', 'Shuffle options') }}
-					</NcActionCheckbox>
+					<slot name="actions" />
 					<NcActionButton @click="onDelete">
 						<template #icon>
 							<IconDelete :size="20" />
@@ -150,10 +146,6 @@ export default {
 			type: Boolean,
 			default: false,
 		},
-		shuffleOptions: {
-			type: Boolean,
-			default: undefined,
-		},
 		edit: {
 			type: Boolean,
 			required: true,
@@ -219,10 +211,6 @@ export default {
 
 		onRequiredChange(isRequired) {
 			this.$emit('update:isRequired', isRequired)
-		},
-
-		onShuffleOptionsChange(shuffleOptions) {
-			this.$emit('update:shuffleOptions', shuffleOptions)
 		},
 
 		/**

--- a/src/components/Questions/QuestionDropdown.vue
+++ b/src/components/Questions/QuestionDropdown.vue
@@ -25,7 +25,6 @@
 		:text="text"
 		:description="description"
 		:is-required="isRequired"
-		:shuffle-options="!!extraSettings?.shuffleOptions"
 		:edit.sync="edit"
 		:read-only="readOnly"
 		:max-string-lengths="maxStringLengths"
@@ -36,8 +35,13 @@
 		@update:text="onTitleChange"
 		@update:description="onDescriptionChange"
 		@update:isRequired="onRequiredChange"
-		@update:shuffleOptions="onShuffleOptionsChange"
 		@delete="onDelete">
+		<template #actions>
+			<NcActionCheckbox :checked="extraSettings?.shuffleOptions"
+				@update:checked="onShuffleOptionsChange">
+				{{ t('forms', 'Shuffle options') }}
+			</NcActionCheckbox>
+		</template>
 		<NcMultiselect v-if="!edit"
 			v-model="selectedOption"
 			:name="text"
@@ -81,6 +85,7 @@
 import { generateOcsUrl } from '@nextcloud/router'
 import { showError } from '@nextcloud/dialogs'
 import axios from '@nextcloud/axios'
+import NcActionCheckbox from '@nextcloud/vue/dist/Components/NcActionCheckbox.js'
 import NcMultiselect from '@nextcloud/vue/dist/Components/NcMultiselect.js'
 
 import AnswerInput from './AnswerInput.vue'
@@ -93,6 +98,7 @@ export default {
 
 	components: {
 		AnswerInput,
+		NcActionCheckbox,
 		NcMultiselect,
 	},
 

--- a/src/components/Questions/QuestionMultiple.vue
+++ b/src/components/Questions/QuestionMultiple.vue
@@ -25,7 +25,6 @@
 		:text="text"
 		:description="description"
 		:is-required="isRequired"
-		:shuffle-options="!!extraSettings?.shuffleOptions"
 		:edit.sync="edit"
 		:read-only="readOnly"
 		:max-string-lengths="maxStringLengths"
@@ -36,8 +35,13 @@
 		@update:text="onTitleChange"
 		@update:description="onDescriptionChange"
 		@update:isRequired="onRequiredChange"
-		@update:shuffleOptions="onShuffleOptionsChange"
 		@delete="onDelete">
+		<template #actions>
+			<NcActionCheckbox :checked="extraSettings?.shuffleOptions"
+				@update:checked="onShuffleOptionsChange">
+				{{ t('forms', 'Shuffle options') }}
+			</NcActionCheckbox>
+		</template>
 		<template v-if="!edit">
 			<NcCheckboxRadioSwitch v-for="(answer) in sortedOptions"
 				:key="answer.id"
@@ -89,6 +93,7 @@
 import { generateOcsUrl } from '@nextcloud/router'
 import { showError } from '@nextcloud/dialogs'
 import axios from '@nextcloud/axios'
+import NcActionCheckbox from '@nextcloud/vue/dist/Components/NcActionCheckbox.js'
 import NcCheckboxRadioSwitch from '@nextcloud/vue/dist/Components/NcCheckboxRadioSwitch.js'
 import IconCheckboxBlankOutline from 'vue-material-design-icons/CheckboxBlankOutline.vue'
 import IconRadioboxBlank from 'vue-material-design-icons/RadioboxBlank.vue'
@@ -105,6 +110,7 @@ export default {
 		AnswerInput,
 		IconCheckboxBlankOutline,
 		IconRadioboxBlank,
+		NcActionCheckbox,
 		NcCheckboxRadioSwitch,
 	},
 


### PR DESCRIPTION
Added a slot for additional, question specific, settings and moved the shuffle option to only the required questions.
Did this to allow further custom question settings without adding more, mostly useless, properties to the question component. E.g. such a feature could be the validation of a short question.

I am not 100% sure about the position of the slot, I think `delete the question` should always be the last option, but not sure if all other common options should be above the slot or also below the slot.