### PR TITLE
fix(markdown): Add margin for all new paragraphs

### DIFF
--- a/src/scssmixins/markdownOutput.scss
+++ b/src/scssmixins/markdownOutput.scss
@@ -22,7 +22,7 @@
 
 @mixin markdown-output {
 	::v-deep {
-		p:not(:first-child) {
+		>:not(:first-child) {
 			margin-top: 1.5em;
 		}
 	}


### PR DESCRIPTION
* Resolved: #1566

### Summary

Before this only `<p>` elements had some top margin applied, but blocks like code blocks (`pre`) would not have any margin and were rendered like if they belong to the previous paragraph.

### Screenshots

before | after
---|---
![no margin between paragraphs](https://user-images.githubusercontent.com/1855448/225965437-12865aff-f2a7-48a2-b78e-70c76c157330.png) | ![margin between all block elements](https://user-images.githubusercontent.com/1855448/225965493-f15ea84c-915f-4e1f-a636-e3c781e1ebbb.png)

Markdown code:
````markdown
Text


Text with\
hard break


Text with\
\
\
empty lines


```
code
```
````