### PR TITLE
Allow reordering questions using the keyboard

### DIFF
--- a/src/components/Questions/QuestionDate.vue
+++ b/src/components/Questions/QuestionDate.vue
@@ -31,11 +31,7 @@
 		:max-string-lengths="maxStringLengths"
 		:title-placeholder="answerType.titlePlaceholder"
 		:warning-invalid="answerType.warningInvalid"
-		@update:text="onTitleChange"
-		@update:description="onDescriptionChange"
-		@update:isRequired="onRequiredChange"
-		@update:name="onNameChange"
-		@delete="onDelete">
+		v-on="commonListeners">
 		<div class="question__content">
 			<NcDatetimePicker v-model="time"
 				:disabled="!readOnly"

--- a/src/components/Questions/QuestionDropdown.vue
+++ b/src/components/Questions/QuestionDropdown.vue
@@ -33,11 +33,7 @@
 		:warning-invalid="answerType.warningInvalid"
 		:content-valid="contentValid"
 		:shift-drag-handle="shiftDragHandle"
-		@update:text="onTitleChange"
-		@update:description="onDescriptionChange"
-		@update:isRequired="onRequiredChange"
-		@update:name="onNameChange"
-		@delete="onDelete">
+		v-on="commonListeners">
 		<template #actions>
 			<NcActionCheckbox :checked="extraSettings?.shuffleOptions"
 				@update:checked="onShuffleOptionsChange">

--- a/src/components/Questions/QuestionLong.vue
+++ b/src/components/Questions/QuestionLong.vue
@@ -31,11 +31,7 @@
 		:max-string-lengths="maxStringLengths"
 		:title-placeholder="answerType.titlePlaceholder"
 		:warning-invalid="answerType.warningInvalid"
-		@update:text="onTitleChange"
-		@update:description="onDescriptionChange"
-		@update:isRequired="onRequiredChange"
-		@update:name="onNameChange"
-		@delete="onDelete">
+		v-on="commonListeners">
 		<div class="question__content">
 			<textarea ref="textarea"
 				:aria-label="t('forms', 'A long answer for the question “{text}”', { text })"

--- a/src/components/Questions/QuestionMultiple.vue
+++ b/src/components/Questions/QuestionMultiple.vue
@@ -33,11 +33,7 @@
 		:warning-invalid="answerType.warningInvalid"
 		:content-valid="contentValid"
 		:shift-drag-handle="shiftDragHandle"
-		@update:text="onTitleChange"
-		@update:description="onDescriptionChange"
-		@update:isRequired="onRequiredChange"
-		@update:name="onNameChange"
-		@delete="onDelete">
+		v-on="commonListeners">
 		<template #actions>
 			<NcActionCheckbox :checked="extraSettings?.shuffleOptions"
 				@update:checked="onShuffleOptionsChange">

--- a/src/components/Questions/QuestionShort.vue
+++ b/src/components/Questions/QuestionShort.vue
@@ -31,11 +31,7 @@
 		:max-string-lengths="maxStringLengths"
 		:title-placeholder="answerType.titlePlaceholder"
 		:warning-invalid="answerType.warningInvalid"
-		@update:text="onTitleChange"
-		@update:description="onDescriptionChange"
-		@update:isRequired="onRequiredChange"
-		@update:name="onNameChange"
-		@delete="onDelete">
+		v-on="commonListeners">
 		<div class="question__content">
 			<input ref="input"
 				:aria-label="t('forms', 'A short answer for the question “{text}”', { text })"

--- a/src/mixins/QuestionMixin.js
+++ b/src/mixins/QuestionMixin.js
@@ -41,6 +41,14 @@ export default {
 		},
 
 		/**
+		 * ID of the form
+		 */
+		formId: {
+			type: Number,
+			default: null,
+		},
+
+		/**
 		 * The question title
 		 */
 		text: {
@@ -88,6 +96,22 @@ export default {
 		options: {
 			type: Array,
 			required: true,
+		},
+
+		/**
+		 * Order of the question
+		 */
+		order: {
+			type: Number,
+			default: -1,
+		},
+
+		/**
+		 * Question type
+		 */
+		type: {
+			type: String,
+			default: null,
 		},
 
 		/**
@@ -143,6 +167,21 @@ export default {
 			}
 			// Ensure order of options always is the same
 			return [...this.options].sort((a, b) => a.id - b.id)
+		},
+
+		/**
+		 * Listeners for all questions to forward
+		 */
+		commonListeners() {
+			return {
+				delete: this.onDelete,
+				'update:text': this.onTitleChange,
+				'update:description': this.onDescriptionChange,
+				'update:isRequired': this.onRequiredChange,
+				'update:name': this.onNameChange,
+				'move-down': (...args) => this.$emit('move-down', ...args),
+				'move-up': (...args) => this.$emit('move-up', ...args),
+			}
 		},
 	},
 


### PR DESCRIPTION
### Part 1: Adding missing aria role
Resolves: #1263 
`div`s require a role when `aria-label` is set (see context in linked issue)

### Part 2: Add buttons
Resolves: #317 
Added buttons for changing the order. Buttons can be focused and triggered using the keyboard.
This also preserves the drag and drop handling, but also allows using buttons or the keyboard.

The buttons are only shown if hovered / focused, but they are always accessible for screen readers.

If a button is clicked / triggered the focus is kept on the button (the vanishing focus ring in the following video happens only because disabled buttons from `@nextcloud/vue` do not have a visual focus ring)


https://user-images.githubusercontent.com/1855448/220498206-3a1befaf-6def-45e1-9be7-980e8ee4b277.mp4

