### PR TITLE
Add Nextcloud 26 support

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -18,7 +18,7 @@ jobs:
       # do not stop on another job's failure
       fail-fast: false
       matrix:
-        php-versions: ["8.0", "8.1"]
+        php-versions: ["8.0", "8.1", "8.2"]
         # Upload coverage only once (out of php-versions)
         coverage-on: ['8.1']
         databases: ['sqlite']

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -15,7 +15,7 @@
 	<licence>agpl</licence>
 	<version>3.0.4</version>
 	<dependencies>
-		<nextcloud min-version="25" max-version="25" />
+		<nextcloud min-version="25" max-version="26" />
 	</dependencies>
 
 	<author>Affan Hussain</author>


### PR DESCRIPTION
Nextcloud 26 will require PHP 8.2 support (added with NC26 beta 2), but it looks like we could keep 3.x on both NC25 and NC26.

BTW all of my PRs are tested on NC26 as my local docker runs only the latest NC pre release, meaning the current main branch works fine on NC26.
