### PR TITLE
[stable2] Drop stable22 & stable23 tests

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -83,7 +83,7 @@ jobs:
       matrix:
         php-versions: ['7.4']
         databases: ['mysql']
-        server-versions: ['stable22', 'stable23', 'stable24']
+        server-versions: ['stable24']
   
     name: php${{ matrix.php-versions }}-${{ matrix.databases }}-${{ matrix.server-versions }}
 


### PR DESCRIPTION
Dropped minversion 22 during release, since it's far out of support.