### PR TITLE
Add missing computed property to edit view

### DIFF
--- a/src/views/Create.vue
+++ b/src/views/Create.vue
@@ -206,6 +206,13 @@ export default {
 			return this.form.questions.reduce((isUsed, question) => isUsed || question.isRequired, false)
 		},
 
+		/**
+		 * Check if form is expired
+		 */
+		isExpired() {
+			return this.form.expires && moment().unix() > this.form.expires
+		},
+
 		infoMessage() {
 			let message = ''
 			if (this.form.isAnonymous) {


### PR DESCRIPTION
This fixes the wrong text (present instead of past tense) being shown in the edit view when the form is expired.

Signed-off-by: Chartman123 <chris-hartmann@gmx.de>