### PR TITLE
fix(Submit): Make `answers` reactive and fix invalid mutation of computed property

### DIFF
--- a/src/components/Questions/AnswerInput.vue
+++ b/src/components/Questions/AnswerInput.vue
@@ -126,7 +126,7 @@ export default {
 
 				// Forward changes, but use current answer.text to avoid erasing
 				// any in-between changes while creating the answer
-				Object.assign(newAnswer, { text: this.$refs.input.value })
+				newAnswer.text = this.$refs.input.value
 				this.$emit('update:answer', answer.id, newAnswer)
 			} else {
 				this.debounceUpdateAnswer(answer)

--- a/src/components/Questions/QuestionMultiple.vue
+++ b/src/components/Questions/QuestionMultiple.vue
@@ -57,7 +57,7 @@
 						:type="isUnique ? 'radio' : 'checkbox'"
 						:required="checkRequired('other-answer')"
 						class="question__label"
-						@update:checked="onChange"
+						@update:checked="onChangeOther"
 						@keydown.enter.exact.prevent="onKeydownEnter">
 						{{ t('forms', 'Other:') }}
 					</NcCheckboxRadioSwitch>
@@ -257,6 +257,22 @@ export default {
 
 		onChange(value) {
 			this.$emit('update:values', this.isUnique ? [value] : value)
+		},
+
+		/**
+		 * Handle toggling the "other"-answer checkbox / radio switch
+		 * @param {string|string[]} value The new value of the answer(s)
+		 */
+		onChangeOther(value) {
+			value = [value].flat()
+			const pureValue = value.filter((v) => !v.startsWith(QUESTION_EXTRASETTINGS_OTHER_PREFIX))
+
+			if (value.length > pureValue.length) {
+				// make sure to add the cached test on re-enable
+				this.onChange([...pureValue, `${QUESTION_EXTRASETTINGS_OTHER_PREFIX}${this.cachedOtherAnswerText}`])
+			} else {
+				this.onChange(value)
+			}
 		},
 
 		/**


### PR DESCRIPTION
* Alternative to resolve #1780 

This fixes the root cause for the question component not updating: Non reactive answers in `Submit`, meaning after assigning a new value to `answers[key]` the watch effect was never triggered and thus the question component was never updated.
So instead use a `onUpdate` method to update the `answers` object in a way that will trigger any watch effect.

Also make `getFormValuesFromLocalStorage` a method instead a computed value. Previously that computed value were assigned a new value which is invalid as computed values should be constant (except for computed setter but this was none).