### PR TITLE
Add note about Markdown formatting within description placeholder

### DIFF
--- a/src/components/Questions/Question.vue
+++ b/src/components/Questions/Question.vue
@@ -78,7 +78,7 @@
 				<NcRichContenteditable v-if="edit || !questionValid"
 					:multiline="true"
 					:value="description"
-					:placeholder="t('forms', 'Description')"
+					:placeholder="t('forms', 'Description (formatting using Markdown is supported)')"
 					:maxlength="maxStringLengths.questionDescription"
 					class="question__header__description__input"
 					@update:value="onDescriptionChange" />

--- a/src/views/Create.vue
+++ b/src/views/Create.vue
@@ -62,7 +62,7 @@
 					class="form-desc form-desc__input"
 					:value="form.description"
 					:multiline="true"
-					:placeholder="t('forms', 'Description')"
+					:placeholder="t('forms', 'Description (formatting using Markdown is supported)')"
 					:maxlength="maxStringLengths.formDescription"
 					@update:value="updateDescription" />
 			</template>


### PR DESCRIPTION
Let users know that they can use Markdown for formatting, looks like this:

![Form description placeholder shows: Description formatting using Markdown is supported](https://user-images.githubusercontent.com/1855448/224841327-63263f8e-2e01-43f7-b51f-3a27b55619d3.png)
