### PR TITLE
fix: Use separate chunk for `vue` and `vue-router` to prevent multiple imports

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -10,6 +10,13 @@ export default createAppConfig({
 	config: {
 		build: {
 			cssCodeSplit: false,
+			rollupOptions: {
+				output: {
+					manualChunks: {
+						vendor: ['vue', 'vue-router'],
+					},
+				},
+			},
 		},
 	},
 })


### PR DESCRIPTION
Fixes #1842

For some reason vue and vue-router are imported multiple times by different chunks, this causes errors as vue2 is not allowed to be used more than one time in one application.
So it is fixed by create a manual chunk just for vue, vue-router and its dependencies.