### PR TITLE
Fix paragraph rendering

### DIFF
--- a/src/components/Questions/Question.vue
+++ b/src/components/Questions/Question.vue
@@ -83,7 +83,7 @@
 					class="question__header__description__input"
 					@update:value="onDescriptionChange" />
 				<!-- eslint-disable-next-line vue/no-v-html -->
-				<p v-else class="question__header__description__output" v-html="computedDescription" />
+				<div v-else class="question__header__description__output" v-html="computedDescription" />
 			</div>
 		</div>
 
@@ -184,7 +184,7 @@ export default {
 		},
 
 		computedDescription() {
-			return this.$markdownit.renderInline(this.description)
+			return this.$markdownit.render(this.description)
 		},
 
 		/**
@@ -247,6 +247,8 @@ export default {
 </script>
 
 <style lang="scss" scoped>
+@import '../../scssmixins/markdownOutput';
+
 .question {
 	position: relative;
 	display: flex;
@@ -342,7 +344,7 @@ export default {
 
 			&__input {
 				margin: 0px;
-				min-height: 1.3em;
+				min-height: 1.5em;
 				border-width: 2px;
 				position: relative;
 				left: -12px;
@@ -353,13 +355,14 @@ export default {
 			&__output {
 				font-size: 14px;
 				color: var(--color-text-maxcontrast) !important;
-				line-height: 1.3em;
+				line-height: 1.5em;
 				z-index: inherit;
 				overflow-wrap: break-word;
 				width: calc(100% - 32px); // match with other inputs
 			}
 			&__output {
 				padding: 6px 0; //compensate border
+				@include markdown-output; // Styling for rendered Output
 			}
 		}
 	}

--- a/src/scssmixins/markdownOutput.scss
+++ b/src/scssmixins/markdownOutput.scss
@@ -1,0 +1,29 @@
+/**
+ * @copyright Copyright (c) 2023 Jonas Rittershofer <jotoeri@users.noreply.github.com>
+ *
+ * @author Jonas Rittershofer <jotoeri@users.noreply.github.com>
+ *
+ * @license AGPL-3.0-or-later
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+@mixin markdown-output {
+	::v-deep {
+		p:not(:first-child) {
+			margin-top: 1.5em;
+		}
+	}
+}

--- a/src/views/Create.vue
+++ b/src/views/Create.vue
@@ -55,7 +55,9 @@
 					@input="onTitleChange" />
 			</h2>
 			<template v-if="edit">
-				<label class="hidden-visually" for="form-desc">{{ t('forms', 'Description') }}</label>
+				<label class="hidden-visually" for="form-desc">
+					{{ t('forms', 'Description') }}
+				</label>
 				<NcRichContenteditable id="form-desc"
 					class="form-desc form-desc__input"
 					:value="form.description"
@@ -65,7 +67,7 @@
 					@update:value="updateDescription" />
 			</template>
 			<!-- eslint-disable-next-line vue/no-v-html -->
-			<div v-else class="form-desc" v-html="formDescription" />
+			<div v-else class="form-desc form-desc__output" v-html="formDescription" />
 			<!-- Show expiration message-->
 			<p v-if="form.expires && form.showExpiration" class="info-message">
 				{{ expirationMessage }}
@@ -428,6 +430,8 @@ export default {
 </script>
 
 <style lang="scss" scoped>
+@import '../scssmixins/markdownOutput';
+
 .app-content {
 	display: flex;
 	align-items: center;
@@ -481,6 +485,11 @@ export default {
 
 			&__input {
 				padding: 3px 14px 18px; // 2px smaller because of border
+			}
+
+			// Styling for rendered Output
+			&__output {
+				@include markdown-output;
 			}
 		}
 

--- a/src/views/Submit.vue
+++ b/src/views/Submit.vue
@@ -297,6 +297,8 @@ export default {
 }
 </script>
 <style lang="scss" scoped>
+@import '../scssmixins/markdownOutput';
+
 .app-content {
 	display: flex;
 	align-items: center;
@@ -345,6 +347,8 @@ export default {
 			resize: none;
 			min-height: calc(20px + 1.5em); // one line
 			color: var(--color-text-maxcontrast);
+
+			@include markdown-output;
 		}
 
 		.info-message {


### PR DESCRIPTION
`render` converts multi-linebreaks to paragraphs, `renderInline` just keeps them as multiple breaks.

Fixes #1537 