### PR TITLE
Drop `v-clipboard` in favor of native browser API

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,6 @@
 				"p-queue": "^7.3.0",
 				"regenerator-runtime": "^0.13.11",
 				"v-click-outside": "^3.2.0",
-				"v-clipboard": "^2.2.3",
 				"vue": "^2.7.14",
 				"vue-material-design-icons": "^5.1.2",
 				"vue-router": "^3.6.5",
@@ -11479,11 +11478,6 @@
 				"node": ">=6"
 			}
 		},
-		"node_modules/v-clipboard": {
-			"version": "2.2.3",
-			"resolved": "https://registry.npmjs.org/v-clipboard/-/v-clipboard-2.2.3.tgz",
-			"integrity": "sha512-Wg+ObZoYK6McHb5OOCFWvm0R7xHp0/p0G1ocx/8bO22jvA/yVY05rADbfiztwCokXBNfQuGv/XSd1ozcTFgekw=="
-		},
 		"node_modules/v8-compile-cache": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
@@ -21075,11 +21069,6 @@
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/v-click-outside/-/v-click-outside-3.2.0.tgz",
 			"integrity": "sha512-QD0bDy38SHJXQBjgnllmkI/rbdiwmq9RC+/+pvrFjYJKTn8dtp7Penf9q1lLBta280fYG2q53mgLhQ+3l3z74w=="
-		},
-		"v-clipboard": {
-			"version": "2.2.3",
-			"resolved": "https://registry.npmjs.org/v-clipboard/-/v-clipboard-2.2.3.tgz",
-			"integrity": "sha512-Wg+ObZoYK6McHb5OOCFWvm0R7xHp0/p0G1ocx/8bO22jvA/yVY05rADbfiztwCokXBNfQuGv/XSd1ozcTFgekw=="
 		},
 		"v8-compile-cache": {
 			"version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
 		"p-queue": "^7.3.0",
 		"regenerator-runtime": "^0.13.11",
 		"v-click-outside": "^3.2.0",
-		"v-clipboard": "^2.2.3",
 		"vue": "^2.7.14",
 		"vue-material-design-icons": "^5.1.2",
 		"vue-router": "^3.6.5",

--- a/src/mixins/ShareLinkMixin.js
+++ b/src/mixins/ShareLinkMixin.js
@@ -21,10 +21,6 @@
  */
 import { generateUrl } from '@nextcloud/router'
 import { showError, showSuccess } from '@nextcloud/dialogs'
-import Clipboard from 'v-clipboard'
-import Vue from 'vue'
-
-Vue.use(Clipboard)
 
 export default {
 	methods: {
@@ -57,9 +53,10 @@ export default {
 		 */
 		async copyLink(event, link) {
 			// Copy link, boolean return indicates success or fail.
-			if (this.$clipboard(link)) {
+			try {
+				await navigator.clipboard.writeText(link)
 				showSuccess(t('forms', 'Form link copied'))
-			} else {
+			} catch (error) {
 				showError(t('forms', 'Cannot copy, please copy the link manually'))
 			}
 			// Set back focus as clipboard removes focus

--- a/src/mixins/ViewsMixin.js
+++ b/src/mixins/ViewsMixin.js
@@ -23,15 +23,11 @@
 import { generateOcsUrl } from '@nextcloud/router'
 import { showError } from '@nextcloud/dialogs'
 import axios from '@nextcloud/axios'
-import Clipboard from 'v-clipboard'
 import MarkdownIt from 'markdown-it'
-import Vue from 'vue'
 
 import CancelableRequest from '../utils/CancelableRequest.js'
 import OcsResponse2Data from '../utils/OcsResponse2Data.js'
 import logger from '../utils/Logger.js'
-
-Vue.use(Clipboard)
 
 export default {
 	provide() {


### PR DESCRIPTION
`v-clipboard` does not work for copying the embedding code in #1353 thats why I switch to `vue-clipboard2`.
But both packages are quite buggy or outdated.

So instead of using a package for this, we should use the browser clipboard API, similar to the server which is switching to that API too: https://github.com/nextcloud/server/pull/36450