### PR TITLE
Replace deprecated code and fix issues found by static code analysis

### DIFF
--- a/.github/workflows/psalm.yml
+++ b/.github/workflows/psalm.yml
@@ -1,0 +1,39 @@
+# This workflow is provided via the organization template repository
+#
+# https://github.com/nextcloud/.github
+# https://docs.github.com/en/actions/learn-github-actions/sharing-workflows-with-your-organization
+
+name: Static analysis
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: psalm-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  static-analysis:
+    runs-on: ubuntu-latest
+
+    name: Nextcloud
+    steps:
+      - name: Checkout
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3
+
+      - name: Set up php
+        uses: shivammathur/setup-php@1a18b2267f80291a81ca1d33e7c851fe09e7dfc4 # v2
+        with:
+          php-version: 8.1
+          coverage: none
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install dependencies
+        run: composer i
+
+      - name: Run coding standards check
+        run: composer run psalm

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ You run several tests by:
 - `composer cs:check` for the Nextcloud php coding standard
 - `composer lint` for php linting
 - `composer test:unit` and `composer test:integration` to run the php functionality tests
+- `composer psalm` for static code analysis
 
 
 ## ♥ How to create a pull request

--- a/composer.json
+++ b/composer.json
@@ -16,13 +16,15 @@
 		"cs:check": "php-cs-fixer fix --dry-run --diff",
 		"lint": "find . -name \\*.php -not -path './vendor*/*' -print0 | xargs -0 -n1 php -l",
 		"test:unit": "phpunit -c tests/phpunit.xml",
-		"test:integration": "phpunit -c tests/phpunit.integration.xml"
+		"test:integration": "phpunit -c tests/phpunit.integration.xml",
+		"psalm": "psalm.phar"
 	},
 	"require-dev": {
 		"bamarni/composer-bin-plugin": "^1.5",
+		"guzzlehttp/guzzle": "^7.4",
 		"nextcloud/ocp": "^25.0.4",
 		"phpunit/phpunit": "^9",
-		"guzzlehttp/guzzle": "^7.4"
+		"psalm/phar": "^5.8"
 	},
 	"require": {
 		"league/csv": "^9.8.0"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "16eb0d3fc3f2e5293da55cba45f8b9c0",
+    "content-hash": "9ec06bd6b5594642a5f940f7e07ff85e",
     "packages": [
         {
             "name": "league/csv",
@@ -433,16 +433,16 @@
         },
         {
             "name": "guzzlehttp/psr7",
-            "version": "2.4.1",
+            "version": "2.4.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/psr7.git",
-                "reference": "69568e4293f4fa993f3b0e51c9723e1e17c41379"
+                "reference": "3cf1b6d4f0c820a2cf8bcaec39fc698f3443b5cf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/psr7/zipball/69568e4293f4fa993f3b0e51c9723e1e17c41379",
-                "reference": "69568e4293f4fa993f3b0e51c9723e1e17c41379",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/3cf1b6d4f0c820a2cf8bcaec39fc698f3443b5cf",
+                "reference": "3cf1b6d4f0c820a2cf8bcaec39fc698f3443b5cf",
                 "shasum": ""
             },
             "require": {
@@ -532,7 +532,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/psr7/issues",
-                "source": "https://github.com/guzzle/psr7/tree/2.4.1"
+                "source": "https://github.com/guzzle/psr7/tree/2.4.4"
             },
             "funding": [
                 {
@@ -548,7 +548,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-08-28T14:45:39+00:00"
+            "time": "2023-03-09T13:19:02+00:00"
         },
         {
             "name": "myclabs/deep-copy",
@@ -1239,6 +1239,41 @@
                 }
             ],
             "time": "2023-03-27T11:43:46+00:00"
+        },
+        {
+            "name": "psalm/phar",
+            "version": "5.8.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/psalm/phar.git",
+                "reference": "6473ecb1ea109a96e69c98b93310eace0d583cc7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/psalm/phar/zipball/6473ecb1ea109a96e69c98b93310eace0d583cc7",
+                "reference": "6473ecb1ea109a96e69c98b93310eace0d583cc7",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1 || ^8.0"
+            },
+            "conflict": {
+                "vimeo/psalm": "*"
+            },
+            "bin": [
+                "psalm.phar"
+            ],
+            "type": "library",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Composer-based Psalm Phar",
+            "support": {
+                "issues": "https://github.com/psalm/phar/issues",
+                "source": "https://github.com/psalm/phar/tree/5.8.0"
+            },
+            "time": "2023-03-10T03:53:59+00:00"
         },
         {
             "name": "psr/container",

--- a/lib/BackgroundJob/UserDeletedJob.php
+++ b/lib/BackgroundJob/UserDeletedJob.php
@@ -46,6 +46,9 @@ class UserDeletedJob extends QueuedJob {
 		$this->logger = $logger;
 	}
 
+	/**
+	 * @param array $argument
+	 */
 	public function run($argument): void {
 		$ownerId = $argument['owner_id'];
 		$this->logger->info('Deleting forms for deleted user {user}', [

--- a/lib/BackgroundJob/UserDeletedJob.php
+++ b/lib/BackgroundJob/UserDeletedJob.php
@@ -46,8 +46,8 @@ class UserDeletedJob extends QueuedJob {
 		$this->logger = $logger;
 	}
 
-	public function run($arguments) {
-		$ownerId = $arguments['owner_id'];
+	public function run($argument): void {
+		$ownerId = $argument['owner_id'];
 		$this->logger->info('Deleting forms for deleted user {user}', [
 			'user' => $ownerId
 		]);

--- a/lib/Controller/ApiController.php
+++ b/lib/Controller/ApiController.php
@@ -986,7 +986,7 @@ class ApiController extends OCSController {
 
 		// If not logged in or anonymous use anonID
 		if (!$this->currentUser || $form->getIsAnonymous()) {
-			$anonID = "anon-user-".  hash('md5', (time() + rand()));
+			$anonID = "anon-user-".  hash('md5', strval(time() + rand()));
 			$submission->setUserId($anonID);
 		} else {
 			$submission->setUserId($this->currentUser->getUID());

--- a/lib/Controller/ApiController.php
+++ b/lib/Controller/ApiController.php
@@ -517,7 +517,7 @@ class ApiController extends OCSController {
 	 * Updates the Order of all Questions of a Form.
 	 *
 	 * @param int $formId Id of the form to reorder
-	 * @param int[] $newOrder Array of Question-Ids in new order.
+	 * @param Array<int, int> $newOrder Array of Question-Ids in new order.
 	 * @return DataResponse
 	 * @throws OCSBadRequestException
 	 * @throws OCSForbiddenException

--- a/lib/Controller/ShareApiController.php
+++ b/lib/Controller/ShareApiController.php
@@ -207,6 +207,7 @@ class ShareApiController extends OCSController {
 		$share->setShareWith($shareWith);
 		$share->setPermissions($permissions);
 
+		/** @var Share */
 		$share = $this->shareMapper->insert($share);
 
 		// Create share-notifications (activity)

--- a/lib/Controller/ShareApiController.php
+++ b/lib/Controller/ShareApiController.php
@@ -316,7 +316,7 @@ class ShareApiController extends OCSController {
 	 * Validate user given permission array
 	 *
 	 * @param array $permissions User given permissions
-	 * @return array Sanitized array of permissions
+	 * @return bool True if permissions are valid, False otherwise
 	 * @throws OCSBadRequestException If invalid permission was given
 	 */
 	protected function validatePermissions(array $permissions, int $shareType): bool {

--- a/lib/Db/AnswerMapper.php
+++ b/lib/Db/AnswerMapper.php
@@ -29,6 +29,9 @@ use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\IDBConnection;
 use OCP\AppFramework\Db\QBMapper;
 
+/**
+ * @extends QBMapper<Answer>
+ */
 class AnswerMapper extends QBMapper {
 
 	/**

--- a/lib/Db/FormMapper.php
+++ b/lib/Db/FormMapper.php
@@ -30,6 +30,9 @@ use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\IDBConnection;
 use OCP\AppFramework\Db\QBMapper;
 
+/**
+ * @extends QBMapper<Form>
+ */
 class FormMapper extends QBMapper {
 	/** @var QuestionMapper */
 	private $questionMapper;

--- a/lib/Db/FormMapper.php
+++ b/lib/Db/FormMapper.php
@@ -56,7 +56,7 @@ class FormMapper extends QBMapper {
 	}
 
 	/**
-	 * @param Integer $id
+	 * @param int $id
 	 * @return Form
 	 * @throws \OCP\AppFramework\Db\MultipleObjectsReturnedException if more than one result
 	 * @throws \OCP\AppFramework\Db\DoesNotExistException if not found
@@ -74,7 +74,7 @@ class FormMapper extends QBMapper {
 	}
 
 	/**
-	 * @param String $hash
+	 * @param string $hash
 	 * @return Form
 	 * @throws \OCP\AppFramework\Db\MultipleObjectsReturnedException if more than one result
 	 * @throws \OCP\AppFramework\Db\DoesNotExistException if not found

--- a/lib/Db/OptionMapper.php
+++ b/lib/Db/OptionMapper.php
@@ -68,7 +68,7 @@ class OptionMapper extends QBMapper {
 				$qb->expr()->eq('question_id', $qb->createNamedParameter($questionId))
 		);
 
-		$qb->execute();
+		$qb->executeStatement();
 	}
 
 	public function findById(int $optionId): Option {

--- a/lib/Db/OptionMapper.php
+++ b/lib/Db/OptionMapper.php
@@ -31,6 +31,9 @@ use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\AppFramework\Db\QBMapper;
 use OCP\IDBConnection;
 
+/**
+ * @extends QBMapper<Option>
+ */
 class OptionMapper extends QBMapper {
 
 	/**

--- a/lib/Db/Question.php
+++ b/lib/Db/Question.php
@@ -40,6 +40,8 @@ use OCP\AppFramework\Db\Entity;
  * @method void setOrder(integer $value)
  * @method string getType()
  * @method void setType(string $value)
+ * @method bool getIsRequired()
+ * @method void setIsRequired(bool $value)
  * @method string getText()
  * @method void setText(string $value)
  * @method string getDescription()

--- a/lib/Db/QuestionMapper.php
+++ b/lib/Db/QuestionMapper.php
@@ -31,6 +31,9 @@ use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\IDBConnection;
 use OCP\AppFramework\Db\DoesNotExistException;
 
+/**
+ * @extends QBMapper<Question>
+ */
 class QuestionMapper extends QBMapper {
 	private $optionMapper;
 

--- a/lib/Db/ShareMapper.php
+++ b/lib/Db/ShareMapper.php
@@ -33,6 +33,9 @@ use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\IDBConnection;
 use OCP\Share\IShare;
 
+/**
+ * @extends QBMapper<Share>
+ */
 class ShareMapper extends QBMapper {
 	/**
 	 * ShareMapper constructor.

--- a/lib/Db/SubmissionMapper.php
+++ b/lib/Db/SubmissionMapper.php
@@ -65,7 +65,7 @@ class SubmissionMapper extends QBMapper {
 	}
 
 	/**
-	 * @param Integer $id
+	 * @param int $id
 	 * @return Submission
 	 * @throws \OCP\AppFramework\Db\MultipleObjectsReturnedException if more than one result
 	 * @throws \OCP\AppFramework\Db\DoesNotExistException if not found
@@ -107,7 +107,7 @@ class SubmissionMapper extends QBMapper {
 	}
 
 	/**
-	 * @throws DBException
+	 * @throws \Exception
 	 */
 	public function countSubmissions(int $formId): int {
 		$qb = $this->db->getQueryBuilder();
@@ -140,7 +140,7 @@ class SubmissionMapper extends QBMapper {
 			$qb->expr()->eq('id', $qb->createNamedParameter($id, IQueryBuilder::PARAM_INT))
 		);
 
-		$qb->execute();
+		$qb->executeStatement();
 	}
 
 	/**
@@ -162,6 +162,6 @@ class SubmissionMapper extends QBMapper {
 			$qb->expr()->eq('form_id', $qb->createNamedParameter($formId, IQueryBuilder::PARAM_INT))
 		);
 
-		$qb->execute();
+		$qb->executeStatement();
 	}
 }

--- a/lib/Db/SubmissionMapper.php
+++ b/lib/Db/SubmissionMapper.php
@@ -31,6 +31,9 @@ use OCP\AppFramework\Db\QBMapper;
 use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\IDBConnection;
 
+/**
+ * @extends QBMapper<Submission>
+ */
 class SubmissionMapper extends QBMapper {
 	private $answerMapper;
 

--- a/lib/Listener/UserDeletedListener.php
+++ b/lib/Listener/UserDeletedListener.php
@@ -31,6 +31,9 @@ use OCP\User\Events\UserDeletedEvent;
 
 use Psr\Log\LoggerInterface;
 
+/**
+ * @implements IEventListener<UserDeletedEvent>
+ */
 class UserDeletedListener implements IEventListener {
 
 	/** @var IJobList */

--- a/lib/Service/SubmissionService.php
+++ b/lib/Service/SubmissionService.php
@@ -71,9 +71,6 @@ class SubmissionService {
 	/** @var IConfig */
 	private $config;
 
-	/** @var IDateTimeFormatter */
-	private $dateTimeFormatter;
-
 	/** @var IL10N */
 	private $l10n;
 
@@ -159,6 +156,7 @@ class SubmissionService {
 	 * @throws NotPermittedException
 	 */
 	public function writeCsvToCloud(string $hash, string $path): string {
+		/** @var \OCP\Files\Folder|\OCP\Files\File $node */
 		$node = $this->storage->getUserFolder($this->currentUser->getUID())->get($path);
 
 		// Get Data
@@ -169,14 +167,17 @@ class SubmissionService {
 			if ($node->getExtension() === 'csv') {
 				$csvData['fileName'] = $node->getName();
 			}
+			/** @var \OCP\Files\Folder $node */
 			$node = $node->getParent();
 		}
 
 		// check if file exists, create otherwise.
 		try {
+			/** @var \OCP\Files\File $file */
 			$file = $node->get($csvData['fileName']);
 		} catch (\OCP\Files\NotFoundException $e) {
 			$node->newFile($csvData['fileName']);
+			/** @var \OCP\Files\File $file */
 			$file = $node->get($csvData['fileName']);
 		}
 

--- a/lib/Settings/Settings.php
+++ b/lib/Settings/Settings.php
@@ -27,8 +27,8 @@ namespace OCA\Forms\Settings;
 
 use OCA\Forms\Service\ConfigService;
 use OCP\AppFramework\Http\TemplateResponse;
+use OCP\AppFramework\Services\IInitialState;
 use OCP\IGroupManager;
-use OCP\IInitialStateService;
 use OCP\Settings\ISettings;
 use OCP\Util;
 
@@ -41,17 +41,17 @@ class Settings implements ISettings {
 	/** @var IGroupManager */
 	private $groupManager;
 
-	/** @var IInitialStateService */
-	private $initialStateService;
+	/** @var IInitialState */
+	private $initialState;
 
 	public function __construct(string $appName,
 								ConfigService $configService,
 								IGroupManager $groupManager,
-								IInitialStateService $initialStateService) {
+								IInitialState $initialState) {
 		$this->appName = $appName;
 		$this->configService = $configService;
 		$this->groupManager = $groupManager;
-		$this->initialStateService = $initialStateService;
+		$this->initialState = $initialState;
 	}
 
 	/**
@@ -73,8 +73,8 @@ class Settings implements ISettings {
 
 	public function getForm(): TemplateResponse {
 		Util::addScript($this->appName, 'forms-settings');
-		$this->initialStateService->provideInitialState($this->appName, 'availableGroups', $this->getAvailableGroups());
-		$this->initialStateService->provideInitialState($this->appName, 'appConfig', $this->configService->getAppConfig());
+		$this->initialState->provideInitialState('availableGroups', $this->getAvailableGroups());
+		$this->initialState->provideInitialState('appConfig', $this->configService->getAppConfig());
 
 		return new TemplateResponse($this->appName, 'settings');
 	}

--- a/psalm.xml
+++ b/psalm.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0"?>
+<psalm
+	errorLevel="4"
+	resolveFromConfigFile="true"
+	totallyTyped="true"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns="https://getpsalm.org/schema/config"
+	xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
+	errorBaseline="tests/psalm-baseline.xml"
+>
+	<projectFiles>
+		<directory name="lib" />
+		<ignoreFiles>
+			<directory name="vendor" />
+		</ignoreFiles>
+	</projectFiles>
+	<extraFiles>
+		<directory name="vendor" />
+		<ignoreFiles>
+			<directory name="vendor/phpunit/php-code-coverage" />
+			<directory name="vendor/psalm" />
+		</ignoreFiles>
+	</extraFiles>
+	<issueHandlers>
+		<UndefinedDocblockClass>
+			<errorLevel type="suppress">
+				<referencedClass name="Doctrine\DBAL\Schema\Schema" />
+				<referencedClass name="Doctrine\DBAL\Schema\SchemaException" />
+				<referencedClass name="Doctrine\DBAL\Driver\Statement" />
+				<referencedClass name="Doctrine\DBAL\Schema\Table" />
+			</errorLevel>
+		</UndefinedDocblockClass>
+	</issueHandlers>
+</psalm>

--- a/tests/psalm-baseline.xml
+++ b/tests/psalm-baseline.xml
@@ -1,0 +1,247 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<files psalm-version="5.8.0@9cf4f60a333f779ad3bc704a555920e81d4fdcda">
+  <file src="lib/Activity/Provider.php">
+    <InvalidCatch>
+      <code><![CDATA[try {
+			// Overwrite formTitle if form is found (i.e. still exists).
+			$formTitle = $this->formMapper->findbyHash($formHash)->getTitle();
+
+			// Append hash and route
+			$formLink .= $formHash;
+			if ($route !== '') {
+				$formLink .= '/' . $route;
+			}
+		} catch (IMapperException $e) {
+			// Ignore if not found, just use stored title
+		}]]></code>
+    </InvalidCatch>
+  </file>
+  <file src="lib/AppInfo/Application.php">
+    <InvalidArgument>
+      <code>UserDeletedListener::class</code>
+    </InvalidArgument>
+  </file>
+  <file src="lib/Controller/ApiController.php">
+    <InvalidCatch>
+      <code><![CDATA[try {
+				$questions[$arrayKey] = $this->questionMapper->findById($questionId);
+			} catch (IMapperException $e) {
+				$this->logger->debug('Could not find question. Id:{id}', [
+					'id' => $questionId
+				]);
+				throw new OCSBadRequestException();
+			}]]></code>
+      <code><![CDATA[try {
+			$form = $this->formMapper->findByHash($hash);
+		} catch (IMapperException $e) {
+			$this->logger->debug('Could not find form');
+			throw new OCSBadRequestException();
+		}]]></code>
+      <code><![CDATA[try {
+			$form = $this->formMapper->findByHash($hash);
+		} catch (IMapperException $e) {
+			$this->logger->debug('Could not find form');
+			throw new OCSBadRequestException();
+		}]]></code>
+      <code><![CDATA[try {
+			$form = $this->formMapper->findByHash($hash);
+		} catch (IMapperException $e) {
+			$this->logger->debug('Could not find form');
+			throw new OCSBadRequestException();
+		}]]></code>
+      <code><![CDATA[try {
+			$form = $this->formMapper->findByHash($hash);
+		} catch (IMapperException $e) {
+			$this->logger->debug('Could not find form');
+			throw new OCSBadRequestException();
+		}]]></code>
+      <code><![CDATA[try {
+			$form = $this->formMapper->findById($formId);
+			$questions = $this->formsService->getQuestions($formId);
+		} catch (IMapperException $e) {
+			$this->logger->debug('Could not find form');
+			throw new OCSBadRequestException();
+		}]]></code>
+      <code><![CDATA[try {
+			$form = $this->formMapper->findById($formId);
+		} catch (IMapperException $e) {
+			$this->logger->debug('Could not find form');
+			throw new OCSBadRequestException();
+		}]]></code>
+      <code><![CDATA[try {
+			$form = $this->formMapper->findById($formId);
+		} catch (IMapperException $e) {
+			$this->logger->debug('Could not find form');
+			throw new OCSBadRequestException();
+		}]]></code>
+      <code><![CDATA[try {
+			$form = $this->formMapper->findById($formId);
+		} catch (IMapperException $e) {
+			$this->logger->debug('Could not find form');
+			throw new OCSBadRequestException();
+		}]]></code>
+      <code><![CDATA[try {
+			$form = $this->formMapper->findById($id);
+		} catch (IMapperException $e) {
+			$this->logger->debug('Could not find form');
+			throw new OCSBadRequestException();
+		}]]></code>
+      <code><![CDATA[try {
+			$form = $this->formMapper->findById($id);
+		} catch (IMapperException $e) {
+			$this->logger->debug('Could not find form');
+			throw new OCSBadRequestException();
+		}]]></code>
+      <code><![CDATA[try {
+			$form = $this->formsService->getForm($id);
+		} catch (IMapperException $e) {
+			$this->logger->debug('Could not find form');
+			throw new OCSBadRequestException();
+		}]]></code>
+      <code><![CDATA[try {
+			$oldForm = $this->formMapper->findById($id);
+		} catch (IMapperException $e) {
+			$this->logger->debug('Could not find form');
+			throw new OCSBadRequestException();
+		}]]></code>
+      <code><![CDATA[try {
+			$option = $this->optionMapper->findById($id);
+			$question = $this->questionMapper->findById($option->getQuestionId());
+			$form = $this->formMapper->findById($question->getFormId());
+		} catch (IMapperException $e) {
+			$this->logger->debug('Could not find form or option');
+			throw new OCSBadRequestException('Could not find form or option');
+		}]]></code>
+      <code><![CDATA[try {
+			$option = $this->optionMapper->findById($id);
+			$question = $this->questionMapper->findById($option->getQuestionId());
+			$form = $this->formMapper->findById($question->getFormId());
+		} catch (IMapperException $e) {
+			$this->logger->debug('Could not find option, question or form');
+			throw new OCSBadRequestException('Could not find option, question or form');
+		}]]></code>
+      <code><![CDATA[try {
+			$question = $this->questionMapper->findById($id);
+			$form = $this->formMapper->findById($question->getFormId());
+		} catch (IMapperException $e) {
+			$this->logger->debug('Could not find form or question');
+			throw new OCSBadRequestException('Could not find form or question');
+		}]]></code>
+      <code><![CDATA[try {
+			$question = $this->questionMapper->findById($id);
+			$form = $this->formMapper->findById($question->getFormId());
+		} catch (IMapperException $e) {
+			$this->logger->debug('Could not find form or question');
+			throw new OCSBadRequestException('Could not find form or question');
+		}]]></code>
+      <code><![CDATA[try {
+			$question = $this->questionMapper->findById($questionId);
+			$form = $this->formMapper->findById($question->getFormId());
+		} catch (IMapperException $e) {
+			$this->logger->debug('Could not find form or question');
+			throw new OCSBadRequestException('Could not find form or question');
+		}]]></code>
+      <code><![CDATA[try {
+			$submission = $this->submissionMapper->findById($id);
+			$form = $this->formMapper->findById($submission->getFormId());
+		} catch (IMapperException $e) {
+			$this->logger->debug('Could not find form or submission');
+			throw new OCSBadRequestException();
+		}]]></code>
+    </InvalidCatch>
+  </file>
+  <file src="lib/Controller/ShareApiController.php">
+    <InvalidCatch>
+      <code><![CDATA[try {
+			$form = $this->formMapper->findById($formId);
+		} catch (IMapperException $e) {
+			$this->logger->debug('Could not find form', ['exception' => $e]);
+			throw new OCSBadRequestException('Could not find form');
+		}]]></code>
+      <code><![CDATA[try {
+			$share = $this->shareMapper->findById($id);
+			$form = $this->formMapper->findById($share->getFormId());
+		} catch (IMapperException $e) {
+			$this->logger->debug('Could not find share', ['exception' => $e]);
+			throw new OCSBadRequestException('Could not find share');
+		}]]></code>
+      <code><![CDATA[try {
+			$share = $this->shareMapper->findById($id);
+			$form = $this->formMapper->findById($share->getFormId());
+		} catch (IMapperException $e) {
+			$this->logger->debug('Could not find share', ['exception' => $e]);
+			throw new OCSBadRequestException('Could not find share');
+		}]]></code>
+    </InvalidCatch>
+  </file>
+  <file src="lib/Db/Form.php">
+    <UndefinedMagicMethod>
+      <code>getAccessJson</code>
+      <code>setAccessJson</code>
+    </UndefinedMagicMethod>
+  </file>
+  <file src="lib/Db/Question.php">
+    <UndefinedMagicMethod>
+      <code>getExtraSettingsJson</code>
+      <code>setExtraSettingsJson</code>
+    </UndefinedMagicMethod>
+  </file>
+  <file src="lib/Db/Share.php">
+    <UndefinedMagicMethod>
+      <code>getPermissionsJson</code>
+      <code>setPermissionsJson</code>
+    </UndefinedMagicMethod>
+  </file>
+  <file src="lib/FormsMigrator.php">
+    <UndefinedClass>
+      <code>OutputInterface</code>
+      <code>OutputInterface</code>
+    </UndefinedClass>
+  </file>
+  <file src="lib/Middleware/PublicCorsMiddleware.php">
+    <NoInterfaceProperties>
+      <code><![CDATA[$this->request->server]]></code>
+    </NoInterfaceProperties>
+    <UndefinedClass>
+      <code>SecurityException</code>
+      <code>SecurityException</code>
+    </UndefinedClass>
+    <UndefinedDocblockClass>
+      <code>SecurityException</code>
+    </UndefinedDocblockClass>
+  </file>
+  <file src="lib/Migration/Version020300Date20210403214012.php">
+    <InvalidOperand>
+      <code>$result</code>
+      <code><![CDATA[$this->ensureColumnIsNullable($schema, 'forms_v2_questions', 'mandatory')]]></code>
+    </InvalidOperand>
+  </file>
+  <file src="lib/Migration/Version030000Date20220402100057.php">
+    <UndefinedClass>
+      <code>Type</code>
+    </UndefinedClass>
+  </file>
+  <file src="lib/Migration/Version030100Date20230115214242.php">
+    <InvalidOperand>
+      <code>$result</code>
+      <code><![CDATA[$this->ensureColumnIsNullable($schema, 'forms_v2_options', 'text')]]></code>
+      <code><![CDATA[$this->ensureColumnIsNullable($schema, 'forms_v2_questions', 'order')]]></code>
+      <code><![CDATA[$this->ensureColumnIsNullable($schema, 'forms_v2_questions', 'text')]]></code>
+      <code><![CDATA[$this->ensureColumnIsNullable($schema, 'forms_v2_shares', 'share_type')]]></code>
+    </InvalidOperand>
+  </file>
+  <file src="lib/Service/FormsService.php">
+    <InvalidThrow>
+      <code>IMapperException</code>
+      <code>IMapperException</code>
+      <code>IMapperException</code>
+    </InvalidThrow>
+  </file>
+  <file src="lib/Service/SubmissionService.php">
+    <MissingDependency>
+      <code><![CDATA[$this->storage]]></code>
+      <code>IRootFolder</code>
+      <code>IRootFolder</code>
+    </MissingDependency>
+  </file>
+</files>


### PR DESCRIPTION
* `OCP\IInitialStateService` is deprecated in favor of `OCP\AppFramework\Services\IInitialState`
* Remove unused `IGroupManager` in `PageController`
* `QueryBuilder::execute` is deprecated
* Fix psalm detected issues / static code analysis
* Minor other issues

Also added a psalm CI workflow for static code analysis.