### PR TITLE
Optimization of FormMapper::findById calls

### DIFF
--- a/lib/Controller/ApiController.php
+++ b/lib/Controller/ApiController.php
@@ -155,7 +155,7 @@ class ApiController extends OCSController {
 
 		$result = [];
 		foreach ($forms as $form) {
-			$result[] = $this->formsService->getPartialFormArray($form->getId());
+			$result[] = $this->formsService->getPartialFormArray($form);
 		}
 
 		return new DataResponse($result);
@@ -175,10 +175,10 @@ class ApiController extends OCSController {
 		$result = [];
 		foreach ($forms as $form) {
 			// Check if the form should be shown on sidebar
-			if (!$this->formsService->isSharedFormShown($form->getId())) {
+			if (!$this->formsService->isSharedFormShown($form)) {
 				continue;
 			}
-			$result[] = $this->formsService->getPartialFormArray($form->getId());
+			$result[] = $this->formsService->getPartialFormArray($form);
 		}
 
 		return new DataResponse($result);
@@ -202,12 +202,12 @@ class ApiController extends OCSController {
 			throw new OCSBadRequestException();
 		}
 
-		if (!$this->formsService->hasUserAccess($form->getId())) {
+		if (!$this->formsService->hasUserAccess($form)) {
 			$this->logger->debug('User has no permissions to get this form');
 			throw new OCSForbiddenException();
 		}
 
-		return new DataResponse($this->formsService->getPartialFormArray($form->getId()));
+		return new DataResponse($this->formsService->getPartialFormArray($form));
 	}
 
 	/**
@@ -223,18 +223,19 @@ class ApiController extends OCSController {
 	 */
 	public function getForm(int $id): DataResponse {
 		try {
-			$form = $this->formsService->getForm($id);
+			$form = $this->formMapper->findById($id);
+			$formData = $this->formsService->getForm($form);
 		} catch (IMapperException $e) {
 			$this->logger->debug('Could not find form');
 			throw new OCSBadRequestException();
 		}
 
-		if (!$this->formsService->hasUserAccess($id)) {
+		if (!$this->formsService->hasUserAccess($form)) {
 			$this->logger->debug('User has no permissions to get this form');
 			throw new OCSForbiddenException();
 		}
 
-		return new DataResponse($form);
+		return new DataResponse($formData);
 	}
 
 	/**
@@ -873,7 +874,7 @@ class ApiController extends OCSController {
 			throw new OCSBadRequestException();
 		}
 
-		if (!$this->formsService->canSeeResults($form->id)) {
+		if (!$this->formsService->canSeeResults($form)) {
 			$this->logger->debug('The current user has no permission to get the results for this form');
 			throw new OCSForbiddenException();
 		}
@@ -959,18 +960,18 @@ class ApiController extends OCSController {
 			// $isPublicShare already false.
 		} finally {
 			// Now forbid, if no public share and no direct share.
-			if (!$isPublicShare && !$this->formsService->hasUserAccess($form->getId())) {
+			if (!$isPublicShare && !$this->formsService->hasUserAccess($form)) {
 				throw new OCSForbiddenException('Not allowed to access this form');
 			}
 		}
 
 		// Not allowed if form has expired.
-		if ($this->formsService->hasFormExpired($form->getId())) {
+		if ($this->formsService->hasFormExpired($form)) {
 			throw new OCSForbiddenException('This form is no longer taking answers');
 		}
 
 		// Does the user have permissions to submit
-		if (!$this->formsService->canSubmit($form->getId())) {
+		if (!$this->formsService->canSubmit($form)) {
 			throw new OCSForbiddenException('Already submitted');
 		}
 
@@ -1138,7 +1139,7 @@ class ApiController extends OCSController {
 			throw new OCSBadRequestException();
 		}
 
-		if (!$this->formsService->canSeeResults($form->id)) {
+		if (!$this->formsService->canSeeResults($form)) {
 			$this->logger->debug('The current user has no permission to get the results for this form');
 			throw new OCSForbiddenException();
 		}
@@ -1172,7 +1173,7 @@ class ApiController extends OCSController {
 			throw new OCSBadRequestException();
 		}
 
-		if (!$this->formsService->canSeeResults($form->id)) {
+		if (!$this->formsService->canSeeResults($form)) {
 			$this->logger->debug('The current user has no permission to get the results for this form');
 			throw new OCSForbiddenException();
 		}

--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -178,14 +178,14 @@ class PageController extends Controller {
 			Util::addStyle($this->appName, 'forms');
 
 			// Has form expired
-			if ($this->formsService->hasFormExpired($form->getId())) {
+			if ($this->formsService->hasFormExpired($form)) {
 				return $this->provideEmptyContent(Constants::EMPTY_EXPIRED, $form);
 			}
 
 			// Public Template to fill the form
 			Util::addScript($this->appName, 'forms-submit');
 			$this->insertHeaderOnIos();
-			$this->initialState->provideInitialState('form', $this->formsService->getPublicForm($form->getId()));
+			$this->initialState->provideInitialState('form', $this->formsService->getPublicForm($form));
 			$this->initialState->provideInitialState('isLoggedIn', $this->userSession->isLoggedIn());
 			$this->initialState->provideInitialState('shareHash', $hash);
 			$this->initialState->provideInitialState('maxStringLengths', Constants::MAX_STRING_LENGTHS);
@@ -215,14 +215,14 @@ class PageController extends Controller {
 		}
 
 		// Has form expired
-		if ($this->formsService->hasFormExpired($form->getId())) {
+		if ($this->formsService->hasFormExpired($form)) {
 			return $this->provideEmptyContent(Constants::EMPTY_EXPIRED, $form);
 		}
 
 		// Main Template to fill the form
 		Util::addScript($this->appName, 'forms-submit');
 		$this->insertHeaderOnIos();
-		$this->initialState->provideInitialState('form', $this->formsService->getPublicForm($form->getId()));
+		$this->initialState->provideInitialState('form', $this->formsService->getPublicForm($form));
 		$this->initialState->provideInitialState('isLoggedIn', $this->userSession->isLoggedIn());
 		$this->initialState->provideInitialState('shareHash', $hash);
 		$this->initialState->provideInitialState('maxStringLengths', Constants::MAX_STRING_LENGTHS);

--- a/tests/Unit/Controller/ApiControllerTest.php
+++ b/tests/Unit/Controller/ApiControllerTest.php
@@ -206,7 +206,7 @@ class ApiControllerTest extends TestCase {
 	
 		$this->formsService->expects(($this->once()))
 			->method('canSeeResults')
-			->with(1)
+			->with($form)
 			->willReturn(false);
 
 		$this->expectException(OCSForbiddenException::class);
@@ -264,7 +264,7 @@ class ApiControllerTest extends TestCase {
 	
 		$this->formsService->expects(($this->once()))
 			->method('canSeeResults')
-			->with(1)
+			->with($form)
 			->willReturn(true);
 
 		$this->submissionService->expects($this->once())
@@ -303,7 +303,7 @@ class ApiControllerTest extends TestCase {
 	
 		$this->formsService->expects(($this->once()))
 			->method('canSeeResults')
-			->with(1)
+			->with($form)
 			->willReturn(false);
 
 		$this->expectException(OCSForbiddenException::class);
@@ -323,7 +323,7 @@ class ApiControllerTest extends TestCase {
 	
 		$this->formsService->expects(($this->once()))
 			->method('canSeeResults')
-			->with(1)
+			->with($form)
 			->willReturn(true);
 
 		$csv = ['data' => '__data__', 'fileName' => 'some.csv'];
@@ -559,17 +559,14 @@ class ApiControllerTest extends TestCase {
 	private function formAccess(bool $hasUserAccess = true, bool $hasFormExpired = false, bool $canSubmit = true) {
 		$this->formsService
 			->method('hasUserAccess')
-			->with(1)
 			->willReturn($hasUserAccess);
 
 		$this->formsService
 			->method('hasFormExpired')
-			->with(1)
 			->willReturn($hasFormExpired);
 
 		$this->formsService
 			->method('canSubmit')
-			->with(1)
 			->willReturn($canSubmit);
 	}
 

--- a/tests/Unit/Service/FormsServiceTest.php
+++ b/tests/Unit/Service/FormsServiceTest.php
@@ -236,11 +236,6 @@ class FormsServiceTest extends TestCase {
 		$form->setShowExpiration(false);
 		$form->setLastUpdated(123456789);
 
-		$this->formMapper->expects($this->any())
-			->method('findById')
-			->with(42)
-			->willReturn($form);
-
 		// User & Group Formatting
 		$user = $this->createMock(IUser::class);
 		$user->expects($this->once())
@@ -310,7 +305,7 @@ class FormsServiceTest extends TestCase {
 			->willReturn(123);
 
 		// Run the test
-		$this->assertEquals($expected, $this->formsService->getForm(42));
+		$this->assertEquals($expected, $this->formsService->getForm($form));
 	}
 
 	public function dataGetPartialForm() {
@@ -341,18 +336,13 @@ class FormsServiceTest extends TestCase {
 		$form->setExpires(0);
 		$form->setLastUpdated(123456789);
 
-		$this->formMapper->expects($this->exactly(2))
-			->method('findById')
-			->with(42)
-			->willReturn($form);
-
 		$this->submissionMapper->expects($this->once())
 			->method('countSubmissions')
 			->with(42)
 			->willReturn(123);
 
 		// Run the test
-		$this->assertEquals($expected, $this->formsService->getPartialFormArray(42));
+		$this->assertEquals($expected, $this->formsService->getPartialFormArray($form));
 	}
 
 	public function dataGetPartialFormShared() {
@@ -395,18 +385,13 @@ class FormsServiceTest extends TestCase {
 			->with(42)
 			->willReturn([$share]);
 
-		$this->formMapper->expects($this->exactly(2))
-			->method('findById')
-			->with(42)
-			->willReturn($form);
-
 		$this->submissionMapper->expects($this->once())
 			->method('countSubmissions')
 			->with(42)
 			->willReturn(123);
 
 		// Run the test
-		$this->assertEquals($expected, $this->formsService->getPartialFormArray(42));
+		$this->assertEquals($expected, $this->formsService->getPartialFormArray($form));
 	}
 
 	public function dataGetPublicForm() {
@@ -455,11 +440,6 @@ class FormsServiceTest extends TestCase {
 		$form->setSubmitMultiple(true);
 		$form->setShowExpiration(false);
 
-		$this->formMapper->expects($this->any())
-			->method('findById')
-			->with(42)
-			->willReturn($form);
-
 		// User & Group Formatting
 		$user = $this->createMock(IUser::class);
 		$user->expects($this->once())
@@ -489,7 +469,7 @@ class FormsServiceTest extends TestCase {
 			->willReturn([$share]);
 
 		// Run the test
-		$this->assertEquals($expected, $this->formsService->getPublicForm(42));
+		$this->assertEquals($expected, $this->formsService->getPublicForm($form));
 	}
 
 	public function dataGetPermissions() {
@@ -559,11 +539,6 @@ class FormsServiceTest extends TestCase {
 		$form->setOwnerId($ownerId);
 		$form->setAccess($access);
 
-		$this->formMapper->expects($this->any())
-			->method('findById')
-			->with(42)
-			->willReturn($form);
-
 		$sharesEntities = [];
 		$shareId = 0;
 		foreach ($shares as $share) {
@@ -585,7 +560,7 @@ class FormsServiceTest extends TestCase {
 			->method('getAllowPermitAll')
 			->willReturn(true);
 
-		$this->assertEquals($expected, $this->formsService->getPermissions(42));
+		$this->assertEquals($expected, $this->formsService->getPermissions($form));
 	}
 
 	// No currentUser on public views.
@@ -612,12 +587,8 @@ class FormsServiceTest extends TestCase {
 
 		$form = new Form();
 		$form->setId(42);
-		$this->formMapper->expects($this->any())
-			->method('findById')
-			->with(42)
-			->willReturn($form);
 
-		$this->assertEquals([], $formsService->getPermissions(42));
+		$this->assertEquals([], $formsService->getPermissions($form));
 	}
 
 	public function dataCanSeeResults() {
@@ -667,11 +638,6 @@ class FormsServiceTest extends TestCase {
 			'permitAllUsers' => false,
 			'showToAllUsers' => false,
 		]);
-		
-		$this->formMapper->expects($this->any())
-			->method('findById')
-			->with(42)
-			->willReturn($form);
 
 		$shares = [];
 		foreach ($sharesArray as $id => $share) {
@@ -689,7 +655,7 @@ class FormsServiceTest extends TestCase {
 			->with(42)
 			->willReturn($shares);
 
-		$this->assertEquals($expected, $this->formsService->canSeeResults(42));
+		$this->assertEquals($expected, $this->formsService->canSeeResults($form));
 	}
 
 	public function dataCanSubmit() {
@@ -738,17 +704,12 @@ class FormsServiceTest extends TestCase {
 		$form->setOwnerId($ownerId);
 		$form->setSubmitMultiple($submitMultiple);
 
-		$this->formMapper->expects($this->any())
-			->method('findById')
-			->with(42)
-			->willReturn($form);
-
 		$this->submissionMapper->expects($this->any())
 			->method('findParticipantsByForm')
 			->with(42)
 			->willReturn($participantsArray);
 
-		$this->assertEquals($expected, $this->formsService->canSubmit(42));
+		$this->assertEquals($expected, $this->formsService->canSubmit($form));
 	}
 
 	/**
@@ -761,11 +722,6 @@ class FormsServiceTest extends TestCase {
 			'permitAllUsers' => false,
 			'showToAllUsers' => false,
 		]);
-
-		$this->formMapper->expects($this->any())
-		->method('findById')
-		->with(42)
-		->willReturn($form);
 
 		$share = new Share;
 		$share->setShareType(IShare::TYPE_LINK);
@@ -798,7 +754,7 @@ class FormsServiceTest extends TestCase {
 			$this->secureRandom
 		);
 
-		$this->assertEquals(true, $formsService->canSubmit(42));
+		$this->assertEquals(true, $formsService->canSubmit($form));
 	}
 
 	public function dataHasPublicLink() {
@@ -842,11 +798,6 @@ class FormsServiceTest extends TestCase {
 		$form->setId(42);
 		$form->setAccess($access);
 
-		$this->formMapper->expects($this->once())
-			->method('findById')
-			->with(42)
-			->willReturn($form);
-
 		$share = new Share();
 		$share->setShareType($shareType);
 		$this->shareMapper->expects($this->any())
@@ -854,7 +805,7 @@ class FormsServiceTest extends TestCase {
 			->with(42)
 			->willReturn([$share]);
 
-		$this->assertEquals($expected, $this->formsService->hasPublicLink(42));
+		$this->assertEquals($expected, $this->formsService->hasPublicLink($form));
 	}
 
 	public function dataHasUserAccess() {
@@ -894,33 +845,25 @@ class FormsServiceTest extends TestCase {
 	 */
 	public function testHasUserAccess(array $accessArray, string $ownerId, bool $expected) {
 		$form = new Form();
+		$form->setId(42);
 		$form->setAccess($accessArray);
 		$form->setOwnerId($ownerId);
-
-		$this->formMapper->expects($this->once())
-			->method('findById')
-			->with(42)
-			->willReturn($form);
 
 		$this->configService->expects($this->any())
 			->method('getAllowPermitAll')
 			->willReturn(true);
 
-		$this->assertEquals($expected, $this->formsService->hasUserAccess(42));
+		$this->assertEquals($expected, $this->formsService->hasUserAccess($form));
 	}
 
 	public function testHasUserAccess_DirectShare() {
 		$form = new Form();
+		$form->setId(42);
 		$form->setAccess([
 			'permitAllUsers' => false,
 			'showToAllUsers' => false,
 		]);
 		$form->setOwnerId('notCurrentUser');
-
-		$this->formMapper->expects($this->once())
-			->method('findById')
-			->with(42)
-			->willReturn($form);
 
 		$share = new Share();
 		$share->setShareType(IShare::TYPE_USER);
@@ -930,27 +873,23 @@ class FormsServiceTest extends TestCase {
 			->with(42)
 			->willReturn([$share]);
 
-		$this->assertEquals(true, $this->formsService->hasUserAccess(42));
+		$this->assertEquals(true, $this->formsService->hasUserAccess($form));
 	}
 
 	public function testHasUserAccess_PermitAllNotAllowed() {
 		$form = new Form();
+		$form->setId(42);
 		$form->setAccess([
 			'permitAllUsers' => true,
 			'showToAllUsers' => true,
 		]);
 		$form->setOwnerId('notCurrentUser');
 
-		$this->formMapper->expects($this->once())
-			->method('findById')
-			->with(42)
-			->willReturn($form);
-
 		$this->configService->expects($this->once())
 			->method('getAllowPermitAll')
 			->willReturn(false);
 
-		$this->assertEquals(false, $this->formsService->hasUserAccess(42));
+		$this->assertEquals(false, $this->formsService->hasUserAccess($form));
 	}
 
 	public function testHasUserAccess_NotLoggedIn() {
@@ -975,18 +914,14 @@ class FormsServiceTest extends TestCase {
 		);
 
 		$form = new Form();
+		$form->setId(42);
 		$form->setAccess([
 			'permitAllUsers' => false,
 			'showToAllUsers' => false,
 		]);
 		$form->setOwnerId('someOtherUser');
 
-		$this->formMapper->expects($this->once())
-			->method('findById')
-			->with(42)
-			->willReturn($form);
-
-		$this->assertEquals(false, $formsService->hasUserAccess(42));
+		$this->assertEquals(false, $formsService->hasUserAccess($form));
 	}
 
 	public function dataIsSharedFormShown() {
@@ -1059,11 +994,6 @@ class FormsServiceTest extends TestCase {
 		$form->setExpires($expires);
 		$form->setAccess($access);
 
-		$this->formMapper->expects($this->any())
-			->method('findById')
-			->with(42)
-			->willReturn($form);
-
 		$this->configService->expects($this->any())
 			->method('getAllowPermitAll')
 			->willReturn(true);
@@ -1076,7 +1006,7 @@ class FormsServiceTest extends TestCase {
 			->with(42)
 			->willReturn([$share]);
 
-		$this->assertEquals($expected, $this->formsService->isSharedFormShown(42));
+		$this->assertEquals($expected, $this->formsService->isSharedFormShown($form));
 	}
 
 	public function testIsSharedFormShown_PermitAllNotAllowed() {
@@ -1089,11 +1019,6 @@ class FormsServiceTest extends TestCase {
 			'showToAllUsers' => true,
 		]);
 
-		$this->formMapper->expects($this->any())
-			->method('findById')
-			->with(42)
-			->willReturn($form);
-
 		$this->configService->expects($this->any())
 			->method('getAllowPermitAll')
 			->willReturn(false);
@@ -1103,7 +1028,7 @@ class FormsServiceTest extends TestCase {
 			->with(42)
 			->willReturn([]);
 
-		$this->assertEquals(false, $this->formsService->isSharedFormShown(42));
+		$this->assertEquals(false, $this->formsService->isSharedFormShown($form));
 	}
 
 	public function dataIsSharedToUser() {
@@ -1178,12 +1103,7 @@ class FormsServiceTest extends TestCase {
 		$form = new Form();
 		$form->setExpires($expires);
 
-		$this->formMapper->expects($this->once())
-			->method('findById')
-			->with(42)
-			->willReturn($form);
-
-		$this->assertEquals($expected, $this->formsService->hasFormExpired(42));
+		$this->assertEquals($expected, $this->formsService->hasFormExpired($form));
 	}
 
 	public function dataGetShareDisplayName() {


### PR DESCRIPTION
Motivation:

There is a method called ApiController::getSharedForms, which is invoked on the main page of the module.

This method retrieves all web forms without exception.

And then this method invokes various other methods to obtain the Form using its formId. In essence, it performs N (representing the total number of forms in the system) additional requests to the database. Even if these requests are somehow cached, they still amount to N unnecessary cache requests.

For other methods, the number of findById calls is reduced.