### PR TITLE
enh: Allow to set `results_delete` permission on the frontend

### DIFF
--- a/lib/Controller/ApiController.php
+++ b/lib/Controller/ApiController.php
@@ -1016,8 +1016,9 @@ class ApiController extends OCSController {
 			throw new OCSBadRequestException();
 		}
 
-		if ($form->getOwnerId() !== $this->currentUser->getUID()) {
-			$this->logger->debug('This form is not owned by the current user');
+		// The current user has permissions to remove submissions
+		if (!$this->formsService->canDeleteResults($form)) {
+			$this->logger->debug('This form is not owned by the current user and user has no `results_delete` permission');
 			throw new OCSForbiddenException();
 		}
 

--- a/lib/Controller/ShareApiController.php
+++ b/lib/Controller/ShareApiController.php
@@ -313,6 +313,11 @@ class ShareApiController extends OCSController {
 			return false;
 		}
 
+		if (in_array(Constants::PERMISSION_RESULTS_DELETE, $sanitizedPermissions) && !in_array(Constants::PERMISSION_RESULTS, $sanitizedPermissions)) {
+			$this->logger->debug('Permission results_delete is only allowed when permission results is also set');
+			return false;
+		}
+
 		// Make sure only users can have special permissions
 		if (count($sanitizedPermissions) > 1) {
 			switch ($shareType) {

--- a/lib/Service/FormsService.php
+++ b/lib/Service/FormsService.php
@@ -253,6 +253,16 @@ class FormsService {
 	}
 
 	/**
+	 * Can the current user delete results of a form
+	 *
+	 * @param Form $form
+	 * @return boolean
+	 */
+	public function canDeleteResults(Form $form): bool {
+		return in_array(Constants::PERMISSION_RESULTS_DELETE, $this->getPermissions($form));
+	}
+
+	/**
 	 * Can the user submit a form
 	 *
 	 * @param Form $form
@@ -475,7 +485,7 @@ class FormsService {
 	 *
 	 * @param int $formId The form to query shares for
 	 * @param string $userId The user to check if shared with
-	 * @return array
+	 * @return Share[]
 	 */
 	protected function getSharesWithUser(int $formId, string $userId): array {
 		$shareEntities = $this->shareMapper->findByForm($formId);

--- a/src/components/SidebarTabs/SharingShareDiv.vue
+++ b/src/components/SidebarTabs/SharingShareDiv.vue
@@ -35,6 +35,9 @@
 			<NcActionCheckbox :checked="canAccessResults" @update:checked="updatePermissionResults">
 				{{ t('forms', 'View responses') }}
 			</NcActionCheckbox>
+			<NcActionCheckbox :checked="canDeleteResults" :disabled="!canAccessResults" @update:checked="updatePermissionDeleteResults">
+				{{ t('forms', 'Delete responses') }}
+			</NcActionCheckbox>
 			<NcActionSeparator />
 			<NcActionButton @click="removeShare">
 				<template #icon>
@@ -82,6 +85,9 @@ export default {
 		canAccessResults() {
 			return this.share.permissions.includes(this.PERMISSION_TYPES.PERMISSION_RESULTS)
 		},
+		canDeleteResults() {
+			return this.share.permissions.includes(this.PERMISSION_TYPES.PERMISSION_RESULTS_DELETE)
+		},
 		isNoUser() {
 			return this.share.shareType !== this.SHARE_TYPES.SHARE_TYPE_USER
 		},
@@ -109,7 +115,18 @@ export default {
 		 * @param {boolean} hasPermission If the results permission should be granted
 		 */
 		updatePermissionResults(hasPermission) {
+			if (hasPermission === false) {
+				// ensure to remove the delete permission if results permission is dropped
+				this.updatePermission(this.PERMISSION_TYPES.PERMISSION_RESULTS_DELETE, false)
+			}
 			return this.updatePermission(this.PERMISSION_TYPES.PERMISSION_RESULTS, hasPermission)
+		},
+
+		/**
+		 * @param {boolean} hasPermission If the results_delete permission should be granted
+		 */
+		updatePermissionDeleteResults(hasPermission) {
+			return this.updatePermission(this.PERMISSION_TYPES.PERMISSION_RESULTS_DELETE, hasPermission)
 		},
 
 		/**

--- a/src/views/Results.vue
+++ b/src/views/Results.vue
@@ -275,6 +275,7 @@ export default {
 
 			try {
 				await axios.delete(generateOcsUrl('apps/forms/api/v2.2/submission/{id}', { id }))
+				showSuccess(t('forms', 'Submission deleted'))
 				const index = this.form.submissions.findIndex(search => search.id === id)
 				this.form.submissions.splice(index, 1)
 				emit('forms:last-updated:set', this.form.id)

--- a/tests/Unit/Controller/ShareApiControllerTest.php
+++ b/tests/Unit/Controller/ShareApiControllerTest.php
@@ -594,6 +594,21 @@ class ShareApiControllerTest extends TestCase {
 				'expected' => 1,
 				'exception' => null
 			],
+			'valid-permissions-share-delete' => [
+				'share' => [
+					'id' => 1,
+					'formId' => 5,
+					'shareType' => 0,
+					'shareWith' => 'user1',
+					'permissions' => [Constants::PERMISSION_SUBMIT]
+				],
+				'formOwner' => 'currentUser',
+				'keyValuePairs' => [
+					'permissions' => [Constants::PERMISSION_RESULTS, Constants::PERMISSION_RESULTS_DELETE, Constants::PERMISSION_SUBMIT]
+				],
+				'expected' => 1,
+				'exception' => null
+			],
 			'no-permission' => [
 				'share' => [
 					'id' => 1,
@@ -605,6 +620,37 @@ class ShareApiControllerTest extends TestCase {
 				'formOwner' => 'currentUser',
 				'keyValuePairs' => [
 					'permissions' => []
+				],
+				'expected' => null,
+				'exception' => '\OCP\AppFramework\OCS\OCSBadRequestException'
+			],
+			'invalid-permission-missing-submit' => [
+				'share' => [
+					'id' => 1,
+					'formId' => 5,
+					'shareType' => 0,
+					'shareWith' => 'user1',
+					'permissions' => [Constants::PERMISSION_SUBMIT],
+				],
+				'formOwner' => 'currentUser',
+				'keyValuePairs' => [
+					'permissions' => [Constants::PERMISSION_RESULTS_DELETE],
+				],
+				'expected' => null,
+				'exception' => '\OCP\AppFramework\OCS\OCSBadRequestException'
+			],
+			// PERMISSION_RESULTS_DELETE is only allowed if PERMISSION_RESULTS is set
+			'invalid-permission-missing-results' => [
+				'share' => [
+					'id' => 1,
+					'formId' => 5,
+					'shareType' => 0,
+					'shareWith' => 'user1',
+					'permissions' => [Constants::PERMISSION_SUBMIT],
+				],
+				'formOwner' => 'currentUser',
+				'keyValuePairs' => [
+					'permissions' => [Constants::PERMISSION_SUBMIT, Constants::PERMISSION_RESULTS_DELETE],
 				],
 				'expected' => null,
 				'exception' => '\OCP\AppFramework\OCS\OCSBadRequestException'


### PR DESCRIPTION
Allow to set the permission for deleting submissions. Also fix the permission check when deleting submission to allow any user with permission to delete a submission instead of restricting to form owner.