### PR TITLE
Reduce white space between questions

### DIFF
--- a/src/components/Questions/Question.vue
+++ b/src/components/Questions/Question.vue
@@ -302,7 +302,7 @@ export default {
 	align-items: stretch;
 	flex-direction: column;
 	justify-content: stretch;
-	margin-bottom: 80px;
+	margin-bottom: 64px;
 	padding-left: 44px;
 	user-select: none;
 	background-color: var(--color-main-background);


### PR DESCRIPTION
Fixes #1234 by reducing the margin on the bottom of the questions from 80px to 64px

|80px | 70px | 60px | 50px |
|---|---|---|---|
|![grafik](https://github.com/nextcloud/forms/assets/16020496/66d2b7be-a3d3-4476-a45d-8c69c4677689)|![grafik](https://github.com/nextcloud/forms/assets/16020496/55e40d16-21f4-4361-9030-476cf967b70f) |![grafik](https://github.com/nextcloud/forms/assets/16020496/86f43dda-57f3-44b3-b32b-b3ec42ae67ba) |![grafik](https://github.com/nextcloud/forms/assets/16020496/8e375e19-da5c-49c0-9586-0f1fa376dbfc) |