### PR TITLE
Make possible hide fields from header

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -14,9 +14,9 @@
 	]]></description>
 
 	<licence>agpl</licence>
-	<version>3.3.1</version>
+	<version>3.4.0</version>
 	<dependencies>
-		<nextcloud min-version="25" max-version="27" />
+		<nextcloud min-version="25" max-version="28" />
 	</dependencies>
 
 	<author>Affan Hussain</author>
@@ -35,6 +35,7 @@
 	<author>Stephan Link</author>
 	<author>Tim Sattizahn</author>
 	<author>Vinzenz Rosenkranz</author>
+	<author>Vitor Mattos</author>
 
 	<category>tools</category>
 	<category>social</category>

--- a/docs/API.md
+++ b/docs/API.md
@@ -116,7 +116,6 @@ Returns the full-depth object of the requested form (without submissions).
   "hash": "em4djk8B9BpXnkYG",
   "showHeader": true,
   "title": "Form 1",
-  "showTitle": true,
   "description": "Description Text",
   "ownerId": "jonas",
   "created": 1611240961,
@@ -127,7 +126,6 @@ Returns the full-depth object of the requested form (without submissions).
   "expires": 0,
   "isAnonymous": false,
   "submitMultiple": true,
-  "showDescription": true,
   "showExpiration": false,
   "canSubmit": true,
   "permissions": [

--- a/docs/API.md
+++ b/docs/API.md
@@ -114,6 +114,7 @@ Returns the full-depth object of the requested form (without submissions).
 "data": {
   "id": 3,
   "hash": "em4djk8B9BpXnkYG",
+  "showHeader": true,
   "title": "Form 1",
   "showTitle": true,
   "description": "Description Text",
@@ -392,7 +393,7 @@ Contains only manipulative question-endpoints. To retrieve options, request the 
   |------------------|----------|-------------|
   | _id_             | Integer  | ID of the share to update |
   | *keyValuePairs*¹ | Array    | Array of key-value pairs to update |
-  
+
   ¹Currently only the _permissions_ can be updated.
 - Method: `POST`
 - Response: **Status-Code OK**, as well as the id of the share object.
@@ -547,7 +548,7 @@ Store Submission to Database
   | _formId_  | Integer | ID of the form to submit into |
   | _answers_ | Array   | Array of Answers |
   | _shareHash_ | String | optional, only neccessary for submissions to a public share link |
-  
+
   The Array of Answers has the following structure:
   - QuestionID as key
   - An **array** of values as value --> Even for short Text Answers, wrapped into Array.

--- a/docs/API.md
+++ b/docs/API.md
@@ -125,6 +125,7 @@ Returns the full-depth object of the requested form (without submissions).
   "expires": 0,
   "isAnonymous": false,
   "submitMultiple": true,
+  "showDescription": true,
   "showExpiration": false,
   "canSubmit": true,
   "permissions": [

--- a/docs/API.md
+++ b/docs/API.md
@@ -115,6 +115,7 @@ Returns the full-depth object of the requested form (without submissions).
   "id": 3,
   "hash": "em4djk8B9BpXnkYG",
   "title": "Form 1",
+  "showTitle": true,
   "description": "Description Text",
   "ownerId": "jonas",
   "created": 1611240961,
@@ -237,7 +238,7 @@ Contains only manipulative question-endpoints. To retrieve questions, request th
   | _formId_  | Integer |          | ID of the form, the new question will belong to |
   | _type_    | [QuestionType](DataStructure.md#question-types) |  | The question-type of the new question |
   | _text_    | String  | yes      | *Optional* The text of the new question. |
-- Response: The new question object. 
+- Response: The new question object.
 ```
 "data": {
   "id": 3,

--- a/docs/DataStructure.md
+++ b/docs/DataStructure.md
@@ -11,7 +11,6 @@ This document describes the Object-Structure, that is used within the Forms App 
 | hash        | 16-char String  | unique       | An instance-wide unique hash |
 | showHeader  | Boolean         |              | If true will be shown on the form |
 | title       | String          | max. 256 ch. | The form title |
-| showTitle   | Boolean         |              | If true will be shown on the form |
 | description | String          | max. 8192 ch. | The Form description |
 | ownerId     | String          |              | The nextcloud userId of the form owner |
 | created     | unix timestamp  |              | When the form has been created |
@@ -19,7 +18,6 @@ This document describes the Object-Structure, that is used within the Forms App 
 | expires     | unix-timestamp  |              | When the form should expire. Timestamp `0` indicates _never_ |
 | isAnonymous | Boolean         |              | If Answers will be stored anonymously |
 | submitMultiple  | Boolean     |              | If users are allowed to submit multiple times to the form |
-| showDescription | Boolean     |              | If true will be shown on the form |
 | showExpiration | Boolean      |              | If the expiration date will be shown on the form |
 | canSubmit   | Boolean         |              | If the user can Submit to the form, i.e. calculated information out of `submitMultiple` and existing submissions. |
 | permissions | Array of [Permissions](#permissions) | Array of permissions regarding the form |
@@ -33,7 +31,6 @@ This document describes the Object-Structure, that is used within the Forms App 
   "hash": "em4djk8B9BpXnkYG",
   "showHeader": true,
   "title": "Form 1",
-  "showTitle": true,
   "description": "Description Text",
   "ownerId": "jonas",
   "created": 1611240961,
@@ -41,7 +38,6 @@ This document describes the Object-Structure, that is used within the Forms App 
   "expires": 0,
   "isAnonymous": false,
   "submitMultiple": true,
-  "showDescription": true,
   "showExpiration": false,
   "canSubmit": true,
   "permissions": [

--- a/docs/DataStructure.md
+++ b/docs/DataStructure.md
@@ -9,6 +9,7 @@ This document describes the Object-Structure, that is used within the Forms App 
 |-------------|-----------------|--------------|-------------|
 | id          | Integer         | unique       | An instance-wide unique id of the form |
 | hash        | 16-char String  | unique       | An instance-wide unique hash |
+| showHeader  | Boolean         |              | If true will be shown on the form |
 | title       | String          | max. 256 ch. | The form title |
 | showTitle   | Boolean         |              | If true will be shown on the form |
 | description | String          | max. 8192 ch. | The Form description |
@@ -30,6 +31,7 @@ This document describes the Object-Structure, that is used within the Forms App 
 {
   "id": 3,
   "hash": "em4djk8B9BpXnkYG",
+  "showHeader": true,
   "title": "Form 1",
   "showTitle": true,
   "description": "Description Text",

--- a/docs/DataStructure.md
+++ b/docs/DataStructure.md
@@ -10,6 +10,7 @@ This document describes the Object-Structure, that is used within the Forms App 
 | id          | Integer         | unique       | An instance-wide unique id of the form |
 | hash        | 16-char String  | unique       | An instance-wide unique hash |
 | title       | String          | max. 256 ch. | The form title |
+| showTitle   | Boolean         |              | If true will be shown on the form |
 | description | String          | max. 8192 ch. | The Form description |
 | ownerId     | String          |              | The nextcloud userId of the form owner |
 | created     | unix timestamp  |              | When the form has been created |
@@ -30,6 +31,7 @@ This document describes the Object-Structure, that is used within the Forms App 
   "id": 3,
   "hash": "em4djk8B9BpXnkYG",
   "title": "Form 1",
+  "showTitle": true,
   "description": "Description Text",
   "ownerId": "jonas",
   "created": 1611240961,

--- a/docs/DataStructure.md
+++ b/docs/DataStructure.md
@@ -17,6 +17,7 @@ This document describes the Object-Structure, that is used within the Forms App 
 | expires     | unix-timestamp  |              | When the form should expire. Timestamp `0` indicates _never_ |
 | isAnonymous | Boolean         |              | If Answers will be stored anonymously |
 | submitMultiple  | Boolean     |              | If users are allowed to submit multiple times to the form |
+| showDescription | Boolean     |              | If true will be shown on the form |
 | showExpiration | Boolean      |              | If the expiration date will be shown on the form |
 | canSubmit   | Boolean         |              | If the user can Submit to the form, i.e. calculated information out of `submitMultiple` and existing submissions. |
 | permissions | Array of [Permissions](#permissions) | Array of permissions regarding the form |
@@ -36,6 +37,7 @@ This document describes the Object-Structure, that is used within the Forms App 
   "expires": 0,
   "isAnonymous": false,
   "submitMultiple": true,
+  "showDescription": true,
   "showExpiration": false,
   "canSubmit": true,
   "permissions": [

--- a/lib/Controller/ApiController.php
+++ b/lib/Controller/ApiController.php
@@ -261,6 +261,7 @@ class ApiController extends OCSController {
 		$form->setCreated(time());
 		$form->setHash($this->formsService->generateFormHash());
 		$form->setTitle('');
+		$form->setShowTitle(true);
 		$form->setDescription('');
 		$form->setAccess([
 			'permitAllUsers' => false,

--- a/lib/Controller/ApiController.php
+++ b/lib/Controller/ApiController.php
@@ -262,14 +262,12 @@ class ApiController extends OCSController {
 		$form->setHash($this->formsService->generateFormHash());
 		$form->setShowHeader(true);
 		$form->setTitle('');
-		$form->setShowTitle(true);
 		$form->setDescription('');
 		$form->setAccess([
 			'permitAllUsers' => false,
 			'showToAllUsers' => false,
 		]);
 		$form->setSubmitMultiple(false);
-		$form->setShowDescription(true);
 		$form->setShowExpiration(false);
 		$form->setExpires(0);
 		$form->setIsAnonymous(false);

--- a/lib/Controller/ApiController.php
+++ b/lib/Controller/ApiController.php
@@ -260,6 +260,7 @@ class ApiController extends OCSController {
 		$form->setOwnerId($this->currentUser->getUID());
 		$form->setCreated(time());
 		$form->setHash($this->formsService->generateFormHash());
+		$form->setShowHeader(true);
 		$form->setTitle('');
 		$form->setShowTitle(true);
 		$form->setDescription('');

--- a/lib/Controller/ApiController.php
+++ b/lib/Controller/ApiController.php
@@ -7,6 +7,7 @@
  * @author John Molakvoæ (skjnldsv) <skjnldsv@protonmail.com>
  * @author Jonas Rittershofer <jotoeri@users.noreply.github.com>
  * @author Roeland Jago Douma <roeland@famdouma.nl>
+ * @author Vitor Mattos <vitor@php.rio>
  *
  * @license AGPL-3.0-or-later
  *
@@ -266,6 +267,7 @@ class ApiController extends OCSController {
 			'showToAllUsers' => false,
 		]);
 		$form->setSubmitMultiple(false);
+		$form->setShowDescription(true);
 		$form->setShowExpiration(false);
 		$form->setExpires(0);
 		$form->setIsAnonymous(false);

--- a/lib/Db/Form.php
+++ b/lib/Db/Form.php
@@ -7,6 +7,7 @@ declare(strict_types=1);
  *
  * @author affan98 <affan98@gmail.com>
  * @author Jonas Rittershofer <jotoeri@users.noreply.github.com>
+ * @author Vitor Mattos <vitor@php.rio>
  *
  * @license AGPL-3.0-or-later
  *
@@ -48,6 +49,8 @@ use OCP\AppFramework\Db\Entity;
  * @method void setIsAnonymous(bool $value)
  * @method integer getSubmitMultiple()
  * @method void setSubmitMultiple(bool $value)
+ * @method integer getShowDescription()
+ * @method void setShowDescription(bool $value)
  * @method integer getShowExpiration()
  * @method void setShowExpiration(bool $value)
  * @method integer getLastUpdated()
@@ -63,6 +66,7 @@ class Form extends Entity {
 	protected $expires;
 	protected $isAnonymous;
 	protected $submitMultiple;
+	protected $showDescription;
 	protected $showExpiration;
 	protected $lastUpdated;
 
@@ -74,6 +78,7 @@ class Form extends Entity {
 		$this->addType('expires', 'integer');
 		$this->addType('isAnonymous', 'bool');
 		$this->addType('submitMultiple', 'bool');
+		$this->addType('showDescription', 'bool');
 		$this->addType('showExpiration', 'bool');
 		$this->addType('lastUpdated', 'integer');
 	}
@@ -101,6 +106,7 @@ class Form extends Entity {
 			'expires' => (int)$this->getExpires(),
 			'isAnonymous' => (bool)$this->getIsAnonymous(),
 			'submitMultiple' => (bool)$this->getSubmitMultiple(),
+			'showDescription' => (bool)$this->getShowDescription(),
 			'showExpiration' => (bool)$this->getShowExpiration(),
 			'lastUpdated' => (int)$this->getLastUpdated()
 		];

--- a/lib/Db/Form.php
+++ b/lib/Db/Form.php
@@ -35,6 +35,8 @@ use OCP\AppFramework\Db\Entity;
  * @method void setHash(string $value)
  * @method string getTitle()
  * @method void setTitle(string $value)
+ * @method integer getShowTitle()
+ * @method void setShowTitle(bool $value)
  * @method string getDescription()
  * @method void setDescription(string $value)
  * @method string getOwnerId()
@@ -59,6 +61,7 @@ use OCP\AppFramework\Db\Entity;
 class Form extends Entity {
 	protected $hash;
 	protected $title;
+	protected $showTitle;
 	protected $description;
 	protected $ownerId;
 	protected $accessJson;
@@ -78,6 +81,7 @@ class Form extends Entity {
 		$this->addType('expires', 'integer');
 		$this->addType('isAnonymous', 'bool');
 		$this->addType('submitMultiple', 'bool');
+		$this->addType('showTitle', 'bool');
 		$this->addType('showDescription', 'bool');
 		$this->addType('showExpiration', 'bool');
 		$this->addType('lastUpdated', 'integer');
@@ -99,6 +103,7 @@ class Form extends Entity {
 			'id' => $this->getId(),
 			'hash' => $this->getHash(),
 			'title' => (string)$this->getTitle(),
+			'showTitle' => (bool)$this->getShowTitle(),
 			'description' => (string)$this->getDescription(),
 			'ownerId' => $this->getOwnerId(),
 			'created' => $this->getCreated(),

--- a/lib/Db/Form.php
+++ b/lib/Db/Form.php
@@ -37,8 +37,6 @@ use OCP\AppFramework\Db\Entity;
  * @method void setShowHeader(bool $value)
  * @method string getTitle()
  * @method void setTitle(string $value)
- * @method integer getShowTitle()
- * @method void setShowTitle(bool $value)
  * @method string getDescription()
  * @method void setDescription(string $value)
  * @method string getOwnerId()
@@ -53,8 +51,6 @@ use OCP\AppFramework\Db\Entity;
  * @method void setIsAnonymous(bool $value)
  * @method integer getSubmitMultiple()
  * @method void setSubmitMultiple(bool $value)
- * @method integer getShowDescription()
- * @method void setShowDescription(bool $value)
  * @method integer getShowExpiration()
  * @method void setShowExpiration(bool $value)
  * @method integer getLastUpdated()
@@ -64,7 +60,6 @@ class Form extends Entity {
 	protected $hash;
 	protected $showHeader;
 	protected $title;
-	protected $showTitle;
 	protected $description;
 	protected $ownerId;
 	protected $accessJson;
@@ -72,7 +67,6 @@ class Form extends Entity {
 	protected $expires;
 	protected $isAnonymous;
 	protected $submitMultiple;
-	protected $showDescription;
 	protected $showExpiration;
 	protected $lastUpdated;
 
@@ -85,8 +79,6 @@ class Form extends Entity {
 		$this->addType('isAnonymous', 'bool');
 		$this->addType('submitMultiple', 'bool');
 		$this->addType('showHeader', 'bool');
-		$this->addType('showTitle', 'bool');
-		$this->addType('showDescription', 'bool');
 		$this->addType('showExpiration', 'bool');
 		$this->addType('lastUpdated', 'integer');
 	}
@@ -108,7 +100,6 @@ class Form extends Entity {
 			'hash' => $this->getHash(),
 			'showHeader' => (bool)$this->getShowHeader(),
 			'title' => (string)$this->getTitle(),
-			'showTitle' => (bool)$this->getShowTitle(),
 			'description' => (string)$this->getDescription(),
 			'ownerId' => $this->getOwnerId(),
 			'created' => $this->getCreated(),
@@ -116,7 +107,6 @@ class Form extends Entity {
 			'expires' => (int)$this->getExpires(),
 			'isAnonymous' => (bool)$this->getIsAnonymous(),
 			'submitMultiple' => (bool)$this->getSubmitMultiple(),
-			'showDescription' => (bool)$this->getShowDescription(),
 			'showExpiration' => (bool)$this->getShowExpiration(),
 			'lastUpdated' => (int)$this->getLastUpdated()
 		];

--- a/lib/Db/Form.php
+++ b/lib/Db/Form.php
@@ -33,6 +33,8 @@ use OCP\AppFramework\Db\Entity;
 /**
  * @method string getHash()
  * @method void setHash(string $value)
+ * @method integer getShowHeader()
+ * @method void setShowHeader(bool $value)
  * @method string getTitle()
  * @method void setTitle(string $value)
  * @method integer getShowTitle()
@@ -60,6 +62,7 @@ use OCP\AppFramework\Db\Entity;
  */
 class Form extends Entity {
 	protected $hash;
+	protected $showHeader;
 	protected $title;
 	protected $showTitle;
 	protected $description;
@@ -81,6 +84,7 @@ class Form extends Entity {
 		$this->addType('expires', 'integer');
 		$this->addType('isAnonymous', 'bool');
 		$this->addType('submitMultiple', 'bool');
+		$this->addType('showHeader', 'bool');
 		$this->addType('showTitle', 'bool');
 		$this->addType('showDescription', 'bool');
 		$this->addType('showExpiration', 'bool');
@@ -102,6 +106,7 @@ class Form extends Entity {
 		return [
 			'id' => $this->getId(),
 			'hash' => $this->getHash(),
+			'showHeader' => (bool)$this->getShowHeader(),
 			'title' => (string)$this->getTitle(),
 			'showTitle' => (bool)$this->getShowTitle(),
 			'description' => (string)$this->getDescription(),

--- a/lib/FormsMigrator.php
+++ b/lib/FormsMigrator.php
@@ -6,6 +6,7 @@ declare(strict_types=1);
  * @copyright Copyright (c) 2022 Jonas Rittershofer <jotoeri@users.noreply.github.com>
  *
  * @author Jonas Rittershofer <jotoeri@users.noreply.github.com>
+ * @author Vitor Mattos <vitor@php.rio>
  *
  * @license AGPL-3.0-or-later
  *
@@ -198,6 +199,7 @@ class FormsMigrator implements IMigrator {
 				$form->setExpires($formData['expires']);
 				$form->setIsAnonymous($formData['isAnonymous']);
 				$form->setSubmitMultiple($formData['submitMultiple']);
+				$form->setShowDescription($formData['showDescription']);
 				$form->setShowExpiration($formData['showExpiration']);
 				$form->setLastUpdated($formData['lastUpdated']);
 

--- a/lib/FormsMigrator.php
+++ b/lib/FormsMigrator.php
@@ -193,7 +193,6 @@ class FormsMigrator implements IMigrator {
 				$form->setHash($this->formsService->generateFormHash());
 				$form->setShowHeader($formData['showHeader']);
 				$form->setTitle($formData['title']);
-				$form->setShowTitle($formData['showTitle']);
 				$form->setDescription($formData['description']);
 				$form->setOwnerId($user->getUID());
 				$form->setCreated($formData['created']);
@@ -201,7 +200,6 @@ class FormsMigrator implements IMigrator {
 				$form->setExpires($formData['expires']);
 				$form->setIsAnonymous($formData['isAnonymous']);
 				$form->setSubmitMultiple($formData['submitMultiple']);
-				$form->setShowDescription($formData['showDescription']);
 				$form->setShowExpiration($formData['showExpiration']);
 				$form->setLastUpdated($formData['lastUpdated']);
 

--- a/lib/FormsMigrator.php
+++ b/lib/FormsMigrator.php
@@ -192,6 +192,7 @@ class FormsMigrator implements IMigrator {
 				$form = new Form();
 				$form->setHash($this->formsService->generateFormHash());
 				$form->setTitle($formData['title']);
+				$form->setShowTitle($formData['showTitle']);
 				$form->setDescription($formData['description']);
 				$form->setOwnerId($user->getUID());
 				$form->setCreated($formData['created']);

--- a/lib/FormsMigrator.php
+++ b/lib/FormsMigrator.php
@@ -191,6 +191,7 @@ class FormsMigrator implements IMigrator {
 			foreach ($data as $formData) {
 				$form = new Form();
 				$form->setHash($this->formsService->generateFormHash());
+				$form->setShowHeader($formData['showHeader']);
 				$form->setTitle($formData['title']);
 				$form->setShowTitle($formData['showTitle']);
 				$form->setDescription($formData['description']);

--- a/lib/Migration/Version030400Date20230824191746.php
+++ b/lib/Migration/Version030400Date20230824191746.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright Copyright (c) 2023 Vitor Mattos <vitor@php.rio>
+ *
+ * @author Vitor Mattos <vitor@php.rio>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Forms\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\DB\Types;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+/**
+ * Auto-generated migration step: Please modify to your needs!
+ */
+class Version030400Date20230824191746 extends SimpleMigrationStep {
+
+	/**
+	 * @param IOutput $output
+	 * @param Closure(): ISchemaWrapper $schemaClosure
+	 * @param array $options
+	 * @return null|ISchemaWrapper
+	 */
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
+		/** @var ISchemaWrapper $schema */
+		$schema = $schemaClosure();
+		$table = $schema->getTable('forms_v2_forms');
+
+		if (!$table->hasColumn('show_description')) {
+			$table->addColumn('show_description', Types::BOOLEAN, [
+				'notnull' => false,
+				'default' => 1,
+			]);
+
+			return $schema;
+		}
+
+		return null;
+	}
+}

--- a/lib/Migration/Version030400Date20230824191746.php
+++ b/lib/Migration/Version030400Date20230824191746.php
@@ -56,20 +56,6 @@ class Version030400Date20230824191746 extends SimpleMigrationStep {
 			]);
 			$changed = true;
 		}
-		if (!$table->hasColumn('show_title')) {
-			$table->addColumn('show_title', Types::BOOLEAN, [
-				'notnull' => false,
-				'default' => 1,
-			]);
-			$changed = true;
-		}
-		if (!$table->hasColumn('show_description')) {
-			$table->addColumn('show_description', Types::BOOLEAN, [
-				'notnull' => false,
-				'default' => 1,
-			]);
-			$changed = true;
-		}
 		if ($changed) {
 			return $schema;
 		}

--- a/lib/Migration/Version030400Date20230824191746.php
+++ b/lib/Migration/Version030400Date20230824191746.php
@@ -49,6 +49,13 @@ class Version030400Date20230824191746 extends SimpleMigrationStep {
 		$table = $schema->getTable('forms_v2_forms');
 
 		$changed = false;
+		if (!$table->hasColumn('show_header')) {
+			$table->addColumn('show_header', Types::BOOLEAN, [
+				'notnull' => false,
+				'default' => 1,
+			]);
+			$changed = true;
+		}
 		if (!$table->hasColumn('show_title')) {
 			$table->addColumn('show_title', Types::BOOLEAN, [
 				'notnull' => false,

--- a/lib/Migration/Version030400Date20230824191746.php
+++ b/lib/Migration/Version030400Date20230824191746.php
@@ -48,12 +48,22 @@ class Version030400Date20230824191746 extends SimpleMigrationStep {
 		$schema = $schemaClosure();
 		$table = $schema->getTable('forms_v2_forms');
 
+		$changed = false;
+		if (!$table->hasColumn('show_title')) {
+			$table->addColumn('show_title', Types::BOOLEAN, [
+				'notnull' => false,
+				'default' => 1,
+			]);
+			$changed = true;
+		}
 		if (!$table->hasColumn('show_description')) {
 			$table->addColumn('show_description', Types::BOOLEAN, [
 				'notnull' => false,
 				'default' => 1,
 			]);
-
+			$changed = true;
+		}
+		if ($changed) {
 			return $schema;
 		}
 

--- a/src/components/SidebarTabs/SettingsSidebarTab.vue
+++ b/src/components/SidebarTabs/SettingsSidebarTab.vue
@@ -42,18 +42,6 @@
 			@update:checked="onShowHeaderChange">
 			{{ t('forms', 'Show header of form') }}
 		</NcCheckboxRadioSwitch>
-		<div v-show="showHeader" class="settings-div--indent">
-			<NcCheckboxRadioSwitch :checked="form.showTitle"
-				type="switch"
-				@update:checked="onShowTitleChange">
-				{{ t('forms', 'Show title of form') }}
-			</NcCheckboxRadioSwitch>
-			<NcCheckboxRadioSwitch :checked="form.showDescription"
-				type="switch"
-				@update:checked="onShowDescriptionChange">
-				{{ t('forms', 'Show description of form') }}
-			</NcCheckboxRadioSwitch>
-		</div>
 		<NcCheckboxRadioSwitch :checked="formExpires"
 			type="switch"
 			@update:checked="onFormExpiresChange">
@@ -133,9 +121,6 @@ export default {
 		submitMultiple() {
 			return this.disableSubmitMultiple || this.form.submitMultiple
 		},
-		showHeader() {
-			return this.form.showHeader
-		},
 		formExpires() {
 			return this.form.expires !== 0
 		},
@@ -168,12 +153,6 @@ export default {
 		},
 		onShowHeaderChange(checked) {
 			this.$emit('update:formProp', 'showHeader', checked)
-		},
-		onShowTitleChange(checked) {
-			this.$emit('update:formProp', 'showTitle', checked)
-		},
-		onShowDescriptionChange(checked) {
-			this.$emit('update:formProp', 'showDescription', checked)
 		},
 		onShowExpirationChange(checked) {
 			this.$emit('update:formProp', 'showExpiration', checked)

--- a/src/components/SidebarTabs/SettingsSidebarTab.vue
+++ b/src/components/SidebarTabs/SettingsSidebarTab.vue
@@ -3,6 +3,7 @@
   -
   - @author John Molakvoæ <skjnldsv@protonmail.com>
   - @author Jonas Rittershofer <jotoeri@users.noreply.github.com>
+  - @author Vitor Mattos <vitor@php.rio>
   -
   - @license AGPL-3.0-or-later
   -
@@ -40,6 +41,11 @@
 			type="switch"
 			@update:checked="onFormExpiresChange">
 			{{ t('forms', 'Set expiration date') }}
+		</NcCheckboxRadioSwitch>
+		<NcCheckboxRadioSwitch :checked="form.showDescription"
+			type="switch"
+			@update:checked="onShowDescriptionChange">
+			{{ t('forms', 'Show description of form') }}
 		</NcCheckboxRadioSwitch>
 		<div v-show="formExpires" class="settings-div--indent">
 			<NcDatetimePicker id="expiresDatetimePicker"
@@ -145,6 +151,9 @@ export default {
 			} else {
 				this.$emit('update:formProp', 'expires', 0)
 			}
+		},
+		onShowDescriptionChange(checked) {
+			this.$emit('update:formProp', 'showDescription', checked)
 		},
 		onShowExpirationChange(checked) {
 			this.$emit('update:formProp', 'showExpiration', checked)

--- a/src/components/SidebarTabs/SettingsSidebarTab.vue
+++ b/src/components/SidebarTabs/SettingsSidebarTab.vue
@@ -37,20 +37,27 @@
 			@update:checked="onSubmitMultipleChange">
 			{{ t('forms', 'Allow multiple responses per person') }}
 		</NcCheckboxRadioSwitch>
+		<NcCheckboxRadioSwitch :checked="form.showHeader"
+			type="switch"
+			@update:checked="onShowHeaderChange">
+			{{ t('forms', 'Show header of form') }}
+		</NcCheckboxRadioSwitch>
+		<div v-show="showHeader" class="settings-div--indent">
+			<NcCheckboxRadioSwitch :checked="form.showTitle"
+				type="switch"
+				@update:checked="onShowTitleChange">
+				{{ t('forms', 'Show title of form') }}
+			</NcCheckboxRadioSwitch>
+			<NcCheckboxRadioSwitch :checked="form.showDescription"
+				type="switch"
+				@update:checked="onShowDescriptionChange">
+				{{ t('forms', 'Show description of form') }}
+			</NcCheckboxRadioSwitch>
+		</div>
 		<NcCheckboxRadioSwitch :checked="formExpires"
 			type="switch"
 			@update:checked="onFormExpiresChange">
 			{{ t('forms', 'Set expiration date') }}
-		</NcCheckboxRadioSwitch>
-		<NcCheckboxRadioSwitch :checked="form.showTitle"
-			type="switch"
-			@update:checked="onShowTitleChange">
-			{{ t('forms', 'Show title of form') }}
-		</NcCheckboxRadioSwitch>
-		<NcCheckboxRadioSwitch :checked="form.showDescription"
-			type="switch"
-			@update:checked="onShowDescriptionChange">
-			{{ t('forms', 'Show description of form') }}
 		</NcCheckboxRadioSwitch>
 		<div v-show="formExpires" class="settings-div--indent">
 			<NcDatetimePicker id="expiresDatetimePicker"
@@ -126,7 +133,9 @@ export default {
 		submitMultiple() {
 			return this.disableSubmitMultiple || this.form.submitMultiple
 		},
-
+		showHeader() {
+			return this.form.showHeader
+		},
 		formExpires() {
 			return this.form.expires !== 0
 		},
@@ -156,6 +165,9 @@ export default {
 			} else {
 				this.$emit('update:formProp', 'expires', 0)
 			}
+		},
+		onShowHeaderChange(checked) {
+			this.$emit('update:formProp', 'showHeader', checked)
 		},
 		onShowTitleChange(checked) {
 			this.$emit('update:formProp', 'showTitle', checked)

--- a/src/components/SidebarTabs/SettingsSidebarTab.vue
+++ b/src/components/SidebarTabs/SettingsSidebarTab.vue
@@ -42,6 +42,11 @@
 			@update:checked="onFormExpiresChange">
 			{{ t('forms', 'Set expiration date') }}
 		</NcCheckboxRadioSwitch>
+		<NcCheckboxRadioSwitch :checked="form.showTitle"
+			type="switch"
+			@update:checked="onShowTitleChange">
+			{{ t('forms', 'Show title of form') }}
+		</NcCheckboxRadioSwitch>
 		<NcCheckboxRadioSwitch :checked="form.showDescription"
 			type="switch"
 			@update:checked="onShowDescriptionChange">
@@ -151,6 +156,9 @@ export default {
 			} else {
 				this.$emit('update:formProp', 'expires', 0)
 			}
+		},
+		onShowTitleChange(checked) {
+			this.$emit('update:formProp', 'showTitle', checked)
 		},
 		onShowDescriptionChange(checked) {
 			this.$emit('update:formProp', 'showDescription', checked)

--- a/src/views/Submit.vue
+++ b/src/views/Submit.vue
@@ -2,6 +2,7 @@
  - @copyright Copyright (c) 2020 John Molakvoæ <skjnldsv@protonmail.com>
  -
  - @author John Molakvoæ <skjnldsv@protonmail.com>
+ - @author Vitor Mattos <vitor@php.rio>
  -
  - @license AGPL-3.0-or-later
  -
@@ -42,7 +43,7 @@
 				{{ formTitle }}
 			</h2>
 			<!-- eslint-disable vue/no-v-html -->
-			<div v-if="!loading && !success && !!formDescription"
+			<div v-if="form.showDescription && !loading && !success && !!formDescription"
 				class="form-desc"
 				dir="auto"
 				v-html="formDescription" />

--- a/src/views/Submit.vue
+++ b/src/views/Submit.vue
@@ -38,7 +38,7 @@
 			@share-form="onShareForm" />
 
 		<!-- Forms title & description-->
-		<header>
+		<header v-if="form.showHeader">
 			<h2 v-if="form.showTitle" ref="title" class="form-title" dir="auto">
 				{{ formTitle }}
 			</h2>

--- a/src/views/Submit.vue
+++ b/src/views/Submit.vue
@@ -39,7 +39,7 @@
 
 		<!-- Forms title & description-->
 		<header>
-			<h2 ref="title" class="form-title" dir="auto">
+			<h2 v-if="form.showTitle" ref="title" class="form-title" dir="auto">
 				{{ formTitle }}
 			</h2>
 			<!-- eslint-disable vue/no-v-html -->

--- a/src/views/Submit.vue
+++ b/src/views/Submit.vue
@@ -39,11 +39,11 @@
 
 		<!-- Forms title & description-->
 		<header v-if="form.showHeader">
-			<h2 v-if="form.showTitle" ref="title" class="form-title" dir="auto">
+			<h2 ref="title" class="form-title" dir="auto">
 				{{ formTitle }}
 			</h2>
 			<!-- eslint-disable vue/no-v-html -->
-			<div v-if="form.showDescription && !loading && !success && !!formDescription"
+			<div v-if="!loading && !success && !!formDescription"
 				class="form-desc"
 				dir="auto"
 				v-html="formDescription" />

--- a/tests/Integration/Api/ApiV2Test.php
+++ b/tests/Integration/Api/ApiV2Test.php
@@ -457,6 +457,7 @@ class ApiV2Test extends TestCase {
 			'getNewForm' => [
 				'expected' => [
 					// 'hash' => Some random, cannot be checked.
+					'showHeader' => true,
 					'title' => '',
 					'showTitle' => true,
 					'description' => '',
@@ -514,6 +515,7 @@ class ApiV2Test extends TestCase {
 			'getFullForm' => [
 				'expected' => [
 					'hash' => 'abcdefg',
+					'showHeader' => true,
 					'title' => 'Title of a Form',
 					'showTitle' => true,
 					'description' => 'Just a simple form.',

--- a/tests/Integration/Api/ApiV2Test.php
+++ b/tests/Integration/Api/ApiV2Test.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
  * @copyright Copyright (c) 2022 Jonas Rittershofer <jotoeri@users.noreply.github.com>
  *
  * @author Jonas Rittershofer <jotoeri@users.noreply.github.com>
+ * @author Vitor Mattos <vitor@php.rio>
  *
  * @license AGPL-3.0-or-later
  *
@@ -62,6 +63,7 @@ class ApiV2Test extends TestCase {
 				'expires' => 0,
 				'is_anonymous' => false,
 				'submit_multiple' => false,
+				'show_description' => true,
 				'show_expiration' => false,
 				'last_updated' => 123456789,
 				'questions' => [
@@ -164,6 +166,7 @@ class ApiV2Test extends TestCase {
 				'expires' => 0,
 				'is_anonymous' => false,
 				'submit_multiple' => false,
+				'show_description' => true,
 				'show_expiration' => false,
 				'last_updated' => 123456789,
 				'questions' => [
@@ -212,6 +215,7 @@ class ApiV2Test extends TestCase {
 					'expires' => $qb->createNamedParameter($form['expires'], IQueryBuilder::PARAM_INT),
 					'is_anonymous' => $qb->createNamedParameter($form['is_anonymous'], IQueryBuilder::PARAM_BOOL),
 					'submit_multiple' => $qb->createNamedParameter($form['submit_multiple'], IQueryBuilder::PARAM_BOOL),
+					'show_description' => $qb->createNamedParameter($form['show_description'], IQueryBuilder::PARAM_BOOL),
 					'show_expiration' => $qb->createNamedParameter($form['show_expiration'], IQueryBuilder::PARAM_BOOL),
 					'last_updated' => $qb->createNamedParameter($form['last_updated'], IQueryBuilder::PARAM_INT),
 				]);
@@ -464,6 +468,7 @@ class ApiV2Test extends TestCase {
 					'expires' => 0,
 					'isAnonymous' => false,
 					'submitMultiple' => false,
+					'showDescription' => true,
 					'showExpiration' => false,
 					// 'lastUpdated' => time() can not be checked exactly
 					'canSubmit' => true,
@@ -519,6 +524,7 @@ class ApiV2Test extends TestCase {
 					'expires' => 0,
 					'isAnonymous' => false,
 					'submitMultiple' => false,
+					'showDescription' => true,
 					'showExpiration' => false,
 					'lastUpdated' => 123456789,
 					'canSubmit' => true,

--- a/tests/Integration/Api/ApiV2Test.php
+++ b/tests/Integration/Api/ApiV2Test.php
@@ -458,6 +458,7 @@ class ApiV2Test extends TestCase {
 				'expected' => [
 					// 'hash' => Some random, cannot be checked.
 					'title' => '',
+					'showTitle' => true,
 					'description' => '',
 					'ownerId' => 'test',
 					// 'created' => time() can not be checked exactly
@@ -514,6 +515,7 @@ class ApiV2Test extends TestCase {
 				'expected' => [
 					'hash' => 'abcdefg',
 					'title' => 'Title of a Form',
+					'showTitle' => true,
 					'description' => 'Just a simple form.',
 					'ownerId' => 'test',
 					'created' => 12345,

--- a/tests/Integration/Api/ApiV2Test.php
+++ b/tests/Integration/Api/ApiV2Test.php
@@ -52,6 +52,7 @@ class ApiV2Test extends TestCase {
 		$this->testForms = [
 			[
 				'hash' => 'abcdefg',
+				'show_header' => true,
 				'title' => 'Title of a Form',
 				'description' => 'Just a simple form.',
 				'owner_id' => 'test',
@@ -63,7 +64,6 @@ class ApiV2Test extends TestCase {
 				'expires' => 0,
 				'is_anonymous' => false,
 				'submit_multiple' => false,
-				'show_description' => true,
 				'show_expiration' => false,
 				'last_updated' => 123456789,
 				'questions' => [
@@ -155,6 +155,7 @@ class ApiV2Test extends TestCase {
 			],
 			[
 				'hash' => 'abcdefghij',
+				'show_header' => true,
 				'title' => 'Title of a second Form',
 				'description' => '',
 				'owner_id' => 'someUser',
@@ -166,7 +167,6 @@ class ApiV2Test extends TestCase {
 				'expires' => 0,
 				'is_anonymous' => false,
 				'submit_multiple' => false,
-				'show_description' => true,
 				'show_expiration' => false,
 				'last_updated' => 123456789,
 				'questions' => [
@@ -207,6 +207,7 @@ class ApiV2Test extends TestCase {
 			$qb->insert('forms_v2_forms')
 				->values([
 					'hash' => $qb->createNamedParameter($form['hash'], IQueryBuilder::PARAM_STR),
+					'show_header' => $qb->createNamedParameter($form['show_header'], IQueryBuilder::PARAM_BOOL),
 					'title' => $qb->createNamedParameter($form['title'], IQueryBuilder::PARAM_STR),
 					'description' => $qb->createNamedParameter($form['description'], IQueryBuilder::PARAM_STR),
 					'owner_id' => $qb->createNamedParameter($form['owner_id'], IQueryBuilder::PARAM_STR),
@@ -215,7 +216,6 @@ class ApiV2Test extends TestCase {
 					'expires' => $qb->createNamedParameter($form['expires'], IQueryBuilder::PARAM_INT),
 					'is_anonymous' => $qb->createNamedParameter($form['is_anonymous'], IQueryBuilder::PARAM_BOOL),
 					'submit_multiple' => $qb->createNamedParameter($form['submit_multiple'], IQueryBuilder::PARAM_BOOL),
-					'show_description' => $qb->createNamedParameter($form['show_description'], IQueryBuilder::PARAM_BOOL),
 					'show_expiration' => $qb->createNamedParameter($form['show_expiration'], IQueryBuilder::PARAM_BOOL),
 					'last_updated' => $qb->createNamedParameter($form['last_updated'], IQueryBuilder::PARAM_INT),
 				]);
@@ -459,7 +459,6 @@ class ApiV2Test extends TestCase {
 					// 'hash' => Some random, cannot be checked.
 					'showHeader' => true,
 					'title' => '',
-					'showTitle' => true,
 					'description' => '',
 					'ownerId' => 'test',
 					// 'created' => time() can not be checked exactly
@@ -470,7 +469,6 @@ class ApiV2Test extends TestCase {
 					'expires' => 0,
 					'isAnonymous' => false,
 					'submitMultiple' => false,
-					'showDescription' => true,
 					'showExpiration' => false,
 					// 'lastUpdated' => time() can not be checked exactly
 					'canSubmit' => true,
@@ -517,7 +515,6 @@ class ApiV2Test extends TestCase {
 					'hash' => 'abcdefg',
 					'showHeader' => true,
 					'title' => 'Title of a Form',
-					'showTitle' => true,
 					'description' => 'Just a simple form.',
 					'ownerId' => 'test',
 					'created' => 12345,
@@ -528,7 +525,6 @@ class ApiV2Test extends TestCase {
 					'expires' => 0,
 					'isAnonymous' => false,
 					'submitMultiple' => false,
-					'showDescription' => true,
 					'showExpiration' => false,
 					'lastUpdated' => 123456789,
 					'canSubmit' => true,

--- a/tests/Unit/Controller/ApiControllerTest.php
+++ b/tests/Unit/Controller/ApiControllerTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
  * @copyright Copyright (c) 2023 Ferdinand Thiessen <rpm@fthiessen.de>
  *
  * @author Ferdinand Thiessen <rpm@fthiessen.de>
+ * @author Vitor Mattos <vitor@php.rio>
  *
  * @license AGPL-3.0-or-later
  *
@@ -358,6 +359,7 @@ class ApiControllerTest extends TestCase {
 				'expires' => 0,
 				'isAnonymous' => false,
 				'submitMultiple' => false,
+				'showDescription' => true,
 				'showExpiration' => false,
 				'lastUpdated' => 123456789
 			]]
@@ -470,6 +472,7 @@ class ApiControllerTest extends TestCase {
 					'expires' => 0,
 					'isAnonymous' => false,
 					'submitMultiple' => false,
+					'showDescription' => false,
 					'showExpiration' => false
 				],
 				'new' => [
@@ -485,6 +488,7 @@ class ApiControllerTest extends TestCase {
 					'expires' => 0,
 					'isAnonymous' => false,
 					'submitMultiple' => false,
+					'showDescription' => false,
 					'showExpiration' => false
 				]
 			]

--- a/tests/Unit/Controller/ApiControllerTest.php
+++ b/tests/Unit/Controller/ApiControllerTest.php
@@ -351,7 +351,6 @@ class ApiControllerTest extends TestCase {
 				'hash' => 'formHash',
 				'showHeader' => true,
 				'title' => '',
-				'showTitle' => true,
 				'description' => '',
 				'ownerId' => 'currentUser',
 				'access' => [
@@ -361,7 +360,6 @@ class ApiControllerTest extends TestCase {
 				'expires' => 0,
 				'isAnonymous' => false,
 				'submitMultiple' => false,
-				'showDescription' => true,
 				'showExpiration' => false,
 				'lastUpdated' => 123456789
 			]]
@@ -464,7 +462,6 @@ class ApiControllerTest extends TestCase {
 					'id' => 7,
 					'showHeader' => true,
 					'title' => '',
-					'showTitle' => true,
 					'hash' => 'old hash',
 					'created' => null,
 					'access' => [
@@ -476,14 +473,12 @@ class ApiControllerTest extends TestCase {
 					'expires' => 0,
 					'isAnonymous' => false,
 					'submitMultiple' => false,
-					'showDescription' => false,
 					'showExpiration' => false
 				],
 				'new' => [
-					'id' => 14,,
+					'id' => 14,
 					'showHeader' => true,
 					'title' => ' - Copy',
-					'showTitle' => true,
 					'hash' => 'new hash',
 					'access' => [
 						'permitAllUsers' => false,
@@ -494,7 +489,6 @@ class ApiControllerTest extends TestCase {
 					'expires' => 0,
 					'isAnonymous' => false,
 					'submitMultiple' => false,
-					'showDescription' => false,
 					'showExpiration' => false
 				]
 			]

--- a/tests/Unit/Controller/ApiControllerTest.php
+++ b/tests/Unit/Controller/ApiControllerTest.php
@@ -350,6 +350,7 @@ class ApiControllerTest extends TestCase {
 				'id' => 7,
 				'hash' => 'formHash',
 				'title' => '',
+				'showTitle' => true,
 				'description' => '',
 				'ownerId' => 'currentUser',
 				'access' => [
@@ -461,6 +462,7 @@ class ApiControllerTest extends TestCase {
 				'old' => [
 					'id' => 7,
 					'title' => '',
+					'showTitle' => true,
 					'hash' => 'old hash',
 					'created' => null,
 					'access' => [
@@ -478,6 +480,7 @@ class ApiControllerTest extends TestCase {
 				'new' => [
 					'id' => 14,
 					'title' => ' - Copy',
+					'showTitle' => true,
 					'hash' => 'new hash',
 					'access' => [
 						'permitAllUsers' => false,

--- a/tests/Unit/Controller/ApiControllerTest.php
+++ b/tests/Unit/Controller/ApiControllerTest.php
@@ -203,7 +203,7 @@ class ApiControllerTest extends TestCase {
 			->method('findByHash')
 			->with('hash')
 			->willReturn($form);
-	
+
 		$this->formsService->expects(($this->once()))
 			->method('canSeeResults')
 			->with(1)
@@ -261,7 +261,7 @@ class ApiControllerTest extends TestCase {
 			->method('findByHash')
 			->with('hash')
 			->willReturn($form);
-	
+
 		$this->formsService->expects(($this->once()))
 			->method('canSeeResults')
 			->with(1)
@@ -276,7 +276,7 @@ class ApiControllerTest extends TestCase {
 			->method('getQuestions')
 			->with(1)
 			->willReturn($questions);
-	
+
 		$this->assertEquals(new DataResponse($expected), $this->apiController->getSubmissions('hash'));
 	}
 
@@ -300,7 +300,7 @@ class ApiControllerTest extends TestCase {
 			->method('findByHash')
 			->with('hash')
 			->willReturn($form);
-	
+
 		$this->formsService->expects(($this->once()))
 			->method('canSeeResults')
 			->with(1)
@@ -320,7 +320,7 @@ class ApiControllerTest extends TestCase {
 			->method('findByHash')
 			->with('hash')
 			->willReturn($form);
-	
+
 		$this->formsService->expects(($this->once()))
 			->method('canSeeResults')
 			->with(1)
@@ -349,6 +349,7 @@ class ApiControllerTest extends TestCase {
 			"forms" => ['expectedForm' => [
 				'id' => 7,
 				'hash' => 'formHash',
+				'showHeader' => true,
 				'title' => '',
 				'showTitle' => true,
 				'description' => '',
@@ -461,6 +462,7 @@ class ApiControllerTest extends TestCase {
 			'works' => [
 				'old' => [
 					'id' => 7,
+					'showHeader' => true,
 					'title' => '',
 					'showTitle' => true,
 					'hash' => 'old hash',
@@ -478,7 +480,8 @@ class ApiControllerTest extends TestCase {
 					'showExpiration' => false
 				],
 				'new' => [
-					'id' => 14,
+					'id' => 14,,
+					'showHeader' => true,
 					'title' => ' - Copy',
 					'showTitle' => true,
 					'hash' => 'new hash',

--- a/tests/Unit/FormsMigratorTest.php
+++ b/tests/Unit/FormsMigratorTest.php
@@ -115,7 +115,7 @@ class FormsMigratorTest extends TestCase {
 	public function dataExport() {
 		return [
 			'exactlyOneOfEach' => [
-				'expectedJson' => '[{"showHeader":true,"title":"Link","showTitle":true,"description":"","created":1646251830,"access":{"permitAllUsers":false,"showToAllUsers":false},"expires":0,"isAnonymous":false,"submitMultiple":false,"showDescription":true,"showExpiration":false,"lastUpdated":123456789,"questions":[{"id":14,"order":2,"type":"multiple","isRequired":false,"text":"checkbox","description":"huhu","extraSettings":{},"options":[{"text":"ans1"}]}],"submissions":[{"userId":"anyUser@localhost","timestamp":1651354059,"answers":[{"questionId":14,"text":"ans1"}]}]}]'
+				'expectedJson' => '[{"showHeader":true,"title":"Link","description":"","created":1646251830,"access":{"permitAllUsers":false,"showToAllUsers":false},"expires":0,"isAnonymous":false,"submitMultiple":false,"showExpiration":false,"lastUpdated":123456789,"questions":[{"id":14,"order":2,"type":"multiple","isRequired":false,"text":"checkbox","description":"huhu","extraSettings":{},"options":[{"text":"ans1"}]}],"submissions":[{"userId":"anyUser@localhost","timestamp":1651354059,"answers":[{"questionId":14,"text":"ans1"}]}]}]'
 			]
 		];
 	}
@@ -141,7 +141,6 @@ class FormsMigratorTest extends TestCase {
 		$form->setHash('abcdefg');
 		$form->setShowHeader(true);
 		$form->setTitle('Link');
-		$form->setShowTitle(true);
 		$form->setDescription('');
 		$form->setOwnerId('someUser');
 		$form->setCreated(1646251830);
@@ -152,7 +151,6 @@ class FormsMigratorTest extends TestCase {
 		$form->setExpires(0);
 		$form->setIsAnonymous(false);
 		$form->setSubmitMultiple(false);
-		$form->setShowDescription(true);
 		$form->setShowExpiration(false);
 		$form->setLastUpdated(123456789);
 
@@ -225,7 +223,7 @@ class FormsMigratorTest extends TestCase {
 	public function dataImport() {
 		return [
 			'exactlyOneOfEach' => [
-				'$inputJson' => '[{"showHeader":true,"title":"Link","showTitle":true,"description":"","created":1646251830,"access":{"permitAllUsers":false,"showToAllUsers":false},"expires":0,"isAnonymous":false,"submitMultiple":false,"showDescription":true,"showExpiration":false,"lastUpdated":123456789,"questions":[{"id":14,"order":2,"type":"multiple","isRequired":false,"text":"checkbox","description":"huhu","extraSettings":{},"options":[{"text":"ans1"}]}],"submissions":[{"userId":"anyUser@localhost","timestamp":1651354059,"answers":[{"questionId":14,"text":"ans1"}]}]}]'
+				'$inputJson' => '[{"showHeader":true,"title":"Link","description":"","created":1646251830,"access":{"permitAllUsers":false,"showToAllUsers":false},"expires":0,"isAnonymous":false,"submitMultiple":false,"showExpiration":false,"lastUpdated":123456789,"questions":[{"id":14,"order":2,"type":"multiple","isRequired":false,"text":"checkbox","description":"huhu","extraSettings":{},"options":[{"text":"ans1"}]}],"submissions":[{"userId":"anyUser@localhost","timestamp":1651354059,"answers":[{"questionId":14,"text":"ans1"}]}]}]'
 			]
 		];
 	}

--- a/tests/Unit/FormsMigratorTest.php
+++ b/tests/Unit/FormsMigratorTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
  * @copyright Copyright (c) 2022 Jonas Rittershofer <jotoeri@users.noreply.github.com>
  *
  * @author Jonas Rittershofer <jotoeri@users.noreply.github.com>
+ * @author Vitor Mattos <vitor@php.rio>
  *
  * @license AGPL-3.0-or-later
  *
@@ -114,7 +115,7 @@ class FormsMigratorTest extends TestCase {
 	public function dataExport() {
 		return [
 			'exactlyOneOfEach' => [
-				'expectedJson' => '[{"title":"Link","description":"","created":1646251830,"access":{"permitAllUsers":false,"showToAllUsers":false},"expires":0,"isAnonymous":false,"submitMultiple":false,"showExpiration":false,"lastUpdated":123456789,"questions":[{"id":14,"order":2,"type":"multiple","isRequired":false,"text":"checkbox","description":"huhu","extraSettings":{},"options":[{"text":"ans1"}]}],"submissions":[{"userId":"anyUser@localhost","timestamp":1651354059,"answers":[{"questionId":14,"text":"ans1"}]}]}]'
+				'expectedJson' => '[{"title":"Link","description":"","created":1646251830,"access":{"permitAllUsers":false,"showToAllUsers":false},"expires":0,"isAnonymous":false,"submitMultiple":false,"showDescription":true,"showExpiration":false,"lastUpdated":123456789,"questions":[{"id":14,"order":2,"type":"multiple","isRequired":false,"text":"checkbox","description":"huhu","extraSettings":{},"options":[{"text":"ans1"}]}],"submissions":[{"userId":"anyUser@localhost","timestamp":1651354059,"answers":[{"questionId":14,"text":"ans1"}]}]}]'
 			]
 		];
 	}
@@ -149,6 +150,7 @@ class FormsMigratorTest extends TestCase {
 		$form->setExpires(0);
 		$form->setIsAnonymous(false);
 		$form->setSubmitMultiple(false);
+		$form->setShowDescription(true);
 		$form->setShowExpiration(false);
 		$form->setLastUpdated(123456789);
 
@@ -221,7 +223,7 @@ class FormsMigratorTest extends TestCase {
 	public function dataImport() {
 		return [
 			'exactlyOneOfEach' => [
-				'$inputJson' => '[{"title":"Link","description":"","created":1646251830,"access":{"permitAllUsers":false,"showToAllUsers":false},"expires":0,"isAnonymous":false,"submitMultiple":false,"showExpiration":false,"lastUpdated":123456789,"questions":[{"id":14,"order":2,"type":"multiple","isRequired":false,"text":"checkbox","description":"huhu","extraSettings":{},"options":[{"text":"ans1"}]}],"submissions":[{"userId":"anyUser@localhost","timestamp":1651354059,"answers":[{"questionId":14,"text":"ans1"}]}]}]'
+				'$inputJson' => '[{"title":"Link","description":"","created":1646251830,"access":{"permitAllUsers":false,"showToAllUsers":false},"expires":0,"isAnonymous":false,"submitMultiple":false,"showDescription":true,"showExpiration":false,"lastUpdated":123456789,"questions":[{"id":14,"order":2,"type":"multiple","isRequired":false,"text":"checkbox","description":"huhu","extraSettings":{},"options":[{"text":"ans1"}]}],"submissions":[{"userId":"anyUser@localhost","timestamp":1651354059,"answers":[{"questionId":14,"text":"ans1"}]}]}]'
 			]
 		];
 	}

--- a/tests/Unit/FormsMigratorTest.php
+++ b/tests/Unit/FormsMigratorTest.php
@@ -115,7 +115,7 @@ class FormsMigratorTest extends TestCase {
 	public function dataExport() {
 		return [
 			'exactlyOneOfEach' => [
-				'expectedJson' => '[{"title":"Link","showTitle":true,"description":"","created":1646251830,"access":{"permitAllUsers":false,"showToAllUsers":false},"expires":0,"isAnonymous":false,"submitMultiple":false,"showDescription":true,"showExpiration":false,"lastUpdated":123456789,"questions":[{"id":14,"order":2,"type":"multiple","isRequired":false,"text":"checkbox","description":"huhu","extraSettings":{},"options":[{"text":"ans1"}]}],"submissions":[{"userId":"anyUser@localhost","timestamp":1651354059,"answers":[{"questionId":14,"text":"ans1"}]}]}]'
+				'expectedJson' => '[{"showHeader":true,"title":"Link","showTitle":true,"description":"","created":1646251830,"access":{"permitAllUsers":false,"showToAllUsers":false},"expires":0,"isAnonymous":false,"submitMultiple":false,"showDescription":true,"showExpiration":false,"lastUpdated":123456789,"questions":[{"id":14,"order":2,"type":"multiple","isRequired":false,"text":"checkbox","description":"huhu","extraSettings":{},"options":[{"text":"ans1"}]}],"submissions":[{"userId":"anyUser@localhost","timestamp":1651354059,"answers":[{"questionId":14,"text":"ans1"}]}]}]'
 			]
 		];
 	}
@@ -139,6 +139,7 @@ class FormsMigratorTest extends TestCase {
 		$form = new Form();
 		$form->setId(42);
 		$form->setHash('abcdefg');
+		$form->setShowHeader(true);
 		$form->setTitle('Link');
 		$form->setShowTitle(true);
 		$form->setDescription('');
@@ -224,7 +225,7 @@ class FormsMigratorTest extends TestCase {
 	public function dataImport() {
 		return [
 			'exactlyOneOfEach' => [
-				'$inputJson' => '[{"title":"Link","showTitle":true,"description":"","created":1646251830,"access":{"permitAllUsers":false,"showToAllUsers":false},"expires":0,"isAnonymous":false,"submitMultiple":false,"showDescription":true,"showExpiration":false,"lastUpdated":123456789,"questions":[{"id":14,"order":2,"type":"multiple","isRequired":false,"text":"checkbox","description":"huhu","extraSettings":{},"options":[{"text":"ans1"}]}],"submissions":[{"userId":"anyUser@localhost","timestamp":1651354059,"answers":[{"questionId":14,"text":"ans1"}]}]}]'
+				'$inputJson' => '[{"showHeader":true,"title":"Link","showTitle":true,"description":"","created":1646251830,"access":{"permitAllUsers":false,"showToAllUsers":false},"expires":0,"isAnonymous":false,"submitMultiple":false,"showDescription":true,"showExpiration":false,"lastUpdated":123456789,"questions":[{"id":14,"order":2,"type":"multiple","isRequired":false,"text":"checkbox","description":"huhu","extraSettings":{},"options":[{"text":"ans1"}]}],"submissions":[{"userId":"anyUser@localhost","timestamp":1651354059,"answers":[{"questionId":14,"text":"ans1"}]}]}]'
 			]
 		];
 	}

--- a/tests/Unit/FormsMigratorTest.php
+++ b/tests/Unit/FormsMigratorTest.php
@@ -115,7 +115,7 @@ class FormsMigratorTest extends TestCase {
 	public function dataExport() {
 		return [
 			'exactlyOneOfEach' => [
-				'expectedJson' => '[{"title":"Link","description":"","created":1646251830,"access":{"permitAllUsers":false,"showToAllUsers":false},"expires":0,"isAnonymous":false,"submitMultiple":false,"showDescription":true,"showExpiration":false,"lastUpdated":123456789,"questions":[{"id":14,"order":2,"type":"multiple","isRequired":false,"text":"checkbox","description":"huhu","extraSettings":{},"options":[{"text":"ans1"}]}],"submissions":[{"userId":"anyUser@localhost","timestamp":1651354059,"answers":[{"questionId":14,"text":"ans1"}]}]}]'
+				'expectedJson' => '[{"title":"Link","showTitle":true,"description":"","created":1646251830,"access":{"permitAllUsers":false,"showToAllUsers":false},"expires":0,"isAnonymous":false,"submitMultiple":false,"showDescription":true,"showExpiration":false,"lastUpdated":123456789,"questions":[{"id":14,"order":2,"type":"multiple","isRequired":false,"text":"checkbox","description":"huhu","extraSettings":{},"options":[{"text":"ans1"}]}],"submissions":[{"userId":"anyUser@localhost","timestamp":1651354059,"answers":[{"questionId":14,"text":"ans1"}]}]}]'
 			]
 		];
 	}
@@ -140,6 +140,7 @@ class FormsMigratorTest extends TestCase {
 		$form->setId(42);
 		$form->setHash('abcdefg');
 		$form->setTitle('Link');
+		$form->setShowTitle(true);
 		$form->setDescription('');
 		$form->setOwnerId('someUser');
 		$form->setCreated(1646251830);
@@ -223,7 +224,7 @@ class FormsMigratorTest extends TestCase {
 	public function dataImport() {
 		return [
 			'exactlyOneOfEach' => [
-				'$inputJson' => '[{"title":"Link","description":"","created":1646251830,"access":{"permitAllUsers":false,"showToAllUsers":false},"expires":0,"isAnonymous":false,"submitMultiple":false,"showDescription":true,"showExpiration":false,"lastUpdated":123456789,"questions":[{"id":14,"order":2,"type":"multiple","isRequired":false,"text":"checkbox","description":"huhu","extraSettings":{},"options":[{"text":"ans1"}]}],"submissions":[{"userId":"anyUser@localhost","timestamp":1651354059,"answers":[{"questionId":14,"text":"ans1"}]}]}]'
+				'$inputJson' => '[{"title":"Link","showTitle":true,"description":"","created":1646251830,"access":{"permitAllUsers":false,"showToAllUsers":false},"expires":0,"isAnonymous":false,"submitMultiple":false,"showDescription":true,"showExpiration":false,"lastUpdated":123456789,"questions":[{"id":14,"order":2,"type":"multiple","isRequired":false,"text":"checkbox","description":"huhu","extraSettings":{},"options":[{"text":"ans1"}]}],"submissions":[{"userId":"anyUser@localhost","timestamp":1651354059,"answers":[{"questionId":14,"text":"ans1"}]}]}]'
 			]
 		];
 	}

--- a/tests/Unit/Service/FormsServiceTest.php
+++ b/tests/Unit/Service/FormsServiceTest.php
@@ -146,6 +146,7 @@ class FormsServiceTest extends TestCase {
 			'one-full-form' => [[
 				'id' => 42,
 				'hash' => 'abcdefg',
+				'showHeader' => true,
 				'title' => 'Form 1',
 				'showTitle' => true,
 				'description' => 'Description Text',
@@ -225,6 +226,7 @@ class FormsServiceTest extends TestCase {
 		$form = new Form();
 		$form->setId(42);
 		$form->setHash('abcdefg');
+		$form->setShowHeader(true);
 		$form->setTitle('Form 1');
 		$form->setShowTitle(true);
 		$form->setShowExpiration(true);
@@ -421,6 +423,7 @@ class FormsServiceTest extends TestCase {
 			'one-full-form' => [[
 				'id' => 42,
 				'hash' => 'abcdefg',
+				'showHeader' => true,
 				'title' => 'Form 1',
 				'showTitle' => true,
 				'description' => 'Description Text',
@@ -449,6 +452,7 @@ class FormsServiceTest extends TestCase {
 		$form = new Form();
 		$form->setId(42);
 		$form->setHash('abcdefg');
+		$form->setShowHeader(true);
 		$form->setTitle('Form 1');
 		$form->setShowTitle(true);
 		$form->setDescription('Description Text');
@@ -677,7 +681,7 @@ class FormsServiceTest extends TestCase {
 			'permitAllUsers' => false,
 			'showToAllUsers' => false,
 		]);
-		
+
 		$this->formMapper->expects($this->any())
 			->method('findById')
 			->with(42)

--- a/tests/Unit/Service/FormsServiceTest.php
+++ b/tests/Unit/Service/FormsServiceTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
  * @copyright Copyright (c) 2021 Jonas Rittershofer <jotoeri@users.noreply.github.com>
  *
  * @author Jonas Rittershofer <jotoeri@users.noreply.github.com>
+ * @author Vitor Mattos <vitor@php.rio>
  *
  * @license AGPL-3.0-or-later
  *
@@ -156,6 +157,7 @@ class FormsServiceTest extends TestCase {
 				'expires' => 0,
 				'isAnonymous' => false,
 				'submitMultiple' => true,
+				'showDescription' => true,
 				'showExpiration' => false,
 				'lastUpdated' => 123456789,
 				'canSubmit' => true,
@@ -233,6 +235,7 @@ class FormsServiceTest extends TestCase {
 		$form->setExpires(0);
 		$form->setIsAnonymous(false);
 		$form->setSubmitMultiple(true);
+		$form->setShowDescription(true);
 		$form->setShowExpiration(false);
 		$form->setLastUpdated(123456789);
 
@@ -422,6 +425,7 @@ class FormsServiceTest extends TestCase {
 				'lastUpdated' => 123456789,
 				'isAnonymous' => false,
 				'submitMultiple' => true,
+				'showDescription' => true,
 				'showExpiration' => false,
 				'canSubmit' => true,
 				'questions' => [],
@@ -453,6 +457,7 @@ class FormsServiceTest extends TestCase {
 		$form->setLastUpdated(123456789);
 		$form->setIsAnonymous(false);
 		$form->setSubmitMultiple(true);
+		$form->setShowDescription(true);
 		$form->setShowExpiration(false);
 
 		$this->formMapper->expects($this->any())

--- a/tests/Unit/Service/FormsServiceTest.php
+++ b/tests/Unit/Service/FormsServiceTest.php
@@ -147,6 +147,7 @@ class FormsServiceTest extends TestCase {
 				'id' => 42,
 				'hash' => 'abcdefg',
 				'title' => 'Form 1',
+				'showTitle' => true,
 				'description' => 'Description Text',
 				'ownerId' => 'currentUser',
 				'created' => 123456789,
@@ -225,6 +226,8 @@ class FormsServiceTest extends TestCase {
 		$form->setId(42);
 		$form->setHash('abcdefg');
 		$form->setTitle('Form 1');
+		$form->setShowTitle(true);
+		$form->setShowExpiration(true);
 		$form->setDescription('Description Text');
 		$form->setOwnerId('currentUser');
 		$form->setCreated(123456789);
@@ -419,6 +422,7 @@ class FormsServiceTest extends TestCase {
 				'id' => 42,
 				'hash' => 'abcdefg',
 				'title' => 'Form 1',
+				'showTitle' => true,
 				'description' => 'Description Text',
 				'created' => 123456789,
 				'expires' => 0,
@@ -446,6 +450,7 @@ class FormsServiceTest extends TestCase {
 		$form->setId(42);
 		$form->setHash('abcdefg');
 		$form->setTitle('Form 1');
+		$form->setShowTitle(true);
 		$form->setDescription('Description Text');
 		$form->setOwnerId('someUser');
 		$form->setCreated(123456789);

--- a/tests/Unit/Service/FormsServiceTest.php
+++ b/tests/Unit/Service/FormsServiceTest.php
@@ -148,7 +148,6 @@ class FormsServiceTest extends TestCase {
 				'hash' => 'abcdefg',
 				'showHeader' => true,
 				'title' => 'Form 1',
-				'showTitle' => true,
 				'description' => 'Description Text',
 				'ownerId' => 'currentUser',
 				'created' => 123456789,
@@ -159,7 +158,6 @@ class FormsServiceTest extends TestCase {
 				'expires' => 0,
 				'isAnonymous' => false,
 				'submitMultiple' => true,
-				'showDescription' => true,
 				'showExpiration' => false,
 				'lastUpdated' => 123456789,
 				'canSubmit' => true,
@@ -228,7 +226,6 @@ class FormsServiceTest extends TestCase {
 		$form->setHash('abcdefg');
 		$form->setShowHeader(true);
 		$form->setTitle('Form 1');
-		$form->setShowTitle(true);
 		$form->setShowExpiration(true);
 		$form->setDescription('Description Text');
 		$form->setOwnerId('currentUser');
@@ -240,7 +237,6 @@ class FormsServiceTest extends TestCase {
 		$form->setExpires(0);
 		$form->setIsAnonymous(false);
 		$form->setSubmitMultiple(true);
-		$form->setShowDescription(true);
 		$form->setShowExpiration(false);
 		$form->setLastUpdated(123456789);
 
@@ -425,14 +421,12 @@ class FormsServiceTest extends TestCase {
 				'hash' => 'abcdefg',
 				'showHeader' => true,
 				'title' => 'Form 1',
-				'showTitle' => true,
 				'description' => 'Description Text',
 				'created' => 123456789,
 				'expires' => 0,
 				'lastUpdated' => 123456789,
 				'isAnonymous' => false,
 				'submitMultiple' => true,
-				'showDescription' => true,
 				'showExpiration' => false,
 				'canSubmit' => true,
 				'questions' => [],
@@ -454,7 +448,6 @@ class FormsServiceTest extends TestCase {
 		$form->setHash('abcdefg');
 		$form->setShowHeader(true);
 		$form->setTitle('Form 1');
-		$form->setShowTitle(true);
 		$form->setDescription('Description Text');
 		$form->setOwnerId('someUser');
 		$form->setCreated(123456789);
@@ -466,7 +459,6 @@ class FormsServiceTest extends TestCase {
 		$form->setLastUpdated(123456789);
 		$form->setIsAnonymous(false);
 		$form->setSubmitMultiple(true);
-		$form->setShowDescription(true);
 		$form->setShowExpiration(false);
 
 		$this->formMapper->expects($this->any())


### PR DESCRIPTION
## Motivation

Make possible use a form embedded in a site as contact form by example. A contact form sometimes haven't a description.

## Before

![Screenshot_20230825_130148](https://github.com/nextcloud/forms/assets/1079143/2cf7f16f-65c8-4406-b088-165d70fe2b5b)

## After
![Screenshot_20230825_130158](https://github.com/nextcloud/forms/assets/1079143/5af6842f-713a-4966-a5e0-d0d2e13fc7cc)


**How I implemented?**
I searched by `show?(expiration)` to look all places with this property and added the changes
