### PR TITLE
fix(Question): close question menu after copy question

### DIFF
--- a/src/components/Questions/Question.vue
+++ b/src/components/Questions/Question.vue
@@ -99,7 +99,8 @@
 						</template>
 						{{ t('forms', 'Technical name') }}
 					</NcActionInput>
-					<NcActionButton @click="onClone">
+					<NcActionButton :close-after-click="true"
+						@click="onClone">
 						<template #icon>
 							<IconContentCopy :size="20" />
 						</template>


### PR DESCRIPTION
This fixes some focus jumping after copying a question by closing the action menu after the click.

Signed-off-by: Christian Hartmann <chris-hartmann@gmx.de>