### PR TITLE
Remove deprecated setModal

### DIFF
--- a/src/views/Results.vue
+++ b/src/views/Results.vue
@@ -168,7 +168,6 @@ import PermissionTypes from '../mixins/PermissionTypes.js'
 
 const picker = getFilePickerBuilder(t('forms', 'Save CSV to Files'))
 	.setMultiSelect(false)
-	.setModal(true)
 	.setType(1)
 	.allowDirectories()
 	.build()


### PR DESCRIPTION
setModal was removed from filePicker in nextcloud-dialogs v5.0.0 : https://github.com/nextcloud-libraries/nextcloud-dialogs/pull/911