### PR TITLE
Add shareHash parameter

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -387,6 +387,7 @@ Contains only manipulative question-endpoints. To retrieve options, request the 
   |------------------|----------|-------------|
   | _id_             | Integer  | ID of the share to update |
   | *keyValuePairs*¹ | Array    | Array of key-value pairs to update |
+  
   ¹Currently only the _permissions_ can be updated.
 - Method: `POST`
 - Response: **Status-Code OK**, as well as the id of the share object.
@@ -540,6 +541,8 @@ Store Submission to Database
   |-----------|---------|-------------|
   | _formId_  | Integer | ID of the form to submit into |
   | _answers_ | Array   | Array of Answers |
+  | _shareHash_ | String | optional, only neccessary for submissions to a public share link |
+  
   The Array of Answers has the following structure:
   - QuestionID as key
   - An **array** of values as value --> Even for short Text Answers, wrapped into Array.


### PR DESCRIPTION
Fixes #1468 

Add missing shareHash parameter to documentation of  `/api/v2/submission/insert`

Signed-off-by: Chartman123 <chris-hartmann@gmx.de>