### PR TITLE
Fix `stable2` phpunit workflows - run on stable24 instead of master

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,12 +13,12 @@ jobs:
 
     strategy:
       matrix:
-        php-versions: ["7.3", "7.4", "8.0", "8.1"]
+        php-versions: ["7.4", "8.0", "8.1"]
 
     name: php${{ matrix.php-versions }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up php ${{ matrix.php-versions }}
         uses: shivammathur/setup-php@v2
@@ -39,12 +39,13 @@ jobs:
     name: cs php${{ matrix.php-versions }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up php
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php-versions }}
+          tools: composer:v1
           coverage: none
 
       - name: Install dependencies
@@ -61,7 +62,7 @@ jobs:
     name: eslint node
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up node
         uses: actions/setup-node@v2
@@ -83,7 +84,7 @@ jobs:
     name: stylelint node
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up node
         uses: actions/setup-node@v2

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -20,7 +20,7 @@ jobs:
       matrix:
         php-versions: ['7.4', "8.0", "8.1"]
         databases: ['sqlite']
-        server-versions: ['master']
+        server-versions: ['stable24']
   
     name: php${{ matrix.php-versions }}-${{ matrix.databases }}-${{ matrix.server-versions }}
 
@@ -66,13 +66,13 @@ jobs:
         working-directory: apps/${{ env.APP_NAME }}
         run: composer test:integration
 
-      - name: Upload coverage
-        uses: codecov/codecov-action@v1
-        with:
-          root_dir: apps/${{ env.APP_NAME }}
-          files: apps/${{ env.APP_NAME }}/tests/clover.unit.xml
-          fail_ci_if_error: true
-          flags: unittests
+#      - name: Upload coverage
+#        uses: codecov/codecov-action@v1
+#        with:
+#          root_dir: apps/${{ env.APP_NAME }}
+#          files: apps/${{ env.APP_NAME }}/tests/clover.unit.xml
+#          fail_ci_if_error: true
+#          flags: unittests
 
   mysql:
     runs-on: ubuntu-latest
@@ -83,7 +83,7 @@ jobs:
       matrix:
         php-versions: ['7.4']
         databases: ['mysql']
-        server-versions: ['stable22', 'stable23', 'master']
+        server-versions: ['stable22', 'stable23', 'stable24']
   
     name: php${{ matrix.php-versions }}-${{ matrix.databases }}-${{ matrix.server-versions }}
 
@@ -147,13 +147,13 @@ jobs:
       matrix:
         php-versions: ['7.4']
         databases: ['pgsql']
-        server-versions: ['master']
+        server-versions: ['stable24']
   
     name: php${{ matrix.php-versions }}-${{ matrix.databases }}-${{ matrix.server-versions }}
 
     services:
       postgres:
-        image: postgres
+        image: postgres:14
         ports:
           - 4444:5432/tcp
         env:
@@ -213,7 +213,7 @@ jobs:
       matrix:
         php-versions: ['7.4']
         databases: ['oci']
-        server-versions: ['master']
+        server-versions: ['stable24']
 
     name: php${{ matrix.php-versions }}-${{ matrix.databases }}-${{ matrix.server-versions }}
 


### PR DESCRIPTION
`stable2` targets Nextcloud 22 - 24, and max. PHP7.4 so do not try to run tests on current Nextcloud master.

And also pin postgres to version 14.