### PR TITLE
enh: Use NcDialog to confirm leaving

### DIFF
--- a/src/components/TopBar.vue
+++ b/src/components/TopBar.vue
@@ -85,6 +85,7 @@
 </template>
 
 <script>
+import logger from '../utils/Logger.js'
 import { useIsMobile } from '@nextcloud/vue'
 import NcButton from '@nextcloud/vue/dist/Components/NcButton.js'
 import IconEye from 'vue-material-design-icons/Eye.vue'
@@ -162,7 +163,7 @@ export default {
 					params: {
 						hash: this.$route.params.hash,
 					},
-				})
+				}).catch((error) => logger.debug('Navigation cancelled', { error }))
 			}
 		},
 
@@ -173,7 +174,7 @@ export default {
 					params: {
 						hash: this.$route.params.hash,
 					},
-				})
+				}).catch((error) => logger.debug('Navigation cancelled', { error }))
 			}
 		},
 
@@ -184,7 +185,7 @@ export default {
 					params: {
 						hash: this.$route.params.hash,
 					},
-				})
+				}).catch((error) => logger.debug('Navigation cancelled', { error }))
 			}
 		},
 


### PR DESCRIPTION
This uses NcDialog for warning the user before leaving an unsubmitted form instead of the default confirm dialog of the browsers. Due to limitations of the browsers this only works for route changes within the Forms app. When switching to other apps, another website or closing the tab/window, the default dialog will still be used.