### PR TITLE
Hide linked file actions from users who have access to results view

### DIFF
--- a/lib/Constants.php
+++ b/lib/Constants.php
@@ -152,7 +152,7 @@ class Constants {
 		self::PERMISSION_EDIT,
 		self::PERMISSION_RESULTS,
 		self::PERMISSION_RESULTS_DELETE,
-		self::PERMISSION_SUBMIT
+		self::PERMISSION_SUBMIT,
 	];
 
 	/**

--- a/lib/Controller/ApiController.php
+++ b/lib/Controller/ApiController.php
@@ -1272,8 +1272,8 @@ class ApiController extends OCSController {
 			throw new OCSNotFoundException();
 		}
 
-		if ($form->getOwnerId() !== $this->currentUser->getUID()) {
-			$this->logger->debug('This form is not owned by the current user');
+		if (!$this->formsService->canEditForm($form)) {
+			$this->logger->debug('User has no permissions to unlink this form from files');
 			throw new OCSForbiddenException();
 		}
 
@@ -1315,8 +1315,9 @@ class ApiController extends OCSController {
 			$this->logger->debug('Could not find form');
 			throw new OCSNotFoundException();
 		}
-		if ($form->getOwnerId() !== $this->currentUser->getUID()) {
-			$this->logger->debug('This form is not owned by the current user');
+
+		if (!$this->formsService->canEditForm($form)) {
+			$this->logger->debug('User has no permissions to link this form with files');
 			throw new OCSForbiddenException();
 		}
 

--- a/lib/Service/FormsService.php
+++ b/lib/Service/FormsService.php
@@ -259,6 +259,16 @@ class FormsService {
 	}
 
 	/**
+	 * Can the current user edit a form
+	 *
+	 * @param Form $form
+	 * @return boolean
+	 */
+	public function canEditForm(Form $form): bool {
+		return in_array(Constants::PERMISSION_EDIT, $this->getPermissions($form));
+	}
+
+	/**
 	 * Can the current user see results of a form
 	 *
 	 * @param Form $form

--- a/src/views/Results.vue
+++ b/src/views/Results.vue
@@ -62,7 +62,7 @@
 						{{ t('forms', 'Share form') }}
 					</NcButton>
 
-					<NcButton v-if="!form.fileId" type="tertiary-no-background" @click="onLinkFile">
+					<NcButton v-if="canEditForm && !form.fileId" type="tertiary-no-background" @click="onLinkFile">
 						<template #icon>
 							<IconLink :size="20" />
 						</template>
@@ -112,28 +112,30 @@
 						</label>
 					</div>
 
-					<NcButton v-if="form.fileId" :href="fileUrl" type="tertiary-no-background">
-						<template #icon>
-							<IconTable :size="20" />
-						</template>
-						{{ t('forms', 'Open spreadsheet') }}
-					</NcButton>
-
-					<NcActions v-else type="tertiary-no-background" :force-name="true">
-						<NcActionButton @click="onLinkFile">
+					<template v-if="canEditForm">
+						<NcButton v-if="form.fileId" :href="fileUrl" type="tertiary-no-background">
 							<template #icon>
-								<IconLink :size="20" />
+								<IconTable :size="20" />
 							</template>
-							{{ t('forms', 'Create spreadsheet') }}
-						</NcActionButton>
-					</NcActions>
+							{{ t('forms', 'Open spreadsheet') }}
+						</NcButton>
+
+						<NcActions v-else type="tertiary-no-background" :force-name="true">
+							<NcActionButton @click="onLinkFile">
+								<template #icon>
+									<IconLink :size="20" />
+								</template>
+								{{ t('forms', 'Create spreadsheet') }}
+							</NcActionButton>
+						</NcActions>
+					</template>
 
 					<!-- Action menu for cloud export and deletion -->
 					<NcActions :aria-label="t('forms', 'Options')"
 						:force-menu="true"
 						@close="isDownloadActionOpened = false">
 						<template v-if="!isDownloadActionOpened">
-							<template v-if="form.fileId">
+							<template v-if="canEditForm && form.fileId">
 								<NcActionButton :close-after-click="true" @click="onReExport">
 									<template #icon>
 										<IconRefresh :size="20" />
@@ -356,6 +358,10 @@ export default {
 			return this.form.permissions.includes(this.PERMISSION_TYPES.PERMISSION_RESULTS_DELETE)
 		},
 
+		canEditForm() {
+			return this.form.permissions.includes(this.PERMISSION_TYPES.PERMISSION_EDIT)
+		},
+
 		noSubmissions() {
 			return this.form.submissions?.length === 0
 		},
@@ -479,7 +485,7 @@ export default {
 			this.$set(this.form, 'fileFormat', form.fileFormat)
 			this.$set(this.form, 'fileId', form.fileId)
 			this.$set(this.form, 'filePath', form.filePath)
-			this.showLinkedFileNotAvailableDialog = form.fileId && !form.filePath
+			this.showLinkedFileNotAvailableDialog = this.canEditForm && form.fileId && !form.filePath
 		},
 
 		async onReExport() {

--- a/tests/Unit/Controller/ApiControllerTest.php
+++ b/tests/Unit/Controller/ApiControllerTest.php
@@ -362,6 +362,11 @@ class ApiControllerTest extends TestCase {
 			->with('hash')
 			->willReturn($form);
 
+		$this->formsService->expects($this->once())
+			->method('canEditForm')
+			->with($form)
+			->willReturn(true);
+
 		$this->apiController->unlinkFile('hash');
 
 		$this->assertNull($form->getFileId());


### PR DESCRIPTION
Use case:
1. Share Form with User, give him access to view results

Current behavior
- User can see `Link file/Unlink file/Open file` buttons (but he not allowed to perform this actions due to checks on BE side)

Behavior after fix
- Only Form owner can see mentioned buttons

<details><summary>Screenshots</summary>

![image](https://github.com/nextcloud/forms/assets/191082/89e124d0-3b4e-48e5-b737-2dd2e6b5f65c)
![image](https://github.com/nextcloud/forms/assets/191082/84e0d6b9-090a-4860-8fee-fa35e8ebfabc)
</details> 
