### PR TITLE
Drop 'Nextcloud' from connected responses string

### DIFF
--- a/src/views/Create.vue
+++ b/src/views/Create.vue
@@ -218,7 +218,7 @@ export default {
 
 			// On Submit, this is dependent on `isLoggedIn`. Create-view is always logged in and the variable isLoggedIn does not exist.
 			if (!this.form.isAnonymous && true) {
-				message += t('forms', 'Responses are connected to your Nextcloud account.')
+				message += t('forms', 'Responses are connected to your account.')
 			}
 
 			if (this.isRequiredUsed) {

--- a/src/views/Submit.vue
+++ b/src/views/Submit.vue
@@ -196,7 +196,7 @@ export default {
 				message += t('forms', 'Responses are anonymous.')
 			}
 			if (!this.form.isAnonymous && this.isLoggedIn) {
-				message += t('forms', 'Responses are connected to your Nextcloud account.')
+				message += t('forms', 'Responses are connected to your account.')
 			}
 			if (this.isRequiredUsed) {
 				message += ' ' + t('forms', 'An asterisk (*) indicates mandatory questions.')


### PR DESCRIPTION
This fixes #1631 by dropping Nextcloud from the string that tells users that there responses are connected to their accounts.