### PR TITLE
fix: Incorrect type for empty extraSettings in frontend

### DIFF
--- a/src/mixins/QuestionMixin.js
+++ b/src/mixins/QuestionMixin.js
@@ -116,10 +116,8 @@ export default {
 
 		/**
 		 * Extra settings
-		 * Currently only contains whether options should be shuffled
 		 */
 		extraSettings: {
-			type: Object,
 			default: () => {
 				return {}
 			},


### PR DESCRIPTION
This fixes an error introduced with the XML fix in #1705 

For questions where extraSettings weren't set we got a type mismatch in the extraSettings prop (Object expected, array provided)