### PR TITLE
fix: Prevent race condition on unique-submission forms

### DIFF
--- a/lib/Db/SubmissionMapper.php
+++ b/lib/Db/SubmissionMapper.php
@@ -110,16 +110,22 @@ class SubmissionMapper extends QBMapper {
 	}
 
 	/**
+	 * Count submissions by form and optionally also by userId
+	 * @param int $formId ID of the form to count submissions for
+	 * @param string|null $userId optionally limit submissions to the one of that user
 	 * @throws \Exception
 	 */
-	public function countSubmissions(int $formId): int {
+	public function countSubmissions(int $formId, ?string $userId = null): int {
 		$qb = $this->db->getQueryBuilder();
 
-		$qb->select($qb->func()->count('*', 'num_submissions'))
+		$query = $qb->select($qb->func()->count('*', 'num_submissions'))
 			->from($this->getTableName())
 			->where($qb->expr()->eq('form_id', $qb->createNamedParameter($formId, IQueryBuilder::PARAM_INT)));
+		if (!is_null($userId)) {
+			$query->andWhere($qb->expr()->eq('user_id', $qb->createNamedParameter($userId, IQueryBuilder::PARAM_STR)));
+		}
 
-		$result = $qb->executeQuery();
+		$result = $query->executeQuery();
 		$row = $result->fetch();
 		$result->closeCursor();
 

--- a/lib/Service/SubmissionService.php
+++ b/lib/Service/SubmissionService.php
@@ -37,6 +37,7 @@ use OCA\Forms\Db\Answer;
 use OCA\Forms\Db\AnswerMapper;
 use OCA\Forms\Db\FormMapper;
 use OCA\Forms\Db\QuestionMapper;
+use OCA\Forms\Db\Submission;
 use OCA\Forms\Db\SubmissionMapper;
 use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\Files\File;
@@ -151,6 +152,13 @@ class SubmissionService {
 		} finally {
 			return $submissionList;
 		}
+	}
+
+	/**
+	 * Validate the new submission is unique
+	 */
+	public function isUniqueSubmission(Submission $newSubmission): bool {
+		return $this->submissionMapper->countSubmissions($newSubmission->getFormId(), $newSubmission->getUserId()) === 1;
 	}
 
 	/**

--- a/tests/Unit/Controller/ApiControllerTest.php
+++ b/tests/Unit/Controller/ApiControllerTest.php
@@ -713,6 +713,10 @@ class ApiControllerTest extends TestCase {
 			->with(1)
 			->willReturn($form);
 
+		$this->submissionService
+			->method('validateSubmission')
+			->willReturn(true);
+
 		$this->formAccess($hasUserAccess, $hasFormExpired, $canSubmit);
 
 		$this->expectException(OCSForbiddenException::class);

--- a/tests/Unit/Service/SubmissionServiceTest.php
+++ b/tests/Unit/Service/SubmissionServiceTest.php
@@ -128,6 +128,41 @@ class SubmissionServiceTest extends TestCase {
 		);
 	}
 
+	/**
+	 * @dataProvider dataIsUniqueSubmission
+	 */
+	public function testIsUniqueSubmission(array $submissionData, int $numberOfSubmissions, bool $expected) {
+		$this->submissionMapper->method('countSubmissions')
+			->with($submissionData['formId'], $submissionData['userId'])
+			->willReturn($numberOfSubmissions);
+
+		$submission = Submission::fromParams($submissionData);
+		$this->assertEquals($expected, $this->submissionService->isUniqueSubmission($submission));
+	}
+
+	public function dataIsUniqueSubmission() {
+		return [
+			[
+				'submissionData' => [
+					'id' => 1,
+					'userId' => 'user',
+					'formId' => 1,
+				],
+				'numberOfSubmissions' => 1,
+				'expected' => true,
+			],
+			[
+				'submissionData' => [
+					'id' => 3,
+					'userId' => 'user',
+					'formId' => 1,
+				],
+				'numberOfSubmissions' => 2,
+				'expected' => false,
+			],
+		];
+	}
+
 	public function testGetSubmissions() {
 		$submission_1 = new Submission();
 		$submission_1->setId(42);


### PR DESCRIPTION
Currently a series of requests can be crafted so that multiple submissions of the same user are inserted.
As the unique property of a submission is only checked once so that if multiple requests arrive at the server right in the same time they will all be inserted.

To prevent this the time window is minimized by placing the check right before the insert and check afterwards if the submission really is unique.