### PR TITLE
Improve and unify Markdown output style

### DIFF
--- a/src/scssmixins/markdownOutput.scss
+++ b/src/scssmixins/markdownOutput.scss
@@ -25,5 +25,45 @@
 		>:not(:first-child) {
 			margin-top: 1.5em;
 		}
+
+		blockquote {
+			padding-left: 1em;
+			border-left: 4px solid var(--color-primary-element);
+			color: var(--color-text-maxcontrast);
+		}
+
+		pre {
+			white-space: pre-wrap;
+			background-color: var(--color-background-dark);
+			border-radius: var(--border-radius);
+			padding: 1em 1.3em;
+		}
+
+		p code {
+			background-color: var(--color-background-dark);
+			border-radius: var(--border-radius);
+			padding: .1em .3em;
+		}
+
+		ul, ol {
+			padding-left: 10px;
+			margin-left: 10px;
+		}
+
+		ul {
+			> li {
+				list-style-type: disc;
+			}
+
+			// Second-level list entries
+			li ul > li {
+				list-style-type: circle;
+			}
+
+			// Third+-level list entries
+			li li ul > li {
+				list-style-type: square;
+			}
+		}
 	}
 }


### PR DESCRIPTION
Improve the output style the get a consistent styling across apps (e.g. this style is used by `text` and `collectives`.
* Add background to code (blocks)
* Add list styles
* Add block quote backgrounds (requires #1574 because otherwise you can not create block quotes (`> ...`)).

before | after
---|---
![No indention, no styling](https://user-images.githubusercontent.com/1855448/226419903-8767077a-e76d-475d-af50-b5e9e1e2b3bf.png) | ![basic styling](https://user-images.githubusercontent.com/1855448/226419925-7424c503-5235-44ae-96fe-b80b80be516e.png)
