### PR TITLE
fix: Enhance extraSettings handling and fix XML output

### DIFF
--- a/docs/DataStructure.md
+++ b/docs/DataStructure.md
@@ -60,7 +60,7 @@ This document describes the Object-Structure, that is used within the Forms App 
 | text           | String          | max. 2048 ch. | The question-text |
 | name           | String          |              | Technical identifier of the question, e.g. used as HTML name attribute |
 | options        | Array of [Options](#option) | | Array of options belonging to the question. Only relevant for question-type with predefined options. |
-| extraSettings  | StdClass        |              | Additional settings for the question. For dropdown/radio/checkbox, there can be a 'shuffleOptions': true - the list of options should be shuffled. For radio/checkbox, 'allowOtherAnswer': true - allows the user to specify their own option. |
+| extraSettings  | [Extra Settings](#extra-settings)        |              | Additional settings for the question.  |
 ```
 {
   "id": 1,
@@ -178,3 +178,11 @@ Currently supported Question-Types are:
 | `date`          | Showing a dropdown calendar to select a date. |
 | _`datetime`_      | _deprecated: No longer available for new questions. Showing a dropdown calendar to select a date **and** a time._ |
 | `time`          | Showing a dropdown menu to select a time. |
+
+## Extra Settings
+Optional extra settings for some [Question Types](#question-types)
+
+| Extra Setting      | Question Type | Type   | Values | Description |
+|--------------------|---------------|--------|--------|-------------|
+| `allowOtherAnswer` | `multiple, multiple_unique` | Boolean | Allows the user to specify a custom answer |
+| `shuffleOptions`   | `dropdown, multiple, multiple_unique` | Boolean | The list of options should be shuffled |

--- a/lib/Db/Question.php
+++ b/lib/Db/Question.php
@@ -71,8 +71,8 @@ class Question extends Entity {
 		$this->addType('name', 'string');
 	}
 
-	public function getExtraSettings(): object {
-		return json_decode($this->getExtraSettingsJson() ?: '{}');
+	public function getExtraSettings(): array {
+		return json_decode($this->getExtraSettingsJson() ?: '{}', true); // assoc=true, => Convert to associative Array
 	}
 
 	/**
@@ -80,6 +80,14 @@ class Question extends Entity {
 	 */
 	public function setExtraSettings($extraSettings) {
 		// TODO: When the php requirement is >= 8.0 change parameter typing to `object|array` to allow assoc. arrays from `Question::fromParams`
+		
+		// Remove extraSettings that are not set
+		foreach ($extraSettings as $key => $value) {
+			if ($value === false) {
+				unset($extraSettings[$key]);
+			}
+		}
+		
 		$this->setExtraSettingsJson(json_encode($extraSettings, JSON_FORCE_OBJECT));
 	}
 

--- a/tests/Unit/Service/FormsServiceTest.php
+++ b/tests/Unit/Service/FormsServiceTest.php
@@ -167,7 +167,7 @@ class FormsServiceTest extends TestCase {
 						'order' => 1,
 						'type' => 'dropdown',
 						'isRequired' => false,
-						'extraSettings' => (object)['shuffleOptions' => true],
+						'extraSettings' => ['shuffleOptions' => true],
 						'text' => 'Question 1',
 						'description' => 'This is our first question.',
 						'name' => '',
@@ -190,7 +190,7 @@ class FormsServiceTest extends TestCase {
 						'order' => 2,
 						'type' => 'short',
 						'isRequired' => true,
-						'extraSettings' => (object)[],
+						'extraSettings' => [],
 						'text' => 'Question 2',
 						'description' => '',
 						'name' => 'city',
@@ -258,7 +258,7 @@ class FormsServiceTest extends TestCase {
 		$question1->setOrder(1);
 		$question1->setType('dropdown');
 		$question1->setIsRequired(false);
-		$question1->setExtraSettings((object)[
+		$question1->setExtraSettings([
 			'shuffleOptions' => true
 		]);
 		$question1->setText('Question 1');


### PR DESCRIPTION
This fixes #1469

The getExtraSettings() function now returns an associative array so that the XML response of the API is working again.

Furthermore, we now store only set (`true`) extraSettings to the DB.