### PR TITLE
Allow to right click share link buttons to copy link manually

### DIFF
--- a/src/components/SidebarTabs/SharingSidebarTab.vue
+++ b/src/components/SidebarTabs/SharingSidebarTab.vue
@@ -51,12 +51,12 @@
 				</div>
 				<span class="share-div__desc">{{ t('forms', 'Share link') }}</span>
 				<NcActions>
-					<NcActionButton @click="copyPublicShareLink($event, share.shareWith)">
+					<NcActionLink :href="getPublicShareLink(share.shareWith)" @click.prevent="copyLink($event, getPublicShareLink(share.shareWith))">
 						<template #icon>
 							<IconCopyAll :size="20" />
 						</template>
 						{{ t('forms', 'Copy to clipboard') }}
-					</NcActionButton>
+					</NcActionLink>
 				</NcActions>
 				<NcActions>
 					<NcActionButton @click="removeShare(share)">
@@ -110,12 +110,12 @@
 				<span>{{ t('forms', 'Only works for logged in accounts with access rights') }}</span>
 			</div>
 			<NcActions>
-				<NcActionButton @click="copyInternalShareLink($event, form.hash)">
+				<NcActionLink :href="getInternalShareLink(form.hash)" @click.prevent="copyLink($event, getInternalShareLink(form.hash))">
 					<template #icon>
 						<IconCopyAll :size="20" />
 					</template>
 					{{ t('forms', 'Copy to clipboard') }}
-				</NcActionButton>
+				</NcActionLink>
 			</NcActions>
 		</div>
 
@@ -165,6 +165,7 @@ import { showError } from '@nextcloud/dialogs'
 import axios from '@nextcloud/axios'
 import NcActions from '@nextcloud/vue/dist/Components/NcActions.js'
 import NcActionButton from '@nextcloud/vue/dist/Components/NcActionButton.js'
+import NcActionLink from '@nextcloud/vue/dist/Components/NcActionLink.js'
 import NcCheckboxRadioSwitch from '@nextcloud/vue/dist/Components/NcCheckboxRadioSwitch.js'
 import IconAccountMultiple from 'vue-material-design-icons/AccountMultiple.vue'
 import IconAlertCircleOutline from 'vue-material-design-icons/AlertCircleOutline.vue'
@@ -192,6 +193,7 @@ export default {
 		IconPlus,
 		NcActions,
 		NcActionButton,
+		NcActionLink,
 		NcCheckboxRadioSwitch,
 		SharingSearchDiv,
 		SharingShareDiv,

--- a/src/mixins/ShareLinkMixin.js
+++ b/src/mixins/ShareLinkMixin.js
@@ -25,24 +25,23 @@ import { showError, showSuccess } from '@nextcloud/dialogs'
 export default {
 	methods: {
 		/**
-		 * Copy internal share link
+		 * Get the internal link for sharing the form
 		 *
-		 * @param {object} event Event of origin, calling the function
-		 * @param {string} formHash Internal form-hash for link
+		 * @param {string} formHash Internal form hash
+		 * @return {string} link
 		 */
-		async copyInternalShareLink(event, formHash) {
-			const shareLink = window.location.protocol + '//' + window.location.host + generateUrl(`/apps/forms/${formHash}`)
-			this.copyLink(event, shareLink)
+		getInternalShareLink(formHash) {
+			return window.location.protocol + '//' + window.location.host + generateUrl(`/apps/forms/${this.form.hash}`)
 		},
+
 		/**
-		 * Copy share link for public share
+		 * Get the publish share link for a given share
 		 *
-		 * @param {object} event Event of origin, calling the function
-		 * @param {string} publicHash Hash of public link-share
+		 * @param {string} publicHash The share hash
+		 * @return {string} link
 		 */
-		async copyPublicShareLink(event, publicHash) {
-			const shareLink = window.location.protocol + '//' + window.location.host + generateUrl(`/apps/forms/s/${publicHash}`)
-			this.copyLink(event, shareLink)
+		getPublicShareLink(publicHash) {
+			return window.location.protocol + '//' + window.location.host + generateUrl(`/apps/forms/s/${publicHash}`)
 		},
 
 		/**


### PR DESCRIPTION
* Resolves #1651

As this allows to manually copy the link (before this it was simply a button with no option to copy the link, it is now a native anchor element which allows copying the target link manually).