### PR TITLE
fix: Replace `NcRichContenteditable` with `textarea`

### DIFF
--- a/css/forms.css
+++ b/css/forms.css
@@ -27,6 +27,15 @@ html {
 	scroll-padding-top: calc(var(--header-height) + 60px);
 }
 
+/* Fix for placeholder styling
+ * TODO: Can be removed, as soon as it is fixed in server
+ * Ref.: https://github.com/nextcloud/server/pull/37522
+ */
+::placeholder {
+	color: var(--color-text-maxcontrast);
+	font-size: var(--default-font-size);
+}
+
 /* Fix for action-popover alignment
  * TODO: Can be removed, as soon as the issue is solved in server or vue-components.
  * Ref.: https://github.com/nextcloud/nextcloud-vue/issues/1384

--- a/src/components/Questions/Question.vue
+++ b/src/components/Questions/Question.vue
@@ -231,8 +231,12 @@ export default {
 		resizeDescription() {
 			// next tick ensures that the textarea is attached to DOM
 			this.$nextTick(() => {
-				const rows = this.$refs.description.value.split('\n').length
-				this.$refs.description.setAttribute('rows', rows)
+				const textarea = this.$refs.description
+				if (textarea) {
+					textarea.style.cssText = 'height: 0'
+					// include 2px border
+					textarea.style.cssText = `height: ${textarea.scrollHeight + 4}px`
+				}
 			})
 		},
 

--- a/src/components/Questions/Question.vue
+++ b/src/components/Questions/Question.vue
@@ -210,7 +210,10 @@ export default {
 			}
 		},
 	},
-
+	// Ensure description is sized correctly on initial render
+	mounted() {
+		this.$nextTick(() => this.resizeDescription())
+	},
 	methods: {
 		onTitleChange({ target }) {
 			this.$emit('update:text', target.value)

--- a/src/components/Questions/Question.vue
+++ b/src/components/Questions/Question.vue
@@ -76,13 +76,13 @@
 				</NcActions>
 			</div>
 			<div v-if="hasDescription || edit || !questionValid" class="question__header__description">
-				<NcRichContenteditable v-if="edit || !questionValid"
-					:multiline="true"
+				<textarea v-if="edit || !questionValid"
+					ref="description"
 					:value="description"
 					:placeholder="t('forms', 'Description (formatting using Markdown is supported)')"
 					:maxlength="maxStringLengths.questionDescription"
 					class="question__header__description__input"
-					@update:value="onDescriptionChange" />
+					@input="onDescriptionChange" />
 				<!-- eslint-disable-next-line vue/no-v-html -->
 				<div v-else class="question__header__description__output" v-html="computedDescription" />
 			</div>
@@ -99,7 +99,6 @@ import { directive as ClickOutside } from 'v-click-outside'
 import NcActions from '@nextcloud/vue/dist/Components/NcActions.js'
 import NcActionButton from '@nextcloud/vue/dist/Components/NcActionButton.js'
 import NcActionCheckbox from '@nextcloud/vue/dist/Components/NcActionCheckbox.js'
-import NcRichContenteditable from '@nextcloud/vue/dist/Components/NcRichContenteditable.js'
 
 import IconAlertCircleOutline from 'vue-material-design-icons/AlertCircleOutline.vue'
 import IconDelete from 'vue-material-design-icons/Delete.vue'
@@ -119,7 +118,6 @@ export default {
 		NcActions,
 		NcActionButton,
 		NcActionCheckbox,
-		NcRichContenteditable,
 	},
 
 	inject: ['$markdownit'],
@@ -205,18 +203,34 @@ export default {
 			return this.description !== ''
 		},
 	},
+	watch: {
+		edit(newEdit) {
+			if (newEdit || !this.questionValid) {
+				this.resizeDescription()
+			}
+		},
+	},
 
 	methods: {
 		onTitleChange({ target }) {
 			this.$emit('update:text', target.value)
 		},
 
-		onDescriptionChange(value) {
-			this.$emit('update:description', value)
+		onDescriptionChange({ target }) {
+			this.resizeDescription()
+			this.$emit('update:description', target.value)
 		},
 
 		onRequiredChange(isRequired) {
 			this.$emit('update:isRequired', isRequired)
+		},
+
+		resizeDescription() {
+			// next tick ensures that the textarea is attached to DOM
+			this.$nextTick(() => {
+				const rows = this.$refs.description.value.split('\n').length
+				this.$refs.description.setAttribute('rows', rows)
+			})
 		},
 
 		/**
@@ -350,6 +364,7 @@ export default {
 				position: relative;
 				left: -12px;
 				padding: 4px 10px;
+				resize: none;
 			}
 
 			&__input,

--- a/src/scssmixins/markdownOutput.scss
+++ b/src/scssmixins/markdownOutput.scss
@@ -21,6 +21,8 @@
  */
 
 @mixin markdown-output {
+	overflow-wrap: break-word;
+
 	::v-deep {
 		>:not(:first-child) {
 			margin-top: 1.5em;

--- a/src/views/Create.vue
+++ b/src/views/Create.vue
@@ -281,12 +281,14 @@ export default {
 			// Keep edit if no title set
 			if (this.form.title) {
 				this.edit = false
+				this.$refs.title.style.height = 'auto'
 			}
 		},
 
 		enableEdit() {
 			this.edit = true
 			this.resizeDescription()
+			this.resizeTitle()
 		},
 
 		initEdit() {
@@ -497,7 +499,7 @@ export default {
 		.form-desc {
 			color: var(--color-text-maxcontrast);
 			line-height: 1.5em;
-			min-height: calc(25px + 1.5em); // one line
+			min-height: 48px; // one line (25px padding + 1.5em text height), CSS calc will round incorrectly to hardcoded
 			padding-top: 5px; // spacing border<>text
 			margin: 0px;
 

--- a/src/views/Create.vue
+++ b/src/views/Create.vue
@@ -305,7 +305,7 @@ export default {
 		resizeTitle() {
 			this.$nextTick(() => {
 				const textarea = this.$refs.title
-				textarea.style.cssText = 'height:auto'
+				textarea.style.cssText = 'height: 0'
 				// include 2px border
 				textarea.style.cssText = `height: ${textarea.scrollHeight + 4}px`
 			})
@@ -318,7 +318,7 @@ export default {
 			// nextTick to ensure textarea is attached to DOM
 			this.$nextTick(() => {
 				const textarea = this.$refs.description
-				textarea.style.cssText = 'height:auto'
+				textarea.style.cssText = 'height: 0'
 				// include 2px border
 				textarea.style.cssText = `height: ${textarea.scrollHeight + 4}px`
 			})

--- a/src/views/Create.vue
+++ b/src/views/Create.vue
@@ -470,8 +470,9 @@ export default {
 			line-height: 34px;
 			color: var(--color-main-text);
 			min-height: 36px;
-			padding: 0 14px; // same as submit but 2px borders
-			margin: 30px 0 14px; // same as on submit but minus padding-top description and borders
+			// padding and margin should be aligned with the submit view (but keep the 2px border in mind)
+			padding: 4px 14px;
+			margin: 22px 0 14px;
 			width: calc(100% - 56px); // margin of header, needed if screen is < 806px (max-width + margin-left)
 			overflow: hidden;
 			text-overflow: ellipsis;
@@ -479,6 +480,9 @@ export default {
 
 			&:read-only {
 				border-color: transparent;
+			}
+			&::placeholder {
+				font-size: 28px;
 			}
 		}
 

--- a/src/views/Create.vue
+++ b/src/views/Create.vue
@@ -498,8 +498,8 @@ export default {
 
 		.form-desc {
 			color: var(--color-text-maxcontrast);
-			line-height: 1.5em;
-			min-height: 48px; // one line (25px padding + 1.5em text height), CSS calc will round incorrectly to hardcoded
+			line-height: 22px;
+			min-height: 47px; // one line (25px padding + 22px text height)
 			padding-top: 5px; // spacing border<>text
 			margin: 0px;
 

--- a/src/views/Submit.vue
+++ b/src/views/Submit.vue
@@ -342,10 +342,10 @@ export default {
 			text-overflow: ellipsis;
 		}
 		.form-desc {
-			line-height: 1.5em;
+			line-height: 22px;
 			padding-bottom: 20px;
 			resize: none;
-			min-height: calc(20px + 1.5em); // one line
+			min-height: 42px;
 			color: var(--color-text-maxcontrast);
 
 			@include markdown-output;


### PR DESCRIPTION
* Resolves: #1562 
* Resolves: #1563
* Resolves: #1564 

Those issues are basically bugs of the `NcRichContenteditable` component.
So the simplest fix is just using a textarea as before, downside: No fancy emoji input (but I think we can cope with that).