### PR TITLE
Move API to v2.1

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -82,7 +82,7 @@ return [
 			'url' => '/api/{apiVersion}/forms',
 			'verb' => 'GET',
 			'requirements' => [
-				'apiVersion' => 'v2'
+				'apiVersion' => 'v2(\.1)?'
 			]
 		],
 		[
@@ -90,7 +90,7 @@ return [
 			'url' => '/api/{apiVersion}/form',
 			'verb' => 'POST',
 			'requirements' => [
-				'apiVersion' => 'v2'
+				'apiVersion' => 'v2(\.1)?'
 			]
 		],
 		[
@@ -98,7 +98,7 @@ return [
 			'url' => '/api/{apiVersion}/form/{id}',
 			'verb' => 'GET',
 			'requirements' => [
-				'apiVersion' => 'v2'
+				'apiVersion' => 'v2(\.1)?'
 			]
 		],
 		[
@@ -106,7 +106,7 @@ return [
 			'url' => '/api/{apiVersion}/form/clone/{id}',
 			'verb' => 'POST',
 			'requirements' => [
-				'apiVersion' => 'v2'
+				'apiVersion' => 'v2(\.1)?'
 			]
 		],
 		[
@@ -114,7 +114,7 @@ return [
 			'url' => '/api/{apiVersion}/form/update',
 			'verb' => 'POST',
 			'requirements' => [
-				'apiVersion' => 'v2'
+				'apiVersion' => 'v2(\.1)?'
 			]
 		],
 		[
@@ -122,7 +122,7 @@ return [
 			'url' => '/api/{apiVersion}/form/{id}',
 			'verb' => 'DELETE',
 			'requirements' => [
-				'apiVersion' => 'v2'
+				'apiVersion' => 'v2(\.1)?'
 			]
 		],
 		[
@@ -130,7 +130,7 @@ return [
 			'url' => '/api/{apiVersion}/partial_form/{hash}',
 			'verb' => 'GET',
 			'requirements' => [
-				'apiVersion' => 'v2'
+				'apiVersion' => 'v2(\.1)?'
 			]
 		],
 		[
@@ -138,7 +138,7 @@ return [
 			'url' => '/api/{apiVersion}/shared_forms',
 			'verb' => 'GET',
 			'requirements' => [
-				'apiVersion' => 'v2'
+				'apiVersion' => 'v2(\.1)?'
 			]
 		],
 
@@ -148,7 +148,7 @@ return [
 			'url' => '/api/{apiVersion}/question',
 			'verb' => 'POST',
 			'requirements' => [
-				'apiVersion' => 'v2'
+				'apiVersion' => 'v2(\.1)?'
 			]
 		],
 		[
@@ -156,7 +156,7 @@ return [
 			'url' => '/api/{apiVersion}/question/update',
 			'verb' => 'POST',
 			'requirements' => [
-				'apiVersion' => 'v2'
+				'apiVersion' => 'v2(\.1)?'
 			]
 		],
 		[
@@ -164,7 +164,7 @@ return [
 			'url' => '/api/{apiVersion}/question/reorder',
 			'verb' => 'POST',
 			'requirements' => [
-				'apiVersion' => 'v2'
+				'apiVersion' => 'v2(\.1)?'
 			]
 		],
 		[
@@ -172,7 +172,7 @@ return [
 			'url' => '/api/{apiVersion}/question/{id}',
 			'verb' => 'DELETE',
 			'requirements' => [
-				'apiVersion' => 'v2'
+				'apiVersion' => 'v2(\.1)?'
 			]
 		],
 
@@ -182,7 +182,7 @@ return [
 			'url' => '/api/{apiVersion}/option',
 			'verb' => 'POST',
 			'requirements' => [
-				'apiVersion' => 'v2'
+				'apiVersion' => 'v2(\.1)?'
 			]
 		],
 		[
@@ -190,7 +190,7 @@ return [
 			'url' => '/api/{apiVersion}/option/update',
 			'verb' => 'POST',
 			'requirements' => [
-				'apiVersion' => 'v2'
+				'apiVersion' => 'v2(\.1)?'
 			]
 		],
 		[
@@ -198,7 +198,7 @@ return [
 			'url' => '/api/{apiVersion}/option/{id}',
 			'verb' => 'DELETE',
 			'requirements' => [
-				'apiVersion' => 'v2'
+				'apiVersion' => 'v2(\.1)?'
 			]
 		],
 
@@ -208,7 +208,7 @@ return [
 			'url' => '/api/{apiVersion}/share',
 			'verb' => 'POST',
 			'requirements' => [
-				'apiVersion' => 'v2'
+				'apiVersion' => 'v2(\.1)?'
 			]
 		],
 		[
@@ -216,7 +216,7 @@ return [
 			'url' => '/api/{apiVersion}/share/{id}',
 			'verb' => 'DELETE',
 			'requirements' => [
-				'apiVersion' => 'v2'
+				'apiVersion' => 'v2(\.1)?'
 			]
 		],
 		[
@@ -234,7 +234,7 @@ return [
 			'url' => '/api/{apiVersion}/submissions/{hash}',
 			'verb' => 'GET',
 			'requirements' => [
-				'apiVersion' => 'v2'
+				'apiVersion' => 'v2(\.1)?'
 			]
 		],
 		[
@@ -242,7 +242,7 @@ return [
 			'url' => '/api/{apiVersion}/submissions/export/{hash}',
 			'verb' => 'GET',
 			'requirements' => [
-				'apiVersion' => 'v2'
+				'apiVersion' => 'v2(\.1)?'
 			]
 		],
 		[
@@ -250,7 +250,7 @@ return [
 			'url' => '/api/{apiVersion}/submissions/export',
 			'verb' => 'POST',
 			'requirements' => [
-				'apiVersion' => 'v2'
+				'apiVersion' => 'v2(\.1)?'
 			]
 		],
 		[
@@ -258,7 +258,7 @@ return [
 			'url' => '/api/{apiVersion}/submissions/{formId}',
 			'verb' => 'DELETE',
 			'requirements' => [
-				'apiVersion' => 'v2'
+				'apiVersion' => 'v2(\.1)?'
 			]
 		],
 		[
@@ -266,7 +266,7 @@ return [
 			'url' => '/api/{apiVersion}/submission/insert',
 			'verb' => 'POST',
 			'requirements' => [
-				'apiVersion' => 'v2'
+				'apiVersion' => 'v2(\.1)?'
 			]
 		],
 		[
@@ -274,7 +274,7 @@ return [
 			'url' => '/api/{apiVersion}/submission/{id}',
 			'verb' => 'DELETE',
 			'requirements' => [
-				'apiVersion' => 'v2'
+				'apiVersion' => 'v2(\.1)?'
 			]
 		],
 	]

--- a/docs/API.md
+++ b/docs/API.md
@@ -27,7 +27,7 @@ This file contains the API-Documentation. For more information on the returned D
 ## Form Endpoints
 ### List owned Forms
 Returns condensed objects of all Forms beeing owned by the authenticated user.
-- Endpoint: `/api/v2/forms`
+- Endpoint: `/api/v2.1/forms`
 - Method: `GET`
 - Parameters: None
 - Response: Array of condensed Form Objects, sorted as newest first.
@@ -62,7 +62,7 @@ Returns condensed objects of all Forms beeing owned by the authenticated user.
 
 ### List shared Forms
 Returns condensed objects of all Forms, that are shared & shown to the authenticated user and that have not expired yet.
-- Endpoint: `/api/v2/shared_forms`
+- Endpoint: `/api/v2.1/shared_forms`
 - Method: `GET`
 - Parameters: None
 - Response: Array of condensed Form Objects, sorted as newest first, similar to [List owned Forms](#list-owned-forms).
@@ -72,7 +72,7 @@ See above, 'List owned forms'
 
 ### Get a partial Form
 Returns a single partial form object, corresponding to owned/shared form-listings.
-- Endpoint: `/api/v2/partial_form/{hash}`
+- Endpoint: `/api/v2.1/partial_form/{hash}`
 - Method: `GET`
 - Url-Parameter:
   | Parameter | Type    | Description |
@@ -93,7 +93,7 @@ Returns a single partial form object, corresponding to owned/shared form-listing
 ```
 
 ### Create a new Form
-- Endpoint: `/api/v2/form`
+- Endpoint: `/api/v2.1/form`
 - Method: `POST`
 - Parameters: None
 - Response: The new form object, similar to requesting an existing form.
@@ -103,7 +103,7 @@ See next section, 'Request full data of a form'
 
 ### Request full data of a form
 Returns the full-depth object of the requested form (without submissions).
-- Endpoint: `/api/v2/form/{id}`
+- Endpoint: `/api/v2.1/form/{id}`
 - Url-Parameter:
   | Parameter | Type    | Description |
   |-----------|---------|-------------|
@@ -184,7 +184,7 @@ Returns the full-depth object of the requested form (without submissions).
 
 ### Clone a form
 Creates a clone of a form (without submissions).
-- Endpoint: `/api/v2/form/clone/{id}`
+- Endpoint: `/api/v2.1/form/clone/{id}`
 - Url-Parameter:
   | Parameter | Type    | Description |
   |-----------|---------|-------------|
@@ -197,7 +197,7 @@ See section 'Request full data of a form'.
 
 ### Update form properties
 Update a single or multiple properties of a form-object. Concerns **only** the Form-Object, properties of Questions, Options and Submissions, as well as their creation or deletion, are handled separately.
-- Endpoint: `/api/v2/form/update`
+- Endpoint: `/api/v2.1/form/update`
 - Method: `POST`
 - Parameters:
   | Parameter | Type    | Description |
@@ -211,7 +211,7 @@ Update a single or multiple properties of a form-object. Concerns **only** the F
 ```
 
 ### Delete a form
-- Endpoint: `/api/v2/form/{id}`
+- Endpoint: `/api/v2.1/form/{id}`
 - Url-Parameter:
   | Parameter | Type    | Description |
   |-----------|---------|-------------|
@@ -226,7 +226,7 @@ Update a single or multiple properties of a form-object. Concerns **only** the F
 Contains only manipulative question-endpoints. To retrieve questions, request the full form data.
 
 ### Create a new question
-- Endpoint: `/api/v2/question`
+- Endpoint: `/api/v2.1/question`
 - Method: `POST`
 - Parameters:
   | Parameter | Type    | Optional | Description |
@@ -249,7 +249,7 @@ Contains only manipulative question-endpoints. To retrieve questions, request th
 
 ### Update question properties
 Update a single or multiple properties of a question-object.
-- Endpoint: `/api/v2/question/update`
+- Endpoint: `/api/v2.1/question/update`
 - Method: `POST`
 - Parameters:
   | Parameter | Type    | Description |
@@ -264,7 +264,7 @@ Update a single or multiple properties of a question-object.
 
 ### Reorder questions
 Reorders all Questions of a single form
-- Endpoint: `/api/v2/question/reorder`
+- Endpoint: `/api/v2.1/question/reorder`
 - Method: `POST`
 - Parameters:
   | Parameter | Type    | Description |
@@ -288,7 +288,7 @@ Reorders all Questions of a single form
 ```
 
 ### Delete a question
-- Endpoint: `/api/v2/question/{id}`
+- Endpoint: `/api/v2.1/question/{id}`
 - Url-Parameter:
   | Parameter | Type    | Description |
   |-----------|---------|-------------|
@@ -303,7 +303,7 @@ Reorders all Questions of a single form
 Contains only manipulative question-endpoints. To retrieve options, request the full form data.
 
 ### Create a new Option
-- Endpoint: `/api/v2/option`
+- Endpoint: `/api/v2.1/option`
 - Method: `POST`
 - Parameters:
   | Parameter | Type    | Description |
@@ -320,7 +320,7 @@ Contains only manipulative question-endpoints. To retrieve options, request the 
 ```
 
 ### Update option properties
-- Endpoint: `/api/v2/option/update`
+- Endpoint: `/api/v2.1/option/update`
 - Method: `POST`
 - Parameters:
   | Parameter | Type    | Description |
@@ -334,7 +334,7 @@ Contains only manipulative question-endpoints. To retrieve options, request the 
 ```
 
 ### Delete an option
-- Endpoint: `/api/v2/option/{id}`
+- Endpoint: `/api/v2.1/option/{id}`
 - Url-Parameter:
   | Parameter | Type    | Description |
   |-----------|---------|-------------|
@@ -347,7 +347,7 @@ Contains only manipulative question-endpoints. To retrieve options, request the 
 
 ## Sharing Endpoints
 ### Add a new Share
-- Endpoint: `/api/v2/share`
+- Endpoint: `/api/v2.1/share`
 - Method: `POST`
 - Parameters:
   | Parameter    | Type     | Description |
@@ -369,7 +369,7 @@ Contains only manipulative question-endpoints. To retrieve options, request the 
 ```
 
 ### Delete a Share
-- Endpoint: `/api/v2/share/{id}`
+- Endpoint: `/api/v2.1/share/{id}`
 - Url-Parameter:
   | Parameter | Type    | Description |
   |-----------|---------|-------------|
@@ -380,7 +380,7 @@ Contains only manipulative question-endpoints. To retrieve options, request the 
 "data": 5
 ```
 
-### Update a Share permissions
+### Update a Share
 - Endpoint: `/api/v2.1/share/update`
 - Url-Parameter:
   | Parameter        | Type     | Description |
@@ -398,7 +398,7 @@ Contains only manipulative question-endpoints. To retrieve options, request the 
 ## Submission Endpoints
 ### Get Form Submissions
 Get all Submissions to a Form
-- Endpoint: `/api/v2/submissions/{hash}`
+- Endpoint: `/api/v2.1/submissions/{hash}`
 - Url-Parameter:
   | Parameter | Type    | Description |
   |-----------|---------|-------------|
@@ -492,7 +492,7 @@ Get all Submissions to a Form
 
 ### Get Submissions as csv (Download)
 Returns all submissions to the form in form of a csv-file.
-- Endpoint: `/api/v2/submissions/export/{hash}`
+- Endpoint: `/api/v2.1/submissions/export/{hash}`
 - Url-Parameter:
   | Parameter | Type    | Description |
   |-----------|---------|-------------|
@@ -507,7 +507,7 @@ Returns all submissions to the form in form of a csv-file.
 
 ### Export Submissions to Cloud (Files-App)
 Creates a csv file and stores it to the cloud, resp. Files-App.
-- Endpoint: `/api/v2/submissions/export`
+- Endpoint: `/api/v2.1/submissions/export`
 - Method: `POST`
 - Parameters:
   | Parameter | Type    | Description |
@@ -521,7 +521,7 @@ Creates a csv file and stores it to the cloud, resp. Files-App.
 
 ### Delete Submissions
 Delete all Submissions to a form
-- Endpoint: `/api/v2/submissions/{formId}`
+- Endpoint: `/api/v2.1/submissions/{formId}`
 - Url-Parameter:
   | Parameter | Type    | Description |
   |-----------|---------|-------------|
@@ -534,7 +534,7 @@ Delete all Submissions to a form
 
 ### Insert a Submission
 Store Submission to Database
-- Endpoint: `/api/v2/submission/insert`
+- Endpoint: `/api/v2.1/submission/insert`
 - Method: `POST`
 - Parameters:
   | Parameter | Type    | Description |
@@ -556,7 +556,7 @@ Store Submission to Database
 - Response: **Status-Code OK**.
 
 ### Delete a single Submission
-- Endpoint: `/api/v2/submission/{id}`
+- Endpoint: `/api/v2.1/submission/{id}`
 - Url-Parameter:
   | Parameter | Type    | Description |
   |-----------|---------|-------------|

--- a/lib/Capabilities.php
+++ b/lib/Capabilities.php
@@ -42,7 +42,7 @@ class Capabilities implements ICapability {
 		return [
 			'forms' => [
 				'version' => $this->appManager->getAppVersion('forms'),
-				'apiVersions' => ['v2']
+				'apiVersions' => ['v2','v2.1']
 			]
 		];
 	}

--- a/src/Forms.vue
+++ b/src/Forms.vue
@@ -264,7 +264,7 @@ export default {
 
 			// Load Owned forms
 			try {
-				const response = await axios.get(generateOcsUrl('apps/forms/api/v2/forms'))
+				const response = await axios.get(generateOcsUrl('apps/forms/api/v2.1/forms'))
 				this.forms = OcsResponse2Data(response)
 			} catch (error) {
 				logger.error('Error while loading owned forms list', { error })
@@ -273,7 +273,7 @@ export default {
 
 			// Load shared forms
 			try {
-				const response = await axios.get(generateOcsUrl('apps/forms/api/v2/shared_forms'))
+				const response = await axios.get(generateOcsUrl('apps/forms/api/v2.1/shared_forms'))
 				this.sharedForms = OcsResponse2Data(response)
 			} catch (error) {
 				logger.error('Error while loading shared forms list', { error })
@@ -292,7 +292,7 @@ export default {
 			this.loading = true
 
 			try {
-				const response = await axios.get(generateOcsUrl('apps/forms/api/v2/partial_form/{hash}', { hash }))
+				const response = await axios.get(generateOcsUrl('apps/forms/api/v2.1/partial_form/{hash}', { hash }))
 				const form = OcsResponse2Data(response)
 
 				// If the user has (at least) submission-permissions, add it to the shared forms
@@ -313,7 +313,7 @@ export default {
 		async onNewForm() {
 			try {
 				// Request a new empty form
-				const response = await axios.post(generateOcsUrl('apps/forms/api/v2/form'))
+				const response = await axios.post(generateOcsUrl('apps/forms/api/v2.1/form'))
 				const newForm = OcsResponse2Data(response)
 				this.forms.unshift(newForm)
 				this.$router.push({ name: 'edit', params: { hash: newForm.hash } })
@@ -331,7 +331,7 @@ export default {
 		 */
 		async onCloneForm(id) {
 			try {
-				const response = await axios.post(generateOcsUrl('apps/forms/api/v2/form/clone/{id}', { id }))
+				const response = await axios.post(generateOcsUrl('apps/forms/api/v2.1/form/clone/{id}', { id }))
 				const newForm = OcsResponse2Data(response)
 				this.forms.unshift(newForm)
 				this.$router.push({ name: 'edit', params: { hash: newForm.hash } })

--- a/src/components/AppNavigationForm.vue
+++ b/src/components/AppNavigationForm.vue
@@ -223,7 +223,7 @@ export default {
 			// All good, let's delete
 			this.loading = true
 			try {
-				await axios.delete(generateOcsUrl('apps/forms/api/v2/form/{id}', { id: this.form.id }))
+				await axios.delete(generateOcsUrl('apps/forms/api/v2.1/form/{id}', { id: this.form.id }))
 				this.$emit('delete', this.form.id)
 			} catch (error) {
 				logger.error(`Error while deleting ${this.formTitle}`, { error: error.response })

--- a/src/components/Questions/AnswerInput.vue
+++ b/src/components/Questions/AnswerInput.vue
@@ -161,7 +161,7 @@ export default {
 		 */
 		async createAnswer(answer) {
 			try {
-				const response = await axios.post(generateOcsUrl('apps/forms/api/v2/option'), {
+				const response = await axios.post(generateOcsUrl('apps/forms/api/v2.1/option'), {
 					questionId: answer.questionId,
 					text: answer.text,
 				})
@@ -189,7 +189,7 @@ export default {
 		 */
 		async updateAnswer(answer) {
 			try {
-				await axios.post(generateOcsUrl('apps/forms/api/v2/option/update'), {
+				await axios.post(generateOcsUrl('apps/forms/api/v2.1/option/update'), {
 					id: this.answer.id,
 					keyValuePairs: {
 						text: answer.text,

--- a/src/components/Questions/QuestionDropdown.vue
+++ b/src/components/Questions/QuestionDropdown.vue
@@ -288,7 +288,7 @@ export default {
 
 			if (!option.local) {
 				// let's not await, deleting in background
-				axios.delete(generateOcsUrl('apps/forms/api/v2/option/{id}', { id: option.id }))
+				axios.delete(generateOcsUrl('apps/forms/api/v2.1/option/{id}', { id: option.id }))
 					.catch(error => {
 						logger.error('Error while deleting an option', { option, error })
 						showError(t('forms', 'There was an issue deleting this option'))

--- a/src/components/Questions/QuestionMultiple.vue
+++ b/src/components/Questions/QuestionMultiple.vue
@@ -317,7 +317,7 @@ export default {
 
 			if (!option.local) {
 				// let's not await, deleting in background
-				axios.delete(generateOcsUrl('apps/forms/api/v2/option/{id}', { id: option.id }))
+				axios.delete(generateOcsUrl('apps/forms/api/v2.1/option/{id}', { id: option.id }))
 					.catch(error => {
 						logger.error('Error while deleting an option', { error, option })
 						showError(t('forms', 'There was an issue deleting this option'))

--- a/src/components/SidebarTabs/SharingSidebarTab.vue
+++ b/src/components/SidebarTabs/SharingSidebarTab.vue
@@ -238,7 +238,7 @@ export default {
 			this.isLoading = true
 
 			try {
-				const response = await axios.post(generateOcsUrl('apps/forms/api/v2/share'), {
+				const response = await axios.post(generateOcsUrl('apps/forms/api/v2.1/share'), {
 					formId: this.form.id,
 					shareType: newShare.shareType,
 					shareWith: newShare.shareWith,
@@ -260,7 +260,7 @@ export default {
 			this.isLoading = true
 
 			try {
-				const response = await axios.post(generateOcsUrl('apps/forms/api/v2/share'), {
+				const response = await axios.post(generateOcsUrl('apps/forms/api/v2.1/share'), {
 					formId: this.form.id,
 					shareType: this.SHARE_TYPES.SHARE_TYPE_LINK,
 				})
@@ -314,7 +314,7 @@ export default {
 			this.isLoading = true
 
 			try {
-				await axios.delete(generateOcsUrl('apps/forms/api/v2/share/{id}', {
+				await axios.delete(generateOcsUrl('apps/forms/api/v2.1/share/{id}', {
 					id: share.id,
 				}))
 				this.$emit('remove-share', share)

--- a/src/mixins/QuestionMixin.js
+++ b/src/mixins/QuestionMixin.js
@@ -251,7 +251,7 @@ export default {
 		async saveQuestionProperty(key, value) {
 			try {
 				// TODO: add loading status feedback ?
-				await axios.post(generateOcsUrl('apps/forms/api/v2/question/update'), {
+				await axios.post(generateOcsUrl('apps/forms/api/v2.1/question/update'), {
 					id: this.id,
 					keyValuePairs: {
 						[key]: value,

--- a/src/mixins/ViewsMixin.js
+++ b/src/mixins/ViewsMixin.js
@@ -127,7 +127,7 @@ export default {
 			this.cancelFetchFullForm = cancel
 
 			try {
-				const response = await request(generateOcsUrl('apps/forms/api/v2/form/{id}', { id }))
+				const response = await request(generateOcsUrl('apps/forms/api/v2.1/form/{id}', { id }))
 				this.$emit('update:form', OcsResponse2Data(response))
 				this.isLoadingForm = false
 			} catch (error) {
@@ -147,7 +147,7 @@ export default {
 		async saveFormProperty(key) {
 			try {
 				// TODO: add loading status feedback ?
-				await axios.post(generateOcsUrl('apps/forms/api/v2/form/update'), {
+				await axios.post(generateOcsUrl('apps/forms/api/v2.1/form/update'), {
 					id: this.form.id,
 					keyValuePairs: {
 						[key]: this.form[key],

--- a/src/views/Create.vue
+++ b/src/views/Create.vue
@@ -323,7 +323,7 @@ export default {
 			this.isLoadingQuestions = true
 
 			try {
-				const response = await axios.post(generateOcsUrl('apps/forms/api/v2/question'), {
+				const response = await axios.post(generateOcsUrl('apps/forms/api/v2.1/question'), {
 					formId: this.form.id,
 					type,
 					text,
@@ -363,7 +363,7 @@ export default {
 			this.isLoadingQuestions = true
 
 			try {
-				await axios.delete(generateOcsUrl('apps/forms/api/v2/question/{id}', { id }))
+				await axios.delete(generateOcsUrl('apps/forms/api/v2.1/question/{id}', { id }))
 				const index = this.form.questions.findIndex(search => search.id === id)
 				this.form.questions.splice(index, 1)
 				emit('forms:last-updated:set', this.form.id)
@@ -383,7 +383,7 @@ export default {
 			const newOrder = this.form.questions.map(question => question.id)
 
 			try {
-				await axios.post(generateOcsUrl('apps/forms/api/v2/question/reorder'), {
+				await axios.post(generateOcsUrl('apps/forms/api/v2.1/question/reorder'), {
 					formId: this.form.id,
 					newOrder,
 				})

--- a/src/views/Results.vue
+++ b/src/views/Results.vue
@@ -223,7 +223,7 @@ export default {
 			logger.debug(`Loading results for form ${this.form.hash}`)
 
 			try {
-				const response = await axios.get(generateOcsUrl('apps/forms/api/v2/submissions/{hash}', { hash: this.form.hash }))
+				const response = await axios.get(generateOcsUrl('apps/forms/api/v2.1/submissions/{hash}', { hash: this.form.hash }))
 
 				let loadedSubmissions = OcsResponse2Data(response).submissions
 				const loadedQuestions = OcsResponse2Data(response).questions
@@ -242,7 +242,7 @@ export default {
 		},
 
 		async onDownloadCsv() {
-			const exportUrl = generateOcsUrl('apps/forms/api/v2/submissions/export/{hash}', { hash: this.form.hash }) + '?requesttoken=' + encodeURIComponent(getRequestToken())
+			const exportUrl = generateOcsUrl('apps/forms/api/v2.1/submissions/export/{hash}', { hash: this.form.hash }) + '?requesttoken=' + encodeURIComponent(getRequestToken())
 			window.open(exportUrl, '_self')
 		},
 
@@ -252,7 +252,7 @@ export default {
 			picker.pick()
 				.then(async (path) => {
 					try {
-						const response = await axios.post(generateOcsUrl('apps/forms/api/v2/submissions/export'), {
+						const response = await axios.post(generateOcsUrl('apps/forms/api/v2.1/submissions/export'), {
 							hash: this.form.hash,
 							path,
 						})
@@ -268,7 +268,7 @@ export default {
 			this.loadingResults = true
 
 			try {
-				await axios.delete(generateOcsUrl('apps/forms/api/v2/submission/{id}', { id }))
+				await axios.delete(generateOcsUrl('apps/forms/api/v2.1/submission/{id}', { id }))
 				const index = this.form.submissions.findIndex(search => search.id === id)
 				this.form.submissions.splice(index, 1)
 				emit('forms:last-updated:set', this.form.id)
@@ -287,7 +287,7 @@ export default {
 
 			this.loadingResults = true
 			try {
-				await axios.delete(generateOcsUrl('apps/forms/api/v2/submissions/{formId}', { formId: this.form.id }))
+				await axios.delete(generateOcsUrl('apps/forms/api/v2.1/submissions/{formId}', { formId: this.form.id }))
 				this.form.submissions = []
 				emit('forms:last-updated:set', this.form.id)
 			} catch (error) {

--- a/src/views/Submit.vue
+++ b/src/views/Submit.vue
@@ -269,7 +269,7 @@ export default {
 			this.loading = true
 
 			try {
-				await axios.post(generateOcsUrl('apps/forms/api/v2/submission/insert'), {
+				await axios.post(generateOcsUrl('apps/forms/api/v2.1/submission/insert'), {
 					formId: this.form.id,
 					answers: this.answers,
 					shareHash: this.shareHash,

--- a/tests/Integration/Api/ApiV2Test.php
+++ b/tests/Integration/Api/ApiV2Test.php
@@ -373,7 +373,7 @@ class ApiV2Test extends TestCase {
 	 * @param array $expected
 	 */
 	public function testGetForms(array $expected): void {
-		$resp = $this->http->request('GET', 'api/v2/forms');
+		$resp = $this->http->request('GET', 'api/v2.1/forms');
 
 		$data = $this->OcsResponse2Data($resp);
 		$data = $this->arrayUnsetId($data);
@@ -404,7 +404,7 @@ class ApiV2Test extends TestCase {
 	 * @param array $expected
 	 */
 	public function testGetSharedForms(array $expected): void {
-		$resp = $this->http->request('GET', 'api/v2/shared_forms');
+		$resp = $this->http->request('GET', 'api/v2.1/shared_forms');
 
 		$data = $this->OcsResponse2Data($resp);
 		$data = $this->arrayUnsetId($data);
@@ -435,7 +435,7 @@ class ApiV2Test extends TestCase {
 	 * @param array $expected
 	 */
 	public function testGetPartialForm(array $expected): void {
-		$resp = $this->http->request('GET', "api/v2/partial_form/{$this->testForms[1]['hash']}");
+		$resp = $this->http->request('GET', "api/v2.1/partial_form/{$this->testForms[1]['hash']}");
 
 		$data = $this->OcsResponse2Data($resp);
 		unset($data['id']);
@@ -477,7 +477,7 @@ class ApiV2Test extends TestCase {
 	 * @param array $expected
 	 */
 	public function testGetNewForm(array $expected): void {
-		$resp = $this->http->request('POST', 'api/v2/form');
+		$resp = $this->http->request('POST', 'api/v2.1/form');
 		$data = $this->OcsResponse2Data($resp);
 
 		// Store for deletion on tearDown
@@ -576,7 +576,7 @@ class ApiV2Test extends TestCase {
 	 * @param array $expected
 	 */
 	public function testGetFullForm(array $expected): void {
-		$resp = $this->http->request('GET', "api/v2/form/{$this->testForms[0]['id']}");
+		$resp = $this->http->request('GET', "api/v2.1/form/{$this->testForms[0]['id']}");
 		$data = $this->OcsResponse2Data($resp);
 
 		// Cannot control ids, but check general consistency.
@@ -634,7 +634,7 @@ class ApiV2Test extends TestCase {
 	 * @param array $expected
 	 */
 	public function testCloneForm(array $expected): void {
-		$resp = $this->http->request('POST', "api/v2/form/clone/{$this->testForms[0]['id']}");
+		$resp = $this->http->request('POST', "api/v2.1/form/clone/{$this->testForms[0]['id']}");
 		$data = $this->OcsResponse2Data($resp);
 
 		// Store for deletion on tearDown
@@ -694,7 +694,7 @@ class ApiV2Test extends TestCase {
 	 * @param array $expected
 	 */
 	public function testUpdateFormProperties(array $expected): void {
-		$resp = $this->http->request('POST', 'api/v2/form/update', [
+		$resp = $this->http->request('POST', 'api/v2.1/form/update', [
 			'json' => [
 				'id' => $this->testForms[0]['id'],
 				'keyValuePairs' => [
@@ -718,7 +718,7 @@ class ApiV2Test extends TestCase {
 	}
 
 	public function testDeleteForm() {
-		$resp = $this->http->request('DELETE', "api/v2/form/{$this->testForms[0]['id']}");
+		$resp = $this->http->request('DELETE', "api/v2.1/form/{$this->testForms[0]['id']}");
 		$data = $this->OcsResponse2Data($resp);
 
 		$this->assertEquals(200, $resp->getStatusCode());
@@ -726,7 +726,7 @@ class ApiV2Test extends TestCase {
 
 		// Check if not existent anymore.
 		try {
-			$this->http->request('GET', "api/v2/form/{$this->testForms[0]['id']}");
+			$this->http->request('GET', "api/v2.1/form/{$this->testForms[0]['id']}");
 		} catch (ClientException $e) {
 			$resp = $e->getResponse();
 		}
@@ -767,7 +767,7 @@ class ApiV2Test extends TestCase {
 	 * @param array $expected
 	 */
 	public function testCreateNewQuestion(array $expected): void {
-		$resp = $this->http->request('POST', 'api/v2/question', [
+		$resp = $this->http->request('POST', 'api/v2.1/question', [
 			'json' => [
 				'formId' => $this->testForms[0]['id'],
 				'type' => 'short',
@@ -807,7 +807,7 @@ class ApiV2Test extends TestCase {
 	 * @param array $fullFormExpected
 	 */
 	public function testUpdateQuestionProperties(array $fullFormExpected): void {
-		$resp = $this->http->request('POST', 'api/v2/question/update', [
+		$resp = $this->http->request('POST', 'api/v2.1/question/update', [
 			'json' => [
 				'id' => $this->testForms[0]['questions'][0]['id'],
 				'keyValuePairs' => [
@@ -849,7 +849,7 @@ class ApiV2Test extends TestCase {
 	 * @param array $fullFormExpected
 	 */
 	public function testReorderQuestions(array $fullFormExpected): void {
-		$resp = $this->http->request('POST', 'api/v2/question/reorder', [
+		$resp = $this->http->request('POST', 'api/v2.1/question/reorder', [
 			'json' => [
 				'formId' => $this->testForms[0]['id'],
 				'newOrder' => [
@@ -889,7 +889,7 @@ class ApiV2Test extends TestCase {
 	 * @param array $fullFormExpected
 	 */
 	public function testDeleteQuestion(array $fullFormExpected) {
-		$resp = $this->http->request('DELETE', "api/v2/question/{$this->testForms[0]['questions'][0]['id']}");
+		$resp = $this->http->request('DELETE', "api/v2.1/question/{$this->testForms[0]['questions'][0]['id']}");
 		$data = $this->OcsResponse2Data($resp);
 
 		$this->assertEquals(200, $resp->getStatusCode());
@@ -916,7 +916,7 @@ class ApiV2Test extends TestCase {
 	 * @param array $expected
 	 */
 	public function testCreateNewOption(array $expected): void {
-		$resp = $this->http->request('POST', 'api/v2/option', [
+		$resp = $this->http->request('POST', 'api/v2.1/option', [
 			'json' => [
 				'questionId' => $this->testForms[0]['questions'][1]['id'],
 				'text' => 'A new Option.'
@@ -952,7 +952,7 @@ class ApiV2Test extends TestCase {
 	 * @param array $fullFormExpected
 	 */
 	public function testUpdateOptionProperties(array $fullFormExpected): void {
-		$resp = $this->http->request('POST', 'api/v2/option/update', [
+		$resp = $this->http->request('POST', 'api/v2.1/option/update', [
 			'json' => [
 				'id' => $this->testForms[0]['questions'][1]['options'][0]['id'],
 				'keyValuePairs' => [
@@ -987,7 +987,7 @@ class ApiV2Test extends TestCase {
 	 * @param array $fullFormExpected
 	 */
 	public function testDeleteOption(array $fullFormExpected) {
-		$resp = $this->http->request('DELETE', "api/v2/option/{$this->testForms[0]['questions'][1]['options'][0]['id']}");
+		$resp = $this->http->request('DELETE', "api/v2.1/option/{$this->testForms[0]['questions'][1]['options'][0]['id']}");
 		$data = $this->OcsResponse2Data($resp);
 
 		$this->assertEquals(200, $resp->getStatusCode());
@@ -1017,7 +1017,7 @@ class ApiV2Test extends TestCase {
 	 * @param array $expected
 	 */
 	public function testAddShare(array $expected) {
-		$resp = $this->http->request('POST', 'api/v2/share', [
+		$resp = $this->http->request('POST', 'api/v2.1/share', [
 			'json' => [
 				'formId' => $this->testForms[0]['id'],
 				'shareType' => 0,
@@ -1087,7 +1087,7 @@ class ApiV2Test extends TestCase {
 	 * @param array $fullFormExpected
 	 */
 	public function testDeleteShare(array $fullFormExpected) {
-		$resp = $this->http->request('DELETE', "api/v2/share/{$this->testForms[0]['shares'][0]['id']}");
+		$resp = $this->http->request('DELETE', "api/v2.1/share/{$this->testForms[0]['shares'][0]['id']}");
 		$data = $this->OcsResponse2Data($resp);
 
 		$this->assertEquals(200, $resp->getStatusCode());
@@ -1164,7 +1164,7 @@ class ApiV2Test extends TestCase {
 	 * @param array $expected
 	 */
 	public function testGetSubmissions(array $expected) {
-		$resp = $this->http->request('GET', "api/v2/submissions/{$this->testForms[0]['hash']}");
+		$resp = $this->http->request('GET', "api/v2.1/submissions/{$this->testForms[0]['hash']}");
 		$data = $this->OcsResponse2Data($resp);
 
 		// Cannot control ids, but check general consistency.
@@ -1216,7 +1216,7 @@ class ApiV2Test extends TestCase {
 	 * @param array $expected
 	 */
 	public function testExportSubmissions(string $expected) {
-		$resp = $this->http->request('GET', "api/v2/submissions/export/{$this->testForms[0]['hash']}");
+		$resp = $this->http->request('GET', "api/v2.1/submissions/export/{$this->testForms[0]['hash']}");
 		$data = substr($resp->getBody()->getContents(), 3); // Some strange Character removed at the beginning
 
 		$this->assertEquals(200, $resp->getStatusCode());
@@ -1228,7 +1228,7 @@ class ApiV2Test extends TestCase {
 	}
 
 	public function testExportToCloud() {
-		$resp = $this->http->request('POST', 'api/v2/submissions/export', [
+		$resp = $this->http->request('POST', 'api/v2.1/submissions/export', [
 			'json' => [
 				'hash' => $this->testForms[0]['hash'],
 				'path' => ''
@@ -1256,7 +1256,7 @@ class ApiV2Test extends TestCase {
 	 * @param array $submissionsExpected
 	 */
 	public function testDeleteSubmissions(array $submissionsExpected) {
-		$resp = $this->http->request('DELETE', "api/v2/submissions/{$this->testForms[0]['id']}");
+		$resp = $this->http->request('DELETE', "api/v2.1/submissions/{$this->testForms[0]['id']}");
 		$data = $this->OcsResponse2Data($resp);
 
 		$this->assertEquals(200, $resp->getStatusCode());
@@ -1283,7 +1283,7 @@ class ApiV2Test extends TestCase {
 	 * @param array $submissionsExpected
 	 */
 	public function testInsertSubmission(array $submissionsExpected) {
-		$resp = $this->http->request('POST', 'api/v2/submission/insert', [
+		$resp = $this->http->request('POST', 'api/v2.1/submission/insert', [
 			'json' => [
 				'formId' => $this->testForms[0]['id'],
 				'answers' => [
@@ -1299,7 +1299,7 @@ class ApiV2Test extends TestCase {
 		$this->assertEquals(200, $resp->getStatusCode());
 
 		// Check stored submissions
-		$resp = $this->http->request('GET', "api/v2/submissions/{$this->testForms[0]['hash']}");
+		$resp = $this->http->request('GET', "api/v2.1/submissions/{$this->testForms[0]['hash']}");
 		$data = $this->OcsResponse2Data($resp);
 
 		// Store for deletion
@@ -1349,7 +1349,7 @@ class ApiV2Test extends TestCase {
 	 * @param array $submissionsExpected
 	 */
 	public function testDeleteSingleSubmission(array $submissionsExpected) {
-		$resp = $this->http->request('DELETE', "api/v2/submission/{$this->testForms[0]['submissions'][0]['id']}");
+		$resp = $this->http->request('DELETE', "api/v2.1/submission/{$this->testForms[0]['submissions'][0]['id']}");
 		$data = $this->OcsResponse2Data($resp);
 
 		$this->assertEquals(200, $resp->getStatusCode());


### PR DESCRIPTION
This fixes #1538 by moving all endpoints to v2.1 and allowing v2 for old endpoints