### PR TITLE
fix: Warning about missing label for other answer

### DIFF
--- a/src/components/Questions/QuestionMultiple.vue
+++ b/src/components/Questions/QuestionMultiple.vue
@@ -72,7 +72,7 @@
 						@keydown.enter.exact.prevent="onKeydownEnter">
 						{{ t('forms', 'Other:') }}
 					</NcCheckboxRadioSwitch>
-					<NcInputField :placeholder="placeholderOtherAnswer"
+					<NcInputField :label="placeholderOtherAnswer"
 						:required="hasRequiredOtherAnswerInput"
 						:value.sync="inputOtherAnswer"
 						class="question__input" />


### PR DESCRIPTION
NcInputField for other answer throws a warning about missing label prop. As label also works as placeholder, this simply changes the prop for the placeholder text from placeholder to label.