### PR TITLE
fix: Fix import of debounce

### DIFF
--- a/src/mixins/QuestionMixin.js
+++ b/src/mixins/QuestionMixin.js
@@ -19,11 +19,11 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  *
  */
-import { debounce } from 'debounce'
 import { showError } from '@nextcloud/dialogs'
 import { emit } from '@nextcloud/event-bus'
 import { generateOcsUrl } from '@nextcloud/router'
 import axios from '@nextcloud/axios'
+import debounce from 'debounce'
 
 import logger from '../utils/Logger.js'
 import Question from '../components/Questions/Question.vue'


### PR DESCRIPTION
Fix wrong import, importing the named export is not possible since the update from #1782 