### PR TITLE
Added possibility to link spreadsheet for automatic submission export in multiple formats

### DIFF
--- a/.github/workflows/appstore-build-publish.yml
+++ b/.github/workflows/appstore-build-publish.yml
@@ -70,6 +70,7 @@ jobs:
         with:
           php-version: ${{ env.PHP_VERSION }}
           coverage: none
+          extensions: gd
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/lint-php-cs.yml
+++ b/.github/workflows/lint-php-cs.yml
@@ -30,6 +30,7 @@ jobs:
           php-version: 8.2
           coverage: none
           ini-file: development
+          extensions: gd
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/psalm.yml
+++ b/.github/workflows/psalm.yml
@@ -50,6 +50,7 @@ jobs:
           php-version: 8.2
           coverage: none
           ini-file: development
+          extensions: gd
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -4,6 +4,7 @@
  *
  * @author affan98 <affan98@gmail.com>
  * @author Christian Hartmann <chris-hartmann@gmx.de>
+ * @author Ferdinand Thiessen <opensource@fthiessen.de>
  * @author John Molakvoæ (skjnldsv) <skjnldsv@protonmail.com>
  * @author Jonas Rittershofer <jotoeri@users.noreply.github.com>
  *
@@ -73,7 +74,7 @@ return [
 			'verb' => 'OPTIONS',
 			'requirements' => [
 				'path' => '.+',
-				'apiVersion' => 'v2(\.[1-3])?'
+				'apiVersion' => 'v2(\.[1-4])?'
 			]
 		],
 
@@ -83,7 +84,7 @@ return [
 			'url' => '/api/{apiVersion}/forms',
 			'verb' => 'GET',
 			'requirements' => [
-				'apiVersion' => 'v2(\.[1-3])?'
+				'apiVersion' => 'v2(\.[1-4])?'
 			]
 		],
 		[
@@ -91,7 +92,7 @@ return [
 			'url' => '/api/{apiVersion}/form',
 			'verb' => 'POST',
 			'requirements' => [
-				'apiVersion' => 'v2(\.[1-3])?'
+				'apiVersion' => 'v2(\.[1-4])?'
 			]
 		],
 		[
@@ -107,7 +108,7 @@ return [
 			'url' => '/api/{apiVersion}/form/clone/{id}',
 			'verb' => 'POST',
 			'requirements' => [
-				'apiVersion' => 'v2(\.[1-3])?'
+				'apiVersion' => 'v2(\.[1-4])?'
 			]
 		],
 		// TODO: Remove POST in next API release
@@ -124,7 +125,7 @@ return [
 			'url' => '/api/{apiVersion}/form/update',
 			'verb' => 'PATCH',
 			'requirements' => [
-				'apiVersion' => 'v2\.[2-3]'
+				'apiVersion' => 'v2\.[2-4]'
 			]
 		],
 		[
@@ -132,7 +133,7 @@ return [
 			'url' => '/api/{apiVersion}/form/transfer',
 			'verb' => 'POST',
 			'requirements' => [
-				'apiVersion' => 'v2\.[2-3]'
+				'apiVersion' => 'v2\.[2-4]'
 			]
 		],
 		[
@@ -140,7 +141,7 @@ return [
 			'url' => '/api/{apiVersion}/form/{id}',
 			'verb' => 'DELETE',
 			'requirements' => [
-				'apiVersion' => 'v2(\.[1-3])?'
+				'apiVersion' => 'v2(\.[1-4])?'
 			]
 		],
 		[
@@ -148,7 +149,7 @@ return [
 			'url' => '/api/{apiVersion}/partial_form/{hash}',
 			'verb' => 'GET',
 			'requirements' => [
-				'apiVersion' => 'v2(\.[1-3])?'
+				'apiVersion' => 'v2(\.[1-4])?'
 			]
 		],
 		[
@@ -156,7 +157,7 @@ return [
 			'url' => '/api/{apiVersion}/shared_forms',
 			'verb' => 'GET',
 			'requirements' => [
-				'apiVersion' => 'v2(\.[1-3])?'
+				'apiVersion' => 'v2(\.[1-4])?'
 			]
 		],
 
@@ -166,7 +167,7 @@ return [
 			'url' => '/api/{apiVersion}/question',
 			'verb' => 'POST',
 			'requirements' => [
-				'apiVersion' => 'v2(\.[1-3])?'
+				'apiVersion' => 'v2(\.[1-4])?'
 			]
 		],
 		// TODO: Remove POST in next API release
@@ -183,7 +184,7 @@ return [
 			'url' => '/api/{apiVersion}/question/update',
 			'verb' => 'PATCH',
 			'requirements' => [
-				'apiVersion' => 'v2\.[2-3]'
+				'apiVersion' => 'v2\.[2-4]'
 			]
 		],
 		// TODO: Remove POST in next API release
@@ -200,7 +201,7 @@ return [
 			'url' => '/api/{apiVersion}/question/reorder',
 			'verb' => 'PUT',
 			'requirements' => [
-				'apiVersion' => 'v2\.[2-3]'
+				'apiVersion' => 'v2\.[2-4]'
 			]
 		],
 		[
@@ -208,7 +209,7 @@ return [
 			'url' => '/api/{apiVersion}/question/{id}',
 			'verb' => 'DELETE',
 			'requirements' => [
-				'apiVersion' => 'v2(\.[1-3])?'
+				'apiVersion' => 'v2(\.[1-4])?'
 			]
 		],
 		[
@@ -216,7 +217,7 @@ return [
 			'url' => '/api/{apiVersion}/question/clone/{id}',
 			'verb' => 'POST',
 			'requirements' => [
-				'apiVersion' => 'v2.3'
+				'apiVersion' => 'v2\.[3-4]'
 			]
 		],
 
@@ -226,7 +227,7 @@ return [
 			'url' => '/api/{apiVersion}/option',
 			'verb' => 'POST',
 			'requirements' => [
-				'apiVersion' => 'v2(\.[1-3])?'
+				'apiVersion' => 'v2(\.[1-4])?'
 			]
 		],
 		// TODO: Remove POST in next API release
@@ -243,7 +244,7 @@ return [
 			'url' => '/api/{apiVersion}/option/update',
 			'verb' => 'PATCH',
 			'requirements' => [
-				'apiVersion' => 'v2\.[2-3]'
+				'apiVersion' => 'v2\.[2-4]'
 			]
 		],
 		[
@@ -251,7 +252,7 @@ return [
 			'url' => '/api/{apiVersion}/option/{id}',
 			'verb' => 'DELETE',
 			'requirements' => [
-				'apiVersion' => 'v2(\.[1-3])?'
+				'apiVersion' => 'v2(\.[1-4])?'
 			]
 		],
 
@@ -261,7 +262,7 @@ return [
 			'url' => '/api/{apiVersion}/share',
 			'verb' => 'POST',
 			'requirements' => [
-				'apiVersion' => 'v2(\.[1-3])?'
+				'apiVersion' => 'v2(\.[1-4])?'
 			]
 		],
 		[
@@ -269,7 +270,7 @@ return [
 			'url' => '/api/{apiVersion}/share/{id}',
 			'verb' => 'DELETE',
 			'requirements' => [
-				'apiVersion' => 'v2(\.[1-3])?'
+				'apiVersion' => 'v2(\.[1-4])?'
 			]
 		],
 		// TODO: Remove POST in next API release
@@ -286,7 +287,7 @@ return [
 			'url' => '/api/{apiVersion}/share/update',
 			'verb' => 'PATCH',
 			'requirements' => [
-				'apiVersion' => 'v2\.[2-3]'
+				'apiVersion' => 'v2\.[2-4]'
 			]
 		],
 
@@ -296,7 +297,7 @@ return [
 			'url' => '/api/{apiVersion}/submissions/{hash}',
 			'verb' => 'GET',
 			'requirements' => [
-				'apiVersion' => 'v2(\.[1-3])?'
+				'apiVersion' => 'v2(\.[1-4])?'
 			]
 		],
 		[
@@ -320,7 +321,7 @@ return [
 			'url' => '/api/{apiVersion}/submissions/{formId}',
 			'verb' => 'DELETE',
 			'requirements' => [
-				'apiVersion' => 'v2(\.[1-3])?'
+				'apiVersion' => 'v2(\.[1-4])?'
 			]
 		],
 		[
@@ -328,7 +329,7 @@ return [
 			'url' => '/api/{apiVersion}/submission/insert',
 			'verb' => 'POST',
 			'requirements' => [
-				'apiVersion' => 'v2(\.[1-3])?'
+				'apiVersion' => 'v2(\.[1-4])?'
 			]
 		],
 		[
@@ -336,7 +337,7 @@ return [
 			'url' => '/api/{apiVersion}/submission/{id}',
 			'verb' => 'DELETE',
 			'requirements' => [
-				'apiVersion' => 'v2(\.[1-3])?'
+				'apiVersion' => 'v2(\.[1-4])?'
 			]
 		],
 		// Submissions linking with file in cloud

--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -99,7 +99,7 @@ return [
 			'url' => '/api/{apiVersion}/form/{id}',
 			'verb' => 'GET',
 			'requirements' => [
-				'apiVersion' => 'v2(\.[1-3])?'
+				'apiVersion' => 'v2(\.[1-4])?'
 			]
 		],
 		[
@@ -304,7 +304,7 @@ return [
 			'url' => '/api/{apiVersion}/submissions/export/{hash}',
 			'verb' => 'GET',
 			'requirements' => [
-				'apiVersion' => 'v2(\.[1-3])?'
+				'apiVersion' => 'v2(\.[1-4])?'
 			]
 		],
 		[
@@ -312,7 +312,7 @@ return [
 			'url' => '/api/{apiVersion}/submissions/export',
 			'verb' => 'POST',
 			'requirements' => [
-				'apiVersion' => 'v2(\.[1-3])?'
+				'apiVersion' => 'v2(\.[1-4])?'
 			]
 		],
 		[
@@ -339,5 +339,23 @@ return [
 				'apiVersion' => 'v2(\.[1-3])?'
 			]
 		],
+		// Submissions linking with file in cloud
+		[
+			'name' => 'api#linkFile',
+			'url' => '/api/{apiVersion}/form/link/{fileFormat}',
+			'verb' => 'POST',
+			'requirements' => [
+				'apiVersion' => 'v2.4',
+				'fileFormat' => 'csv|ods|xlsx'
+			]
+		],
+		[
+			'name' => 'api#unlinkFile',
+			'url' => '/api/{apiVersion}/form/unlink',
+			'verb' => 'POST',
+			'requirements' => [
+				'apiVersion' => 'v2.4',
+			]
+		]
 	]
 ];

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
 		"phpunit/phpunit": "^9"
 	},
 	"require": {
-		"league/csv": "^9.8.0"
+		"phpoffice/phpspreadsheet": "^1.29"
 	},
 	"extra": {
 		"bamarni-bin": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,52 +4,102 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a8c96b8fab85ad79f54e9ee7bfd41b71",
+    "content-hash": "fb5b7ffb977f6896be83170c3fb32813",
     "packages": [
         {
-            "name": "league/csv",
-            "version": "9.8.0",
+            "name": "ezyang/htmlpurifier",
+            "version": "v4.17.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/thephpleague/csv.git",
-                "reference": "9d2e0265c5d90f5dd601bc65ff717e05cec19b47"
+                "url": "https://github.com/ezyang/htmlpurifier.git",
+                "reference": "bbc513d79acf6691fa9cf10f192c90dd2957f18c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/csv/zipball/9d2e0265c5d90f5dd601bc65ff717e05cec19b47",
-                "reference": "9d2e0265c5d90f5dd601bc65ff717e05cec19b47",
+                "url": "https://api.github.com/repos/ezyang/htmlpurifier/zipball/bbc513d79acf6691fa9cf10f192c90dd2957f18c",
+                "reference": "bbc513d79acf6691fa9cf10f192c90dd2957f18c",
                 "shasum": ""
             },
             "require": {
-                "ext-json": "*",
-                "ext-mbstring": "*",
-                "php": "^7.4 || ^8.0"
+                "php": "~5.6.0 || ~7.0.0 || ~7.1.0 || ~7.2.0 || ~7.3.0 || ~7.4.0 || ~8.0.0 || ~8.1.0 || ~8.2.0 || ~8.3.0"
             },
             "require-dev": {
-                "ext-curl": "*",
-                "ext-dom": "*",
-                "friendsofphp/php-cs-fixer": "^v3.4.0",
-                "phpstan/phpstan": "^1.3.0",
-                "phpstan/phpstan-phpunit": "^1.0.0",
-                "phpstan/phpstan-strict-rules": "^1.1.0",
-                "phpunit/phpunit": "^9.5.11"
+                "cerdic/css-tidy": "^1.7 || ^2.0",
+                "simpletest/simpletest": "dev-master"
             },
             "suggest": {
-                "ext-dom": "Required to use the XMLConverter and or the HTMLConverter classes",
-                "ext-iconv": "Needed to ease transcoding CSV using iconv stream filters"
+                "cerdic/css-tidy": "If you want to use the filter 'Filter.ExtractStyleBlocks'.",
+                "ext-bcmath": "Used for unit conversion and imagecrash protection",
+                "ext-iconv": "Converts text to and from non-UTF-8 encodings",
+                "ext-tidy": "Used for pretty-printing HTML"
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "9.x-dev"
-                }
-            },
             "autoload": {
                 "files": [
-                    "src/functions_include.php"
+                    "library/HTMLPurifier.composer.php"
                 ],
+                "psr-0": {
+                    "HTMLPurifier": "library/"
+                },
+                "exclude-from-classmap": [
+                    "/library/HTMLPurifier/Language/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-2.1-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Edward Z. Yang",
+                    "email": "admin@htmlpurifier.org",
+                    "homepage": "http://ezyang.com"
+                }
+            ],
+            "description": "Standards compliant HTML filter written in PHP",
+            "homepage": "http://htmlpurifier.org/",
+            "keywords": [
+                "html"
+            ],
+            "support": {
+                "issues": "https://github.com/ezyang/htmlpurifier/issues",
+                "source": "https://github.com/ezyang/htmlpurifier/tree/v4.17.0"
+            },
+            "time": "2023-11-17T15:01:25+00:00"
+        },
+        {
+            "name": "maennchen/zipstream-php",
+            "version": "2.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/maennchen/ZipStream-PHP.git",
+                "reference": "3fa72e4c71a43f9e9118752a5c90e476a8dc9eb3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/maennchen/ZipStream-PHP/zipball/3fa72e4c71a43f9e9118752a5c90e476a8dc9eb3",
+                "reference": "3fa72e4c71a43f9e9118752a5c90e476a8dc9eb3",
+                "shasum": ""
+            },
+            "require": {
+                "ext-mbstring": "*",
+                "myclabs/php-enum": "^1.5",
+                "php": "^8.0",
+                "psr/http-message": "^1.0"
+            },
+            "require-dev": {
+                "ext-zip": "*",
+                "friendsofphp/php-cs-fixer": "^3.9",
+                "guzzlehttp/guzzle": "^6.5.3 || ^7.2.0",
+                "mikey179/vfsstream": "^1.6",
+                "php-coveralls/php-coveralls": "^2.4",
+                "phpunit/phpunit": "^8.5.8 || ^9.4.2",
+                "vimeo/psalm": "^5.0"
+            },
+            "type": "library",
+            "autoload": {
                 "psr-4": {
-                    "League\\Csv\\": "src"
+                    "ZipStream\\": "src/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -58,37 +108,528 @@
             ],
             "authors": [
                 {
-                    "name": "Ignace Nyamagana Butera",
-                    "email": "nyamsprod@gmail.com",
-                    "homepage": "https://github.com/nyamsprod/",
-                    "role": "Developer"
+                    "name": "Paul Duncan",
+                    "email": "pabs@pablotron.org"
+                },
+                {
+                    "name": "Jonatan Männchen",
+                    "email": "jonatan@maennchen.ch"
+                },
+                {
+                    "name": "Jesse Donat",
+                    "email": "donatj@gmail.com"
+                },
+                {
+                    "name": "András Kolesár",
+                    "email": "kolesar@kolesar.hu"
                 }
             ],
-            "description": "CSV data manipulation made easy in PHP",
-            "homepage": "https://csv.thephpleague.com",
+            "description": "ZipStream is a library for dynamically streaming dynamic zip files from PHP without writing to the disk at all on the server.",
             "keywords": [
-                "convert",
-                "csv",
-                "export",
-                "filter",
-                "import",
-                "read",
-                "transform",
-                "write"
+                "stream",
+                "zip"
             ],
             "support": {
-                "docs": "https://csv.thephpleague.com",
-                "issues": "https://github.com/thephpleague/csv/issues",
-                "rss": "https://github.com/thephpleague/csv/releases.atom",
-                "source": "https://github.com/thephpleague/csv"
+                "issues": "https://github.com/maennchen/ZipStream-PHP/issues",
+                "source": "https://github.com/maennchen/ZipStream-PHP/tree/2.4.0"
             },
             "funding": [
                 {
-                    "url": "https://github.com/sponsors/nyamsprod",
+                    "url": "https://github.com/maennchen",
                     "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/zipstream",
+                    "type": "open_collective"
                 }
             ],
-            "time": "2022-01-04T00:13:07+00:00"
+            "time": "2022-12-08T12:29:14+00:00"
+        },
+        {
+            "name": "markbaker/complex",
+            "version": "3.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/MarkBaker/PHPComplex.git",
+                "reference": "95c56caa1cf5c766ad6d65b6344b807c1e8405b9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/MarkBaker/PHPComplex/zipball/95c56caa1cf5c766ad6d65b6344b807c1e8405b9",
+                "reference": "95c56caa1cf5c766ad6d65b6344b807c1e8405b9",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "require-dev": {
+                "dealerdirect/phpcodesniffer-composer-installer": "dev-master",
+                "phpcompatibility/php-compatibility": "^9.3",
+                "phpunit/phpunit": "^7.0 || ^8.0 || ^9.0",
+                "squizlabs/php_codesniffer": "^3.7"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Complex\\": "classes/src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mark Baker",
+                    "email": "mark@lange.demon.co.uk"
+                }
+            ],
+            "description": "PHP Class for working with complex numbers",
+            "homepage": "https://github.com/MarkBaker/PHPComplex",
+            "keywords": [
+                "complex",
+                "mathematics"
+            ],
+            "support": {
+                "issues": "https://github.com/MarkBaker/PHPComplex/issues",
+                "source": "https://github.com/MarkBaker/PHPComplex/tree/3.0.2"
+            },
+            "time": "2022-12-06T16:21:08+00:00"
+        },
+        {
+            "name": "markbaker/matrix",
+            "version": "3.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/MarkBaker/PHPMatrix.git",
+                "reference": "728434227fe21be27ff6d86621a1b13107a2562c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/MarkBaker/PHPMatrix/zipball/728434227fe21be27ff6d86621a1b13107a2562c",
+                "reference": "728434227fe21be27ff6d86621a1b13107a2562c",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1 || ^8.0"
+            },
+            "require-dev": {
+                "dealerdirect/phpcodesniffer-composer-installer": "dev-master",
+                "phpcompatibility/php-compatibility": "^9.3",
+                "phpdocumentor/phpdocumentor": "2.*",
+                "phploc/phploc": "^4.0",
+                "phpmd/phpmd": "2.*",
+                "phpunit/phpunit": "^7.0 || ^8.0 || ^9.0",
+                "sebastian/phpcpd": "^4.0",
+                "squizlabs/php_codesniffer": "^3.7"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Matrix\\": "classes/src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mark Baker",
+                    "email": "mark@demon-angel.eu"
+                }
+            ],
+            "description": "PHP Class for working with matrices",
+            "homepage": "https://github.com/MarkBaker/PHPMatrix",
+            "keywords": [
+                "mathematics",
+                "matrix",
+                "vector"
+            ],
+            "support": {
+                "issues": "https://github.com/MarkBaker/PHPMatrix/issues",
+                "source": "https://github.com/MarkBaker/PHPMatrix/tree/3.0.1"
+            },
+            "time": "2022-12-02T22:17:43+00:00"
+        },
+        {
+            "name": "myclabs/php-enum",
+            "version": "1.8.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/myclabs/php-enum.git",
+                "reference": "a867478eae49c9f59ece437ae7f9506bfaa27483"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/myclabs/php-enum/zipball/a867478eae49c9f59ece437ae7f9506bfaa27483",
+                "reference": "a867478eae49c9f59ece437ae7f9506bfaa27483",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "php": "^7.3 || ^8.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.5",
+                "squizlabs/php_codesniffer": "1.*",
+                "vimeo/psalm": "^4.6.2"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "MyCLabs\\Enum\\": "src/"
+                },
+                "classmap": [
+                    "stubs/Stringable.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP Enum contributors",
+                    "homepage": "https://github.com/myclabs/php-enum/graphs/contributors"
+                }
+            ],
+            "description": "PHP Enum implementation",
+            "homepage": "http://github.com/myclabs/php-enum",
+            "keywords": [
+                "enum"
+            ],
+            "support": {
+                "issues": "https://github.com/myclabs/php-enum/issues",
+                "source": "https://github.com/myclabs/php-enum/tree/1.8.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/mnapoli",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/myclabs/php-enum",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2022-08-04T09:53:51+00:00"
+        },
+        {
+            "name": "phpoffice/phpspreadsheet",
+            "version": "1.29.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPOffice/PhpSpreadsheet.git",
+                "reference": "fde2ccf55eaef7e86021ff1acce26479160a0fa0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPOffice/PhpSpreadsheet/zipball/fde2ccf55eaef7e86021ff1acce26479160a0fa0",
+                "reference": "fde2ccf55eaef7e86021ff1acce26479160a0fa0",
+                "shasum": ""
+            },
+            "require": {
+                "ext-ctype": "*",
+                "ext-dom": "*",
+                "ext-fileinfo": "*",
+                "ext-gd": "*",
+                "ext-iconv": "*",
+                "ext-libxml": "*",
+                "ext-mbstring": "*",
+                "ext-simplexml": "*",
+                "ext-xml": "*",
+                "ext-xmlreader": "*",
+                "ext-xmlwriter": "*",
+                "ext-zip": "*",
+                "ext-zlib": "*",
+                "ezyang/htmlpurifier": "^4.15",
+                "maennchen/zipstream-php": "^2.1 || ^3.0",
+                "markbaker/complex": "^3.0",
+                "markbaker/matrix": "^3.0",
+                "php": "^7.4 || ^8.0",
+                "psr/http-client": "^1.0",
+                "psr/http-factory": "^1.0",
+                "psr/simple-cache": "^1.0 || ^2.0 || ^3.0"
+            },
+            "require-dev": {
+                "dealerdirect/phpcodesniffer-composer-installer": "dev-main",
+                "dompdf/dompdf": "^1.0 || ^2.0",
+                "friendsofphp/php-cs-fixer": "^3.2",
+                "mitoteam/jpgraph": "^10.3",
+                "mpdf/mpdf": "^8.1.1",
+                "phpcompatibility/php-compatibility": "^9.3",
+                "phpstan/phpstan": "^1.1",
+                "phpstan/phpstan-phpunit": "^1.0",
+                "phpunit/phpunit": "^8.5 || ^9.0 || ^10.0",
+                "squizlabs/php_codesniffer": "^3.7",
+                "tecnickcom/tcpdf": "^6.5"
+            },
+            "suggest": {
+                "dompdf/dompdf": "Option for rendering PDF with PDF Writer",
+                "ext-intl": "PHP Internationalization Functions",
+                "mitoteam/jpgraph": "Option for rendering charts, or including charts with PDF or HTML Writers",
+                "mpdf/mpdf": "Option for rendering PDF with PDF Writer",
+                "tecnickcom/tcpdf": "Option for rendering PDF with PDF Writer"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "PhpOffice\\PhpSpreadsheet\\": "src/PhpSpreadsheet"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Maarten Balliauw",
+                    "homepage": "https://blog.maartenballiauw.be"
+                },
+                {
+                    "name": "Mark Baker",
+                    "homepage": "https://markbakeruk.net"
+                },
+                {
+                    "name": "Franck Lefevre",
+                    "homepage": "https://rootslabs.net"
+                },
+                {
+                    "name": "Erik Tilt"
+                },
+                {
+                    "name": "Adrien Crivelli"
+                }
+            ],
+            "description": "PHPSpreadsheet - Read, Create and Write Spreadsheet documents in PHP - Spreadsheet engine",
+            "homepage": "https://github.com/PHPOffice/PhpSpreadsheet",
+            "keywords": [
+                "OpenXML",
+                "excel",
+                "gnumeric",
+                "ods",
+                "php",
+                "spreadsheet",
+                "xls",
+                "xlsx"
+            ],
+            "support": {
+                "issues": "https://github.com/PHPOffice/PhpSpreadsheet/issues",
+                "source": "https://github.com/PHPOffice/PhpSpreadsheet/tree/1.29.0"
+            },
+            "time": "2023-06-14T22:48:31+00:00"
+        },
+        {
+            "name": "psr/http-client",
+            "version": "1.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-client.git",
+                "reference": "bb5906edc1c324c9a05aa0873d40117941e5fa90"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-client/zipball/bb5906edc1c324c9a05aa0873d40117941e5fa90",
+                "reference": "bb5906edc1c324c9a05aa0873d40117941e5fa90",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0 || ^8.0",
+                "psr/http-message": "^1.0 || ^2.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Client\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for HTTP clients",
+            "homepage": "https://github.com/php-fig/http-client",
+            "keywords": [
+                "http",
+                "http-client",
+                "psr",
+                "psr-18"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/http-client"
+            },
+            "time": "2023-09-23T14:17:50+00:00"
+        },
+        {
+            "name": "psr/http-factory",
+            "version": "1.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-factory.git",
+                "reference": "e616d01114759c4c489f93b099585439f795fe35"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-factory/zipball/e616d01114759c4c489f93b099585439f795fe35",
+                "reference": "e616d01114759c4c489f93b099585439f795fe35",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.0.0",
+                "psr/http-message": "^1.0 || ^2.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Message\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interfaces for PSR-7 HTTP message factories",
+            "keywords": [
+                "factory",
+                "http",
+                "message",
+                "psr",
+                "psr-17",
+                "psr-7",
+                "request",
+                "response"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/http-factory/tree/1.0.2"
+            },
+            "time": "2023-04-10T20:10:41+00:00"
+        },
+        {
+            "name": "psr/http-message",
+            "version": "1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-message.git",
+                "reference": "cb6ce4845ce34a8ad9e68117c10ee90a29919eba"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-message/zipball/cb6ce4845ce34a8ad9e68117c10ee90a29919eba",
+                "reference": "cb6ce4845ce34a8ad9e68117c10ee90a29919eba",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Message\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for HTTP messages",
+            "homepage": "https://github.com/php-fig/http-message",
+            "keywords": [
+                "http",
+                "http-message",
+                "psr",
+                "psr-7",
+                "request",
+                "response"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/http-message/tree/1.1"
+            },
+            "time": "2023-04-04T09:50:52+00:00"
+        },
+        {
+            "name": "psr/simple-cache",
+            "version": "3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/simple-cache.git",
+                "reference": "764e0b3939f5ca87cb904f570ef9be2d78a07865"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/simple-cache/zipball/764e0b3939f5ca87cb904f570ef9be2d78a07865",
+                "reference": "764e0b3939f5ca87cb904f570ef9be2d78a07865",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.0.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\SimpleCache\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interfaces for simple caching",
+            "keywords": [
+                "cache",
+                "caching",
+                "psr",
+                "psr-16",
+                "simple-cache"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/simple-cache/tree/3.0.0"
+            },
+            "time": "2021-10-29T13:26:27+00:00"
         }
     ],
     "packages-dev": [

--- a/lib/Constants.php
+++ b/lib/Constants.php
@@ -166,4 +166,12 @@ class Constants {
 	 * Constants related to extra settings for questions
 	 */
 	public const QUESTION_EXTRASETTINGS_OTHER_PREFIX = 'system-other-answer:';
+
+	public const SUPPORTED_EXPORT_FORMATS = [
+		'csv' => 'text/csv',
+		'ods' => 'application/vnd.oasis.opendocument.spreadsheet',
+		'xlsx' => 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+	];
+
+	public const DEFAULT_FILE_FORMAT = 'csv';
 }

--- a/lib/Db/Form.php
+++ b/lib/Db/Form.php
@@ -38,6 +38,10 @@ use OCP\AppFramework\Db\Entity;
  * @method void setDescription(string $value)
  * @method string getOwnerId()
  * @method void setOwnerId(string $value)
+ * @method int|null getFileId()
+ * @method void setFileId(int|null $value)
+ * @method string|null getFileFormat()
+ * @method void setFileFormat(string|null $value)
  * @method array getAccess()
  * @method void setAccess(array $value)
  * @method integer getCreated()
@@ -60,6 +64,8 @@ class Form extends Entity {
 	protected $title;
 	protected $description;
 	protected $ownerId;
+	protected $fileId;
+	protected $fileFormat;
 	protected $accessJson;
 	protected $created;
 	protected $expires;
@@ -99,6 +105,8 @@ class Form extends Entity {
 			'title' => (string)$this->getTitle(),
 			'description' => (string)$this->getDescription(),
 			'ownerId' => $this->getOwnerId(),
+			'fileId' => $this->getFileId(),
+			'fileFormat' => $this->getFileFormat(),
 			'created' => $this->getCreated(),
 			'access' => $this->getAccess(),
 			'expires' => (int)$this->getExpires(),

--- a/lib/Migration/Version040010Date20240122133700.php
+++ b/lib/Migration/Version040010Date20240122133700.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright Copyright (c) 2024 Kostiantyn Miakshyn <molodchick@gmail.com>
+ *
+ * @author Kostiantyn Miakshyn <molodchick@gmail.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Forms\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\DB\Types;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+class Version040010Date20240122133700 extends SimpleMigrationStep {
+	/**
+	 * @param IOutput $output
+	 * @param Closure $schemaClosure The `\Closure` returns a `ISchemaWrapper`
+	 * @param array $options
+	 * @return null|ISchemaWrapper
+	 */
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
+		/** @var ISchemaWrapper $schema */
+		$schema = $schemaClosure();
+
+		$table = $schema->getTable('forms_v2_forms');
+		$table->addColumn('file_id', Types::BIGINT, [
+			'notnull' => false,
+			'default' => null,
+			'length' => 11,
+			'unsigned' => true,
+		]);
+
+		$table->addColumn('file_format', Types::STRING, [
+			'notnull' => false,
+			'default' => null,
+			'length' => 5,
+		]);
+
+		return $schema;
+	}
+}

--- a/psalm.xml
+++ b/psalm.xml
@@ -38,4 +38,7 @@
 			</errorLevel>
 		</UndefinedDocblockClass>
 	</issueHandlers>
+	<stubs>
+		<file name="tests/stubs/oc_hooks_emitter.php" />
+	</stubs>
 </psalm>

--- a/tests/Unit/FormsMigratorTest.php
+++ b/tests/Unit/FormsMigratorTest.php
@@ -114,10 +114,60 @@ class FormsMigratorTest extends TestCase {
 	public function dataExport() {
 		return [
 			'exactlyOneOfEach' => [
-				'expectedJson' => '[{"title":"Link","description":"","created":1646251830,"access":{"permitAllUsers":false,"showToAllUsers":false},"expires":0,"isAnonymous":false,"submitMultiple":false,"showExpiration":false,"lastUpdated":123456789,"submissionMessage":"Back to website","questions":[{"id":14,"order":2,"type":"multiple","isRequired":false,"text":"checkbox","description":"huhu","extraSettings":{},"options":[{"text":"ans1"}]}],"submissions":[{"userId":"anyUser@localhost","timestamp":1651354059,"answers":[{"questionId":14,"text":"ans1"}]}]}]'
+				'expectedJson' => <<<'JSON'
+[
+  {
+    "title": "Link",
+    "description": "",
+    "fileId": null,
+    "fileFormat": null,
+    "created": 1646251830,
+    "access": {
+      "permitAllUsers": false,
+      "showToAllUsers": false
+    },
+    "expires": 0,
+    "isAnonymous": false,
+    "submitMultiple": false,
+    "showExpiration": false,
+    "lastUpdated": 123456789,
+    "submissionMessage": "Back to website",
+    "questions": [
+      {
+        "id": 14,
+        "order": 2,
+        "type": "multiple",
+        "isRequired": false,
+        "text": "checkbox",
+        "description": "huhu",
+        "extraSettings": {},
+        "options": [
+          {
+            "text": "ans1"
+          }
+        ]
+      }
+    ],
+    "submissions": [
+      {
+        "userId": "anyUser@localhost",
+        "timestamp": 1651354059,
+        "answers": [
+          {
+            "questionId": 14,
+            "text": "ans1"
+          }
+        ]
+      }
+    ]
+  }
+]
+JSON
+
 			]
 		];
 	}
+
 	/**
 	 * @dataProvider dataExport
 	 *
@@ -213,8 +263,7 @@ class FormsMigratorTest extends TestCase {
 		$exportDestination->expects($this->once())
 			->method('addFileContents')
 			->will($this->returnCallback(function ($path, $jsonData) use ($expectedJson) {
-				$this->assertEquals($expectedJson, $jsonData);
-				return;
+				$this->assertJsonStringEqualsJsonString($expectedJson, $jsonData);
 			}));
 		$this->formsMigrator->export($user, $exportDestination, $output);
 	}

--- a/tests/stubs/oc_hooks_emitter.php
+++ b/tests/stubs/oc_hooks_emitter.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace OC\Hooks {
+	class Emitter {
+		public function emit(string $class, string $value, array $option) {
+		}
+		/** Closure $closure */
+		public function listen(string $class, string $value, $closure) {
+		}
+	}
+}


### PR DESCRIPTION
Hello everyone!

I've added possibility to link form with spreadsheet in csv/ods/xlsx format and automatically export it once new submission added. Inspired from #1403 but with more formats. Also we edit already existent file, which give us possibility to add additional columns with notes/statuses/etc.

Here you can find few video/screenshots:

https://github.com/nextcloud/forms/assets/191082/4e1426dc-17dd-4328-81e4-7e84bd43e414


<details>
<summary>Exported file</summary>

![image](https://github.com/nextcloud/forms/assets/191082/4288d4ae-f40c-4117-806f-8529c6a96d7e)
</details>

What is out of scope right now but can be added in upcoming PRs:
- handling of responses deletion
- handling of adding/removal of the questions

Todo:
- [x] fix old tests and add new
