### PR TITLE
Fix sharing form

### DIFF
--- a/src/Forms.vue
+++ b/src/Forms.vue
@@ -55,7 +55,7 @@
 		</NcAppNavigation>
 
 		<!-- No forms & loading emptycontents -->
-		<NcAppContent v-if="loading || !hasForms || !routeHash || !routeAllowed">
+		<NcAppContent v-if="loading || !routeHash || !routeAllowed">
 			<NcEmptyContent v-if="loading"
 				class="forms-emptycontent"
 				:name="t('forms', 'Loading forms …')">


### PR DESCRIPTION
- Sharing form to all logged in user by enabling `Permit access to all logged in accounts` only works if that other user already a form created or  `Show to all accounts on sidebar` is also enabled

- If a user try to open a form using shared link and not created  any form will not able to see form .

- I find that this `hasForms` always false if user not created any form and also the shared form link not enabled this `Show to all accounts on sidebar` option

- To fix this `<NcAppContent v-if="loading || !hasForms || !routeHash || !routeAllowed">` => `<NcAppContent v-if="loading || !routeHash || !routeAllowed">` - removing !hasForms will solves this issue.

- Also this MR fixes this issue https://github.com/nextcloud/forms/issues/1779