### PR TITLE
fix: Regression if user is not logged in `getPermissions`

### DIFF
--- a/lib/Service/FormsService.php
+++ b/lib/Service/FormsService.php
@@ -271,9 +271,11 @@ class FormsService {
 		}
 
 		$permissions = [];
-		$shares = $this->getSharesWithUser($formId, $this->currentUser->getUID());
-		foreach ($shares as $share) {
-			$permissions = array_merge($permissions, $share->getPermissions());
+		if ($this->currentUser) {
+			$shares = $this->getSharesWithUser($formId, $this->currentUser->getUID());
+			foreach ($shares as $share) {
+				$permissions = array_merge($permissions, $share->getPermissions());
+			}
 		}
 
 		// Fall back to submit permission if access is granted to all users


### PR DESCRIPTION
If the user is not logged in `getPermissions` will try to call `getUID` on `null`.
This makes public shares impossible (`getPublicForm` calls `getForm` which calls `getPermissions`).