### PR TITLE
feat: Add 'Other' option for radio/checkbox questions.

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -152,7 +152,8 @@ Returns the full-depth object of the requested form (without submissions).
           "questionId": 1,
           "text": "Option 2"
         }
-      ]
+      ],
+      "extraSettings": {}
     },
     {
       "id": 2,
@@ -162,7 +163,8 @@ Returns the full-depth object of the requested form (without submissions).
       "isRequired": true,
       "text": "Question 2",
       "name": "something_other",
-      "options": []
+      "options": [],
+      "extraSettings": {}
     }
   ],
   "shares": [
@@ -247,6 +249,7 @@ Contains only manipulative question-endpoints. To retrieve questions, request th
   "name": "",
   "text": "",
   "options": []
+  "extraSettings": {}
 }
 ```
 
@@ -478,7 +481,8 @@ Get all Submissions to a Form
           "questionId": 1,
           "text": "Option 3"
         }
-      ]
+      ],
+      "extraSettings": {}
     },
     {
       "id": 2,
@@ -487,7 +491,8 @@ Get all Submissions to a Form
       "type": "short",
       "isRequired": true,
       "text": "Question 2",
-      "options": []
+      "options": [],
+      "extraSettings": {}
     }
   ]
 }

--- a/docs/DataStructure.md
+++ b/docs/DataStructure.md
@@ -50,16 +50,17 @@ This document describes the Object-Structure, that is used within the Forms App 
 ```
 
 ### Question
-| Property    | Type            | Restrictions | Description |
-|-------------|-----------------|--------------|-------------|
-| id          | Integer         | unique       | An instance-wide unique id of the question |
-| formId      | Integer         |              | The id of the form, the question belongs to |
-| order       | Integer         | unique within form; *not* `0` | The order of the question within that form. Value `0` indicates deleted questions within database (typ. not visible outside) |
-| type        | [Question-Type](#question-types) | | Type of the question |
-| isRequired  | Boolean         |              | If the question is required to fill the form |
-| text        | String          | max. 2048 ch. | The question-text |
-| name        | String          |              | Technical identifier of the question, e.g. used as HTML name attribute |
-| options     | Array of [Options](#option) | | Array of options belonging to the question. Only relevant for question-type with predefined options. |
+| Property       | Type            | Restrictions | Description |
+|----------------|-----------------|--------------|-------------|
+| id             | Integer         | unique       | An instance-wide unique id of the question |
+| formId         | Integer         |              | The id of the form, the question belongs to |
+| order          | Integer         | unique within form; *not* `0` | The order of the question within that form. Value `0` indicates deleted questions within database (typ. not visible outside) |
+| type           | [Question-Type](#question-types) | | Type of the question |
+| isRequired     | Boolean         |              | If the question is required to fill the form |
+| text           | String          | max. 2048 ch. | The question-text |
+| name           | String          |              | Technical identifier of the question, e.g. used as HTML name attribute |
+| options        | Array of [Options](#option) | | Array of options belonging to the question. Only relevant for question-type with predefined options. |
+| extraSettings  | StdClass        |              | Additional settings for the question. For dropdown/radio/checkbox, there can be a 'shuffleOptions': true - the list of options should be shuffled. For radio/checkbox, 'allowOtherAnswer': true - allows the user to specify their own option. |
 ```
 {
   "id": 1,
@@ -69,7 +70,8 @@ This document describes the Object-Structure, that is used within the Forms App 
   "isRequired": false,
   "text": "Question 1",
   "name": "firstname",
-  "options": []
+  "options": [],
+  "extraSettings": {}
 }
 ```
 

--- a/lib/Constants.php
+++ b/lib/Constants.php
@@ -131,4 +131,9 @@ class Constants {
 	 */
 	public const EMPTY_NOTFOUND = 'notfound';
 	public const EMPTY_EXPIRED = 'expired';
+
+	/**
+	 * Constants related to extra settings for questions
+	 */
+	public const QUESTION_EXTRASETTINGS_OTHER_PREFIX = 'system-other-answer:';
 }

--- a/lib/Controller/ApiController.php
+++ b/lib/Controller/ApiController.php
@@ -1002,25 +1002,28 @@ class ApiController extends OCSController {
 			$questionIndex = array_search($questionId, array_column($questions, 'id'));
 			if ($questionIndex === false) {
 				continue;
-			} else {
-				$question = $questions[$questionIndex];
 			}
+			
+			$question = $questions[$questionIndex];
 
 			foreach ($answerArray as $answer) {
+				$answerText = '';
+
 				// Are we using answer ids as values
 				if (in_array($question['type'], Constants::ANSWER_TYPES_PREDEFINED)) {
 					// Search corresponding option, skip processing if not found
 					$optionIndex = array_search($answer, array_column($question['options'], 'id'));
-					if ($optionIndex === false) {
-						continue;
-					} else {
-						$option = $question['options'][$optionIndex];
+					if ($optionIndex !== false) {
+						$answerText = $question['options'][$optionIndex]['text'];
+					} elseif (!empty($question['extraSettings']->allowOtherAnswer) && strpos($answer, Constants::QUESTION_EXTRASETTINGS_OTHER_PREFIX) === 0) {
+						$answerText = str_replace(Constants::QUESTION_EXTRASETTINGS_OTHER_PREFIX, "", $answer);
 					}
-
-					// Load option-text
-					$answerText = $option['text'];
 				} else {
 					$answerText = $answer; // Not a multiple-question, answerText is given answer
+				}
+
+				if ($answerText === "") {
+					continue;
 				}
 
 				$answerEntity = new Answer();

--- a/lib/Service/SubmissionService.php
+++ b/lib/Service/SubmissionService.php
@@ -309,7 +309,11 @@ class SubmissionService {
 			$questionAnswered = array_key_exists($questionId, $answers);
 
 			// Check if all required questions have an answer
-			if ($question['isRequired'] && (!$questionAnswered || !array_filter($answers[$questionId], 'strlen'))) {
+			if ($question['isRequired'] &&
+				(!$questionAnswered ||
+				!array_filter($answers[$questionId], 'strlen') ||
+				(!empty($question['extraSettings']->allowOtherAnswer) && !array_filter($answers[$questionId], fn ($value) => $value !== Constants::QUESTION_EXTRASETTINGS_OTHER_PREFIX)))
+			) {
 				return false;
 			}
 
@@ -328,9 +332,9 @@ class SubmissionService {
 					!$this->validateDateTime($answers[$questionId][0], Constants::ANSWER_PHPDATETIME_FORMAT[$question['type']])) {
 					return false;
 				}
-	
+
 				// Check if all answers are within the possible options
-				if (in_array($question['type'], Constants::ANSWER_TYPES_PREDEFINED)) {
+				if (in_array($question['type'], Constants::ANSWER_TYPES_PREDEFINED) && empty($question['extraSettings']->allowOtherAnswer)) {
 					foreach ($answers[$questionId] as $answer) {
 						// Search corresponding option, return false if non-existent
 						if (array_search($answer, array_column($question['options'], 'id')) === false) {

--- a/src/components/Results/ResultsSummary.vue
+++ b/src/components/Results/ResultsSummary.vue
@@ -92,6 +92,15 @@ export default {
 				percentage: 0,
 			}))
 
+			// Also record 'Other'
+			if (this.question.extraSettings?.allowOtherAnswer) {
+				questionOptionsStats.unshift({
+					text: t('forms', 'Other'),
+					count: 0,
+					percentage: 0,
+				})
+			}
+
 			// Also record 'No response'
 			questionOptionsStats.unshift({
 				// TRANSLATORS Counts on Results-Summary, how many users did not respond to this question.
@@ -112,11 +121,15 @@ export default {
 				answers.forEach(answer => {
 					const optionsStatIndex = questionOptionsStats.findIndex(option => option.text === answer.text)
 					if (optionsStatIndex < 0) {
-						questionOptionsStats.push({
-							text: answer.text,
-							count: 1,
-							percentage: 0,
-						})
+						if (this.question.extraSettings?.allowOtherAnswer) {
+							questionOptionsStats[1].count++
+						} else {
+							questionOptionsStats.push({
+								text: answer.text,
+								count: 1,
+								percentage: 0,
+							})
+						}
 					} else {
 						questionOptionsStats[optionsStatIndex].count++
 					}

--- a/src/models/AnswerTypes.js
+++ b/src/models/AnswerTypes.js
@@ -70,6 +70,8 @@ export default {
 		validate: question => question.options.length > 0,
 
 		titlePlaceholder: t('forms', 'Checkbox question title'),
+		createPlaceholder: t('forms', 'People can submit a different answer'),
+		submitPlaceholder: t('forms', 'Enter your answer'),
 		warningInvalid: t('forms', 'This question needs a title and at least one answer!'),
 	},
 
@@ -81,6 +83,8 @@ export default {
 		validate: question => question.options.length > 0,
 
 		titlePlaceholder: t('forms', 'Radio buttons question title'),
+		createPlaceholder: t('forms', 'People can submit a different answer'),
+		submitPlaceholder: t('forms', 'Enter your answer'),
 		warningInvalid: t('forms', 'This question needs a title and at least one answer!'),
 
 		// Using the same vue-component as multiple, this specifies that the component renders as multiple_unique.

--- a/tests/Unit/Service/SubmissionServiceTest.php
+++ b/tests/Unit/Service/SubmissionServiceTest.php
@@ -24,8 +24,8 @@ declare(strict_types=1);
  */
 namespace OCA\Forms\Tests\Unit\Service;
 
+use OCA\Forms\Constants;
 use OCA\Forms\Db\Answer;
-
 use OCA\Forms\Db\AnswerMapper;
 use OCA\Forms\Db\Form;
 use OCA\Forms\Db\FormMapper;
@@ -561,6 +561,20 @@ class SubmissionServiceTest extends TestCase {
 				// Expected Result
 				false
 			],
+			'required-empty-other-answer' => [
+				// Questions
+				[
+					['id' => 1, 'type' => 'multiple_unique', 'isRequired' => true, 'extraSettings' => (object)['allowOtherAnswer' => true], 'options' => [
+						['id' => 3]
+					]]
+				],
+				// Answers
+				[
+					'1' => [Constants::QUESTION_EXTRASETTINGS_OTHER_PREFIX]
+				],
+				// Expected Result
+				false
+			],
 			'more-than-allowed' => [
 				// Questions
 				[
@@ -587,6 +601,21 @@ class SubmissionServiceTest extends TestCase {
 				// Answers
 				[
 					'1' => [3,10]
+				],
+				// Expected Result
+				false
+			],
+			'other-answer-not-allowed' => [
+				// Questions
+				[
+					['id' => 1, 'type' => 'multiple', 'isRequired' => false, 'options' => [
+						['id' => 3],
+						['id' => 5]
+					]],
+				],
+				// Answers
+				[
+					'1' => [3, Constants::QUESTION_EXTRASETTINGS_OTHER_PREFIX . 'other answer']
 				],
 				// Expected Result
 				false
@@ -635,6 +664,9 @@ class SubmissionServiceTest extends TestCase {
 						['id' => 6]
 					]],
 					['id' => 8, 'type' => 'time', 'isRequired' => false],
+					['id' => 9, 'type' => 'multiple_unique', 'isRequired' => true, 'extraSettings' => (object)['allowOtherAnswer' => true], 'options' => [
+						['id' => 3]
+					]],
 				],
 				// Answers
 				[
@@ -645,7 +677,8 @@ class SubmissionServiceTest extends TestCase {
 					'5' => [1,2],
 					'6' => [4],
 					'7' => [5],
-					'8' => ['17:45']
+					'8' => ['17:45'],
+					'9' => [Constants::QUESTION_EXTRASETTINGS_OTHER_PREFIX . 'other answer']
 				],
 				// Expected Result
 				true


### PR DESCRIPTION
I have implemented a feature to provide other answer for radio buttons and checkboxes.

Related to #93

Demo:

![image](https://github.com/nextcloud/forms/assets/5858915/f0b26560-a035-4a8d-ae9f-880dd37a8ef9)

![image](https://github.com/nextcloud/forms/assets/5858915/21b93853-01b1-4bcb-a026-ed0099bd86e3)

![image](https://github.com/nextcloud/forms/assets/5858915/164dc3f5-2478-48c9-aa3a-bed80b831c0a)

