### PR TITLE
stop filtering result while sharing

### DIFF
--- a/src/components/SidebarTabs/SharingSearchDiv.vue
+++ b/src/components/SidebarTabs/SharingSearchDiv.vue
@@ -30,6 +30,7 @@
 			:options="options"
 			:placeholder="t('forms', 'Search for user, group or circle …')"
 			:user-select="true"
+			:filter-by="() => true"
 			label="displayName"
 			@search="asyncSearch"
 			@input="addShare">


### PR DESCRIPTION
- Share only works by display name right now

- Search by username to share form is broken completely as there is a filterBy option in [vue-select](https://vue-select.org/api/props.html#filterby) whose return value defaults to return (label || '').toLocaleLowerCase().indexOf(search.toLocaleLowerCase()) > -1

   - label in our code is set to displayName so only search by displayName works
- Since we already get our results by searching(OCS), I don't see why we need the filterBy option in the first place
   - So I just make the return value true
   - In case we do need the option, we should make it check for both displayName and username attributes