### PR TITLE
Fix public view

### DIFF
--- a/lib/Service/FormsService.php
+++ b/lib/Service/FormsService.php
@@ -265,8 +265,12 @@ class FormsService {
 	public function getPermissions(int $formId): array {
 		$form = $this->formMapper->findById($formId);
 
+		if (!$this->currentUser) {
+			return [];
+		}
+
 		// Owner is allowed to do everything
-		if ($this->currentUser && $this->currentUser->getUID() === $form->getOwnerId()) {
+		if ($this->currentUser->getUID() === $form->getOwnerId()) {
 			return Constants::PERMISSION_ALL;
 		}
 

--- a/tests/Unit/Service/FormsServiceTest.php
+++ b/tests/Unit/Service/FormsServiceTest.php
@@ -577,6 +577,38 @@ class FormsServiceTest extends TestCase {
 		$this->assertEquals($expected, $this->formsService->getPermissions(42));
 	}
 
+	// No currentUser on public views.
+	public function testGetPermissions_NotLoggedIn() {
+		$userSession = $this->createMock(IUserSession::class);
+		$userSession->expects($this->once())
+			->method('getUser')
+			->willReturn(null);
+
+		$formsService = new FormsService(
+			$this->activityManager,
+			$this->formMapper,
+			$this->optionMapper,
+			$this->questionMapper,
+			$this->shareMapper,
+			$this->submissionMapper,
+			$this->configService,
+			$this->groupManager,
+			$this->logger,
+			$this->userManager,
+			$userSession,
+			$this->secureRandom
+		);
+
+		$form = new Form();
+		$form->setId(42);
+		$this->formMapper->expects($this->any())
+			->method('findById')
+			->with(42)
+			->willReturn($form);
+
+		$this->assertEquals([], $formsService->getPermissions(42));
+	}
+
 	public function dataCanSeeResults() {
 		return [
 			'allowFormOwner' => [


### PR DESCRIPTION
Non-logged in view currently fails with currentUser->getUID() on null.

Permissions are only used with internal views/users, thus we can just quickly return here.