### PR TITLE
enh: Better text contrast for form description (closes #1878)

### DIFF
--- a/src/views/Create.vue
+++ b/src/views/Create.vue
@@ -4,6 +4,7 @@
   - @author René Gieling <github@dartcafe.de>
   - @author Nick Gallo
   - @author John Molakvoæ <skjnldsv@protonmail.com>
+  - @author Michael Schmidmaier
   -
   - @license AGPL-3.0-or-later
   -
@@ -512,7 +513,7 @@ export default {
 		}
 
 		.form-desc {
-			color: var(--color-text-maxcontrast);
+			color: var(--color-main-text);
 			line-height: 22px;
 			min-height: 47px; // one line (25px padding + 22px text height)
 			padding-block-start: 5px; // spacing border<>text

--- a/src/views/Submit.vue
+++ b/src/views/Submit.vue
@@ -2,6 +2,7 @@
  - @copyright Copyright (c) 2020 John Molakvoæ <skjnldsv@protonmail.com>
  -
  - @author John Molakvoæ <skjnldsv@protonmail.com>
+ - @author Michael Schmidmaier
  -
  - @license AGPL-3.0-or-later
  -
@@ -562,7 +563,7 @@ export default {
 			padding-block-end: 20px;
 			resize: none;
 			min-height: 42px;
-			color: var(--color-text-maxcontrast);
+			color: var(--color-main-text);
 
 			@include markdown-output;
 		}


### PR DESCRIPTION
Changes form descriptions in Create.vue and Submit.vue to use the `--color-main-text` CSS variable instead of `--color-text-maxcontrast` for better readability.