### PR TITLE
fix: Make form editable with keyboard

### DIFF
--- a/src/components/Questions/AnswerInput.vue
+++ b/src/components/Questions/AnswerInput.vue
@@ -1,5 +1,5 @@
 <template>
-	<li class="question__item">
+	<li class="question__item" @focusout="handleTabbing">
 		<div :is="pseudoIcon"
 			v-if="!isDropdown"
 			class="question__item__pseudoInput" />
@@ -15,7 +15,7 @@
 			dir="auto"
 			@input="onInput"
 			@keydown.delete="deleteEntry"
-			@keydown.enter.prevent="addNewEntry">
+			@keydown.enter.prevent="focusNextInput">
 
 		<!-- Delete answer -->
 		<NcActions>
@@ -98,6 +98,10 @@ export default {
 	},
 
 	methods: {
+		handleTabbing() {
+			this.$emit('tabbed-out')
+		},
+
 		/**
 		 * Focus the input
 		 */
@@ -133,8 +137,8 @@ export default {
 		/**
 		 * Request a new answer
 		 */
-		addNewEntry() {
-			this.$emit('add')
+		focusNextInput() {
+			this.$emit('focus-next', this.index)
 		},
 
 		/**
@@ -221,13 +225,14 @@ export default {
 	.question__input {
 		width: 100%;
 		position: relative;
-		margin-inline-end: 2px !important;
+		inset-inline-start: -12px;
+		margin-inline-end: -12px !important;
 
 		&--shifted {
-			inset-inline-start: -30px;
+			inset-inline-start: -34px;
 			inset-block-start: 1px;
-			margin-inline-end: -30px !important;
-			padding-inline-start: 32px !important;
+			margin-inline-end: -34px !important;
+			padding-inline-start: 36px !important;
 		}
 	}
 }

--- a/src/components/Questions/Question.vue
+++ b/src/components/Questions/Question.vue
@@ -21,14 +21,11 @@
   -->
 
 <template>
-	<li v-click-outside="disableEdit"
-		:class="{
+	<li :class="{
 			'question': true,
-			'question--edit': edit,
 			'question--editable': !readOnly
 		}"
-		:aria-label="t('forms', 'Question number {index}', {index})"
-		@click="enableEdit">
+		:aria-label="t('forms', 'Question number {index}', {index})">
 		<!-- Drag handle -->
 		<!-- TODO: implement arrow key mapping to reorder question -->
 		<div v-if="!readOnly"
@@ -62,7 +59,7 @@
 		<!-- Header -->
 		<div class="question__header">
 			<div class="question__header__title">
-				<input v-if="edit || !questionValid"
+				<input v-if="!readOnly || !questionValid"
 					:placeholder="titlePlaceholder"
 					:aria-label="t('forms', 'Title of question number {index}', {index})"
 					:value="text"
@@ -79,7 +76,7 @@
 					dir="auto">
 					{{ computedText }}
 				</h3>
-				<div v-if="!edit && !questionValid"
+				<div v-if="!readOnly && !questionValid"
 					v-tooltip.auto="warningInvalid"
 					class="question__header__title__warning"
 					tabindex="0">
@@ -111,8 +108,8 @@
 					</NcActionButton>
 				</NcActions>
 			</div>
-			<div v-if="hasDescription || edit || !questionValid" class="question__header__description">
-				<textarea v-if="edit || !questionValid"
+			<div v-if="hasDescription || !readOnly || !questionValid" class="question__header__description">
+				<textarea v-if="!readOnly || !questionValid"
 					ref="description"
 					dir="auto"
 					:value="description"
@@ -131,8 +128,6 @@
 </template>
 
 <script>
-import { directive as ClickOutside } from 'v-click-outside'
-
 import NcActions from '@nextcloud/vue/dist/Components/NcActions.js'
 import NcActionButton from '@nextcloud/vue/dist/Components/NcActionButton.js'
 import NcActionCheckbox from '@nextcloud/vue/dist/Components/NcActionCheckbox.js'
@@ -148,10 +143,6 @@ import IconIdentifier from 'vue-material-design-icons/Identifier.vue'
 
 export default {
 	name: 'Question',
-
-	directives: {
-		ClickOutside,
-	},
 
 	components: {
 		IconAlertCircleOutline,
@@ -193,10 +184,6 @@ export default {
 		shiftDragHandle: {
 			type: Boolean,
 			default: false,
-		},
-		edit: {
-			type: Boolean,
-			required: true,
 		},
 		readOnly: {
 			type: Boolean,
@@ -266,13 +253,6 @@ export default {
 			return this.description !== ''
 		},
 	},
-	watch: {
-		edit(newEdit) {
-			if (newEdit || !this.questionValid) {
-				this.resizeDescription()
-			}
-		},
-	},
 	// Ensure description is sized correctly on initial render
 	mounted() {
 		this.$nextTick(() => this.resizeDescription())
@@ -317,24 +297,6 @@ export default {
 		onMoveUp() {
 			this.$emit('move-up')
 			this.$nextTick(() => this.$refs.buttonUp.$el.focus())
-		},
-
-		/**
-		 * Enable the edit mode
-		 */
-		enableEdit() {
-			if (!this.readOnly) {
-				this.$emit('update:edit', true)
-			}
-		},
-
-		/**
-		 * Disable the edit mode
-		 */
-		disableEdit() {
-			if (!this.readOnly) {
-				this.$emit('update:edit', false)
-			}
 		},
 
 		/**

--- a/src/components/Questions/QuestionDate.vue
+++ b/src/components/Questions/QuestionDate.vue
@@ -128,6 +128,10 @@ export default {
 .mx-datepicker {
 	width: 300px;
 
+	&.disabled {
+		inset-inline-start: -12px;
+	}
+
 	:deep(.mx-input) {
 		height: 44px !important;
 	}

--- a/src/components/Questions/QuestionLong.vue
+++ b/src/components/Questions/QuestionLong.vue
@@ -98,6 +98,8 @@ export default {
 		// Just overrides Server CSS-Styling for disabled inputs. -> Not Good??
 		background-color: var(--color-main-background);
 		color: var(--color-main-text);
+		width: calc(100% - 32px) !important;
+		margin-inline-start: -12px;
 	}
 }
 

--- a/src/components/Questions/QuestionShort.vue
+++ b/src/components/Questions/QuestionShort.vue
@@ -75,6 +75,10 @@ export default {
 .question__input[type=text] {
 	width: 100%;
 	min-height: 44px;
-}
 
+	&:disabled {
+		width: calc(100% - 32px) !important;
+		margin-inline-start: -12px;
+	}
+}
 </style>

--- a/src/mixins/QuestionMixin.js
+++ b/src/mixins/QuestionMixin.js
@@ -160,16 +160,9 @@ export default {
 		Question,
 	},
 
-	data() {
-		return {
-			// Do we display this question in edit or fill mode
-			edit: false,
-		}
-	},
-
 	computed: {
 		questionProps() {
-			const props = { ...this.$props, edit: this.edit }
+			const props = { ...this.$props }
 			const allowedKeys = Object.keys(Question.props)
 			Object.keys(props).forEach((key) => {
 				if (!allowedKeys.includes(key)) {
@@ -180,7 +173,7 @@ export default {
 		},
 		sortedOptions() {
 			// Only shuffle options if not in editing mode (and shuffling is enabled)
-			if (!this.edit && this.extraSettings?.shuffleOptions) {
+			if (this.readOnly && this.extraSettings?.shuffleOptions) {
 				return this.shuffleArray(this.options)
 			}
 			// Ensure order of options always is the same
@@ -197,7 +190,6 @@ export default {
 				'update:description': this.onDescriptionChange,
 				'update:isRequired': this.onRequiredChange,
 				'update:name': this.onNameChange,
-				'update:edit': () => { this.edit = !this.edit },
 				'move-down': (...args) => this.$emit('move-down', ...args),
 				'move-up': (...args) => this.$emit('move-up', ...args),
 			}
@@ -296,12 +288,11 @@ export default {
 		 * Focus the first focusable element
 		 */
 		focus() {
-			this.edit = true
 			this.$el.scrollIntoView({ behavior: 'smooth' })
 			this.$nextTick(() => {
-				const title = this.$el.querySelector('.question__header-title')
+				const title = this.$el.querySelector('.question__header__title__text__input')
 				if (title) {
-					title.select()
+					title.focus()
 				}
 			})
 		},


### PR DESCRIPTION
This fixes #416 by always showing the edit mode for all fields in Edit/Create view

![grafik](https://github.com/nextcloud/forms/assets/16020496/24118435-209c-416c-b081-921ef70d03c8)

To-Do:
- [x] Fix tabbing from multilple choice questions to next question. Probably due to switching between normal Input and AnswerInput.vue (also tracked in #1256)
- [x] Focus after adding question not in title
- [x] emit onInput event after creating a new option only works after first input
