### PR TITLE
chore: replace isMobile mixin with useIsMobile composable

### DIFF
--- a/src/Forms.vue
+++ b/src/Forms.vue
@@ -113,6 +113,7 @@ import { showError } from '@nextcloud/dialogs'
 import axios from '@nextcloud/axios'
 import moment from '@nextcloud/moment'
 
+import { useIsMobile } from '@nextcloud/vue'
 import NcAppContent from '@nextcloud/vue/dist/Components/NcAppContent.js'
 import NcAppNavigation from '@nextcloud/vue/dist/Components/NcAppNavigation.js'
 import NcAppNavigationCaption from '@nextcloud/vue/dist/Components/NcAppNavigationCaption.js'
@@ -121,7 +122,6 @@ import NcButton from '@nextcloud/vue/dist/Components/NcButton.js'
 import NcContent from '@nextcloud/vue/dist/Components/NcContent.js'
 import NcEmptyContent from '@nextcloud/vue/dist/Components/NcEmptyContent.js'
 import NcLoadingIcon from '@nextcloud/vue/dist/Components/NcLoadingIcon.js'
-import isMobile from '@nextcloud/vue/dist/Mixins/isMobile.js'
 
 import IconPlus from 'vue-material-design-icons/Plus.vue'
 
@@ -148,7 +148,13 @@ export default {
 		NcLoadingIcon,
 	},
 
-	mixins: [isMobile, PermissionTypes],
+	mixins: [PermissionTypes],
+
+	setup() {
+		return {
+			isMobile: useIsMobile(),
+		}
+	},
 
 	data() {
 		return {

--- a/src/components/TopBar.vue
+++ b/src/components/TopBar.vue
@@ -85,8 +85,8 @@
 </template>
 
 <script>
+import { useIsMobile } from '@nextcloud/vue'
 import NcButton from '@nextcloud/vue/dist/Components/NcButton.js'
-import isMobile from '@nextcloud/vue/dist/Mixins/isMobile.js'
 import IconEye from 'vue-material-design-icons/Eye.vue'
 import IconMenuOpen from 'vue-material-design-icons/MenuOpen.vue'
 import IconPencil from 'vue-material-design-icons/Pencil.vue'
@@ -106,7 +106,7 @@ export default {
 		NcButton,
 	},
 
-	mixins: [isMobile, PermissionTypes],
+	mixins: [PermissionTypes],
 
 	props: {
 		sidebarOpened: {
@@ -117,6 +117,12 @@ export default {
 			type: Array,
 			default: () => [],
 		},
+	},
+
+	setup() {
+		return {
+			isMobile: useIsMobile(),
+		}
 	},
 
 	computed: {


### PR DESCRIPTION
Replace deprecated `isMobile` mixin (as of nextcloud-vue 8.4) with `useIsMobile` composable

Signed-off-by: Christian Hartmann <chris-hartmann@gmx.de>