### PR TITLE
feat: Add forms `state` to close and archive forms

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -58,7 +58,8 @@ Returns condensed objects of all Forms beeing owned by the authenticated user.
       "results",
       "submit"
     ],
-    "partial": true
+    "partial": true,
+    "state": 0
   },
   {
     "id": 3,
@@ -70,7 +71,8 @@ Returns condensed objects of all Forms beeing owned by the authenticated user.
       "results",
       "submit"
     ],
-    "partial": true
+    "partial": true,
+    "state": 0
   }
 ]
 ```
@@ -103,7 +105,8 @@ Returns a single partial form object, corresponding to owned/shared form-listing
   "permissions": [
     "submit"
   ],
-  "partial": true
+  "partial": true,
+  "state": 0
 }
 ```
 
@@ -146,6 +149,7 @@ Returns the full-depth object of the requested form (without submissions).
   "submitMultiple": true,
   "showExpiration": false,
   "canSubmit": true,
+  "state": 0,
   "permissions": [
     "edit",
     "results",

--- a/docs/DataStructure.md
+++ b/docs/DataStructure.md
@@ -17,6 +17,7 @@ This document describes the Object-Structure, that is used within the Forms App 
 | access      | [Access-Object](#access-object) |  | Describing access-settings of the form |
 | expires     | unix-timestamp  |               | When the form should expire. Timestamp `0` indicates _never_ |
 | isAnonymous | Boolean         |               | If Answers will be stored anonymously |
+| state       | Integer         | [Form state](#form-state)| The state of the form |
 | submitMultiple  | Boolean     |               | If users are allowed to submit multiple times to the form |
 | showExpiration | Boolean      |               | If the expiration date will be shown on the form |
 | canSubmit   | Boolean         |               | If the user can Submit to the form, i.e. calculated information out of `submitMultiple` and existing submissions. |
@@ -45,10 +46,20 @@ This document describes the Object-Structure, that is used within the Forms App 
     "submit"
   ],
   "questions": [],
-  "submissions": [],
+  "state": 0,
   "shares": []
+  "submissions": [],
 }
 ```
+
+#### Form state
+The form state is used for additional states, currently following states are defined:
+
+| Value          | Meaning                                     |
+|----------------|---------------------------------------------|
+| 0              | Form is active and open for new submissions |
+| 1              | Form is closed and does not allow new submissions |
+| 2              | Form is archived, it does not allow new submissions and can also not be modified anymore |
 
 ### Question
 | Property       | Type            | Restrictions | Description |

--- a/lib/Constants.php
+++ b/lib/Constants.php
@@ -54,6 +54,13 @@ class Constants {
 	];
 
 	/**
+	 * State flags of a form
+	 */
+	public const FORM_STATE_ACTIVE = 0;
+	public const FORM_STATE_CLOSED = 1;
+	public const FORM_STATE_ARCHIVED = 2;
+
+	/**
 	 * !! Keep in sync with src/models/AnswerTypes.js !!
 	 */
 

--- a/lib/Controller/ApiController.php
+++ b/lib/Controller/ApiController.php
@@ -3,6 +3,7 @@
  * @copyright Copyright (c) 2017 Vinzenz Rosenkranz <vinzenz.rosenkranz@gmail.com>
  *
  * @author affan98 <affan98@gmail.com>
+ * @author Ferdinand Thiessen <opensource@fthiessen.de>
  * @author Jan-Christoph Borchardt <hey@jancborchardt.net>
  * @author John Molakvoæ (skjnldsv) <skjnldsv@protonmail.com>
  * @author Jonas Rittershofer <jotoeri@users.noreply.github.com>
@@ -471,6 +472,11 @@ class ApiController extends OCSController {
 			throw new OCSForbiddenException();
 		}
 
+		if ($this->formsService->isFormArchived($form)) {
+			$this->logger->debug('This form is archived and can not be modified');
+			throw new OCSForbiddenException();
+		}
+
 		// Retrieve all active questions sorted by Order. Takes the order of the last array-element and adds one.
 		$questions = $this->questionMapper->findByForm($formId);
 		$lastQuestion = array_pop($questions);
@@ -527,6 +533,11 @@ class ApiController extends OCSController {
 
 		if ($form->getOwnerId() !== $this->currentUser->getUID()) {
 			$this->logger->debug('This form is not owned by the current user');
+			throw new OCSForbiddenException();
+		}
+
+		if ($this->formsService->isFormArchived($form)) {
+			$this->logger->debug('This form is archived and can not be modified');
 			throw new OCSForbiddenException();
 		}
 
@@ -627,6 +638,11 @@ class ApiController extends OCSController {
 			throw new OCSForbiddenException();
 		}
 
+		if ($this->formsService->isFormArchived($form)) {
+			$this->logger->debug('This form is archived and can not be modified');
+			throw new OCSForbiddenException();
+		}
+
 		// Don't allow empty array
 		if (sizeof($keyValuePairs) === 0) {
 			$this->logger->info('Empty keyValuePairs, will not update.');
@@ -690,6 +706,11 @@ class ApiController extends OCSController {
 			throw new OCSForbiddenException();
 		}
 
+		if ($this->formsService->isFormArchived($form)) {
+			$this->logger->debug('This form is archived and can not be modified');
+			throw new OCSForbiddenException();
+		}
+
 		// Store Order of deleted Question
 		$deletedOrder = $question->getOrder();
 
@@ -738,6 +759,11 @@ class ApiController extends OCSController {
 
 		if ($form->getOwnerId() !== $this->currentUser->getUID()) {
 			$this->logger->debug('This form is not owned by the current user');
+			throw new OCSForbiddenException();
+		}
+
+		if ($this->formsService->isFormArchived($form)) {
+			$this->logger->debug('This form is archived and can not be modified');
 			throw new OCSForbiddenException();
 		}
 
@@ -797,6 +823,11 @@ class ApiController extends OCSController {
 			throw new OCSForbiddenException();
 		}
 
+		if ($this->formsService->isFormArchived($form)) {
+			$this->logger->debug('This form is archived and can not be modified');
+			throw new OCSForbiddenException();
+		}
+
 		$option = new Option();
 
 		$option->setQuestionId($questionId);
@@ -838,6 +869,11 @@ class ApiController extends OCSController {
 
 		if ($form->getOwnerId() !== $this->currentUser->getUID()) {
 			$this->logger->debug('This form is not owned by the current user');
+			throw new OCSForbiddenException();
+		}
+
+		if ($this->formsService->isFormArchived($form)) {
+			$this->logger->debug('This form is archived and can not be modified');
 			throw new OCSForbiddenException();
 		}
 
@@ -892,6 +928,11 @@ class ApiController extends OCSController {
 
 		if ($form->getOwnerId() !== $this->currentUser->getUID()) {
 			$this->logger->debug('This form is not owned by the current user');
+			throw new OCSForbiddenException();
+		}
+
+		if ($this->formsService->isFormArchived($form)) {
+			$this->logger->debug('This form is archived and can not be modified');
 			throw new OCSForbiddenException();
 		}
 
@@ -1180,8 +1221,9 @@ class ApiController extends OCSController {
 			throw new OCSBadRequestException();
 		}
 
-		if ($form->getOwnerId() !== $this->currentUser->getUID()) {
-			$this->logger->debug('This form is not owned by the current user');
+		// The current user has permissions to remove submissions
+		if (!$this->formsService->canDeleteResults($form)) {
+			$this->logger->debug('This form is not owned by the current user and user has no `results_delete` permission');
 			throw new OCSForbiddenException();
 		}
 

--- a/lib/Db/Form.php
+++ b/lib/Db/Form.php
@@ -7,6 +7,7 @@ declare(strict_types=1);
  *
  * @author affan98 <affan98@gmail.com>
  * @author Jonas Rittershofer <jotoeri@users.noreply.github.com>
+ * @author Ferdinand Thiessen <opensource@fthiessen.de>
  *
  * @license AGPL-3.0-or-later
  *
@@ -44,20 +45,22 @@ use OCP\AppFramework\Db\Entity;
  * @method void setFileFormat(string|null $value)
  * @method array getAccess()
  * @method void setAccess(array $value)
- * @method integer getCreated()
- * @method void setCreated(integer $value)
- * @method integer getExpires()
- * @method void setExpires(integer $value)
- * @method integer getIsAnonymous()
+ * @method int getCreated()
+ * @method void setCreated(int $value)
+ * @method int getExpires()
+ * @method void setExpires(int $value)
+ * @method int getIsAnonymous()
  * @method void setIsAnonymous(bool $value)
- * @method integer getSubmitMultiple()
+ * @method int getSubmitMultiple()
  * @method void setSubmitMultiple(bool $value)
- * @method integer getShowExpiration()
+ * @method int getShowExpiration()
  * @method void setShowExpiration(bool $value)
- * @method integer getLastUpdated()
- * @method void setLastUpdated(integer $value)
+ * @method int getLastUpdated()
+ * @method void setLastUpdated(int $value)
  * @method ?string getSubmissionMessage()
  * @method void setSubmissionMessage(?string $value)
+ * @method int getState()
+ * @method void setState(?int $value)
  */
 class Form extends Entity {
 	protected $hash;
@@ -74,6 +77,7 @@ class Form extends Entity {
 	protected $showExpiration;
 	protected $submissionMessage;
 	protected $lastUpdated;
+	protected $state;
 
 	/**
 	 * Form constructor.
@@ -85,6 +89,7 @@ class Form extends Entity {
 		$this->addType('submitMultiple', 'bool');
 		$this->addType('showExpiration', 'bool');
 		$this->addType('lastUpdated', 'integer');
+		$this->addType('state', 'integer');
 	}
 
 	// JSON-Decoding of access-column.
@@ -115,6 +120,7 @@ class Form extends Entity {
 			'showExpiration' => (bool)$this->getShowExpiration(),
 			'lastUpdated' => (int)$this->getLastUpdated(),
 			'submissionMessage' => $this->getSubmissionMessage(),
+			'state' => $this->getState(),
 		];
 	}
 }

--- a/lib/Migration/Version040200Date20240219201500.php
+++ b/lib/Migration/Version040200Date20240219201500.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright Copyright (c) 2024 Ferdinand Thiessen <opensource@fthiessen.de>
+ *
+ * @author Ferdinand Thiessen <opensource@fthiessen.de>
+ *
+ * @license AGPL-3.0-or-later
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Forms\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\DB\QueryBuilder\IQueryBuilder;
+use OCP\DB\Types;
+use OCP\IDBConnection;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+/**
+ * This migration adds the `state` property to forms for closed, archived or active forms
+ */
+class Version040200Date20240219201500 extends SimpleMigrationStep {
+
+	public function __construct(
+		protected IDBConnection $db,
+	) {
+	}
+
+	/**
+	 * @param IOutput $output
+	 * @param Closure $schemaClosure The `\Closure` returns a `ISchemaWrapper`
+	 * @param array $options
+	 * @return null|ISchemaWrapper
+	 */
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
+		/** @var ISchemaWrapper $schema */
+		$schema = $schemaClosure();
+		$table = $schema->getTable('forms_v2_forms');
+
+		if (!$table->hasColumn('state')) {
+			$table->addColumn('state', Types::SMALLINT, [
+				'notnull' => true,
+				'default' => 0,
+				'unsigned' => true,
+			]);
+		}
+
+		return $schema;
+	}
+
+	/**
+	 * Set all old forms to active state
+	 */
+	public function postSchemaChange(IOutput $output, Closure $schemaClosure, array $options) {
+		$query = $this->db->getQueryBuilder();
+		$query->update('forms_v2_forms')
+			->set('state', $query->createNamedParameter(0, IQueryBuilder::PARAM_INT))
+			->executeStatement();
+	}
+}

--- a/lib/Service/FormsService.php
+++ b/lib/Service/FormsService.php
@@ -389,8 +389,6 @@ class FormsService {
 	 * @return bool
 	 */
 	public function isSharedFormShown(Form $form): bool {
-		$access = $form->getAccess();
-
 		// Dont show here to owner, as its in the owned list anyways.
 		if ($form->getOwnerId() === $this->currentUser->getUID()) {
 			return false;
@@ -401,6 +399,7 @@ class FormsService {
 			return false;
 		}
 
+		$access = $form->getAccess();
 		// Shown if permitall and showntoall are both set.
 		if ($access['permitAllUsers'] &&
 			$access['showToAllUsers'] &&

--- a/src/components/ArchivedFormsModal.vue
+++ b/src/components/ArchivedFormsModal.vue
@@ -1,0 +1,99 @@
+<!--
+  - @copyright Copyright (c) 2024 Ferdinand Thiessen <opensource@fthiessen.de>
+  -
+  - @author Ferdinand Thiessen <opensource@fthiessen.de>
+  -
+  - @license AGPL-3.0-or-later
+  -
+  - This program is free software: you can redistribute it and/or modify
+  - it under the terms of the GNU Affero General Public License as
+  - published by the Free Software Foundation, either version 3 of the
+  - License, or (at your option) any later version.
+  -
+  - This program is distributed in the hope that it will be useful,
+  - but WITHOUT ANY WARRANTY; without even the implied warranty of
+  - MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  - GNU Affero General Public License for more details.
+  -
+  - You should have received a copy of the GNU Affero General Public License
+  - along with this program. If not, see <http://www.gnu.org/licenses/>.
+  -
+  -->
+
+<template>
+	<NcDialog content-classes="archived-forms"
+		:name="t('forms', 'Archived forms')"
+		:open="open"
+		size="normal"
+		@update:open="$emit('update:open', $event)">
+		<ul :aria-label="t('forms', 'Archived forms')">
+			<AppNavigationForm v-for="form, key in shownForms"
+				:key="key"
+				:form="form"
+				:read-only="false"
+				force-display-actions
+				@delete="onDelete(form)"
+				@mobile-close-navigation="$emit('update:open', false)" />
+		</ul>
+	</NcDialog>
+</template>
+
+<script>
+import { translate as t } from '@nextcloud/l10n'
+import { defineComponent } from 'vue'
+
+import NcDialog from '@nextcloud/vue/dist/Components/NcDialog.js'
+import AppNavigationForm from './AppNavigationForm.vue'
+
+export default defineComponent({
+	name: 'ArchivedFormsModal',
+
+	components: {
+		AppNavigationForm,
+		NcDialog,
+	},
+
+	props: {
+		open: {
+			type: Boolean,
+			required: true,
+		},
+		forms: {
+			type: Array,
+			required: true,
+		},
+	},
+
+	emits: ['update:open'],
+
+	data() {
+		return {
+			shownForms: [],
+		}
+	},
+
+	watch: {
+		forms: {
+			immediate: true,
+			handler() {
+				this.shownForms = [...this.forms]
+			},
+		},
+	},
+
+	methods: {
+		t,
+
+		onDelete(form) {
+			this.shownForms = this.shownForms.filter(({ id }) => id !== form.id)
+		},
+	},
+})
+</script>
+
+<style scoped>
+:deep(.archived-forms) {
+	min-height: 50vh !important;
+	padding-block-end: 22px;
+}
+</style>

--- a/src/components/TopBar.vue
+++ b/src/components/TopBar.vue
@@ -18,10 +18,6 @@
   - You should have received a copy of the GNU Affero General Public License
   - along with this program.  If not, see <http://www.gnu.org/licenses/>.
   -
-  -
-  - UPDATE: Adds Quiz option and takes the input:
-  - is yet to store input of quizzes and cannot represtent them
-  - requires quizFormItem.vue (should be added to svn)
   -->
 <template>
 	<div class="top-bar" role="toolbar">
@@ -110,6 +106,11 @@ export default {
 	mixins: [PermissionTypes],
 
 	props: {
+		archived: {
+			type: Boolean,
+			default: false,
+		},
+
 		sidebarOpened: {
 			type: Boolean,
 			default: null,
@@ -128,7 +129,7 @@ export default {
 
 	computed: {
 		canEdit() {
-			return this.permissions.includes(this.PERMISSION_TYPES.PERMISSION_EDIT)
+			return this.permissions.includes(this.PERMISSION_TYPES.PERMISSION_EDIT) && !this.archived
 		},
 		canSubmit() {
 			return this.permissions.includes(this.PERMISSION_TYPES.PERMISSION_SUBMIT)
@@ -144,7 +145,7 @@ export default {
 			return this.permissions.length === 1 && this.permissions.includes(this.PERMISSION_TYPES.PERMISSION_SUBMIT)
 		},
 		showSidebarToggle() {
-			return this.canEdit && this.sidebarOpened !== null
+			return this.permissions.includes(this.PERMISSION_TYPES.PERMISSION_EDIT) && this.sidebarOpened !== null
 		},
 	},
 

--- a/src/models/FormStates.ts
+++ b/src/models/FormStates.ts
@@ -1,0 +1,32 @@
+/**
+ * @copyright Copyright (c) 2024 Ferdinand Thiessen <opensource@fthiessen.de>
+ *
+ * @author Ferdinand Thiessen <opensource@fthiessen.de>
+ *
+ * @license AGPL-3.0-or-later
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+// Keep in sync with Constants.php
+
+/**
+ * State of a form
+ */
+export enum FormState {
+	FormActive = 0,
+	FormClosed = 1,
+	FormArchived = 2,
+}

--- a/src/views/Results.vue
+++ b/src/views/Results.vue
@@ -31,7 +31,8 @@
 			size="normal"
 			:can-close="false" />
 
-		<TopBar :permissions="form?.permissions"
+		<TopBar :archived="isFormArchived"
+			:permissions="form?.permissions"
 			:sidebar-opened="sidebarOpened"
 			@update:sidebarOpened="onSidebarChange"
 			@share-form="onShareForm" />
@@ -270,6 +271,7 @@ import IconShareVariant from 'vue-material-design-icons/ShareVariant.vue'
 import IconTable from 'vue-material-design-icons/Table.vue'
 import IconTableSvg from '@mdi/svg/svg/table.svg?raw'
 
+import { FormState } from '../models/FormStates.ts'
 import ResultsSummary from '../components/Results/ResultsSummary.vue'
 import Submission from '../components/Results/Submission.vue'
 import TopBar from '../components/TopBar.vue'
@@ -354,8 +356,12 @@ export default {
 	},
 
 	computed: {
+		isFormArchived() {
+			return this.form.state === FormState.FormArchived
+		},
+
 		canDeleteSubmissions() {
-			return this.form.permissions.includes(this.PERMISSION_TYPES.PERMISSION_RESULTS_DELETE)
+			return this.form.permissions.includes(this.PERMISSION_TYPES.PERMISSION_RESULTS_DELETE) && !this.isFormArchived
 		},
 
 		canEditForm() {

--- a/tests/Integration/Api/ApiV2Test.php
+++ b/tests/Integration/Api/ApiV2Test.php
@@ -62,6 +62,7 @@ class ApiV2Test extends TestCase {
 				],
 				'created' => 12345,
 				'expires' => 0,
+				'state' => 0,
 				'is_anonymous' => false,
 				'submit_multiple' => false,
 				'show_expiration' => false,
@@ -167,6 +168,7 @@ class ApiV2Test extends TestCase {
 				],
 				'created' => 12345,
 				'expires' => 0,
+				'state' => 0,
 				'is_anonymous' => false,
 				'submit_multiple' => false,
 				'show_expiration' => false,
@@ -205,6 +207,7 @@ class ApiV2Test extends TestCase {
 				],
 				'created' => 12345,
 				'expires' => 0,
+				'state' => 0,
 				'is_anonymous' => false,
 				'submit_multiple' => false,
 				'show_expiration' => false,
@@ -270,6 +273,7 @@ class ApiV2Test extends TestCase {
 					'access_json' => $qb->createNamedParameter(json_encode($form['access_json']), IQueryBuilder::PARAM_STR),
 					'created' => $qb->createNamedParameter($form['created'], IQueryBuilder::PARAM_INT),
 					'expires' => $qb->createNamedParameter($form['expires'], IQueryBuilder::PARAM_INT),
+					'state' => $qb->createNamedParameter($form['state'], IQueryBuilder::PARAM_INT),
 					'is_anonymous' => $qb->createNamedParameter($form['is_anonymous'], IQueryBuilder::PARAM_BOOL),
 					'submit_multiple' => $qb->createNamedParameter($form['submit_multiple'], IQueryBuilder::PARAM_BOOL),
 					'show_expiration' => $qb->createNamedParameter($form['show_expiration'], IQueryBuilder::PARAM_BOOL),
@@ -427,6 +431,7 @@ class ApiV2Test extends TestCase {
 						'hash' => 'abcdefg',
 						'title' => 'Title of a Form',
 						'expires' => 0,
+						'state' => 0,
 						'lastUpdated' => 123456789,
 						'permissions' => Constants::PERMISSION_ALL,
 						'partial' => true,
@@ -436,6 +441,7 @@ class ApiV2Test extends TestCase {
 						'hash' => 'third',
 						'title' => 'Title of a third Form',
 						'expires' => 0,
+						'state' => 0,
 						'lastUpdated' => 123456789,
 						'permissions' => Constants::PERMISSION_ALL,
 						'partial' => true,
@@ -468,6 +474,7 @@ class ApiV2Test extends TestCase {
 						'hash' => 'abcdefghij',
 						'title' => 'Title of a second Form',
 						'expires' => 0,
+						'state' => 0,
 						'lastUpdated' => 123456789,
 						'permissions' => [
 							'submit'
@@ -500,6 +507,7 @@ class ApiV2Test extends TestCase {
 					'hash' => 'abcdefghij',
 					'title' => 'Title of a second Form',
 					'expires' => 0,
+					'state' => 0,
 					'lastUpdated' => 123456789,
 					'permissions' => [
 						'submit'
@@ -538,6 +546,7 @@ class ApiV2Test extends TestCase {
 						'showToAllUsers' => false
 					],
 					'expires' => 0,
+					'state' => 0,
 					'isAnonymous' => false,
 					'submitMultiple' => false,
 					'showExpiration' => false,
@@ -596,6 +605,7 @@ class ApiV2Test extends TestCase {
 						'showToAllUsers' => false
 					],
 					'expires' => 0,
+					'state' => 0,
 					'isAnonymous' => false,
 					'submitMultiple' => false,
 					'showExpiration' => false,

--- a/tests/Unit/Controller/ApiControllerTest.php
+++ b/tests/Unit/Controller/ApiControllerTest.php
@@ -386,6 +386,7 @@ class ApiControllerTest extends TestCase {
 		return [
 			'forms' => ['expectedForm' => [
 				'id' => 7,
+				'state' => 0,
 				'hash' => 'formHash',
 				'title' => '',
 				'description' => '',

--- a/tests/Unit/FormsMigratorTest.php
+++ b/tests/Unit/FormsMigratorTest.php
@@ -127,6 +127,7 @@ class FormsMigratorTest extends TestCase {
       "showToAllUsers": false
     },
     "expires": 0,
+	"state": 0,
     "isAnonymous": false,
     "submitMultiple": false,
     "showExpiration": false,
@@ -187,6 +188,7 @@ JSON
 
 		$form = new Form();
 		$form->setId(42);
+		$form->setState(0);
 		$form->setHash('abcdefg');
 		$form->setTitle('Link');
 		$form->setDescription('');
@@ -271,7 +273,7 @@ JSON
 	public function dataImport() {
 		return [
 			'exactlyOneOfEach' => [
-				'$inputJson' => '[{"title":"Link","description":"","created":1646251830,"access":{"permitAllUsers":false,"showToAllUsers":false},"expires":0,"isAnonymous":false,"submitMultiple":false,"showExpiration":false,"lastUpdated":123456789,"questions":[{"id":14,"order":2,"type":"multiple","isRequired":false,"text":"checkbox","description":"huhu","extraSettings":{},"options":[{"text":"ans1"}]}],"submissions":[{"userId":"anyUser@localhost","timestamp":1651354059,"answers":[{"questionId":14,"text":"ans1"}]}]}]'
+				'$inputJson' => '[{"title":"Link","description":"","created":1646251830,"access":{"permitAllUsers":false,"showToAllUsers":false},"expires":0,"state":0,"isAnonymous":false,"submitMultiple":false,"showExpiration":false,"lastUpdated":123456789,"questions":[{"id":14,"order":2,"type":"multiple","isRequired":false,"text":"checkbox","description":"huhu","extraSettings":{},"options":[{"text":"ans1"}]}],"submissions":[{"userId":"anyUser@localhost","timestamp":1651354059,"answers":[{"questionId":14,"text":"ans1"}]}]}]'
 			]
 		];
 	}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
 	"compilerOptions": {
+		"allowJs": true,
 		"target": "ESNext",
 		"module": "ES2020",
 		"moduleResolution": "Bundler",


### PR DESCRIPTION
* Resolves #1834
* Resolves #1101 

I recommend to hide white space when review.

This adds a new field "state" to a form, this field is `0` by default which means the form is in active state.
Currently two other states are implemented:
* `closed` when then form was manually closed
* `archived` when the form was archived

Closed forms do not allow any new submissions, archived forms even do not allow any modification.
Archived forms are shown in a separate list on the side bar to save space.

### Screenshots
open list | closed list
---|---
![Screenshot 2024-02-19 at 13-57-03 Formulare - Nextcloud](https://github.com/nextcloud/forms/assets/1855448/a7c44ca9-7358-4473-a3fb-4443fd2370af)|![Screenshot 2024-02-19 at 13-56-47 Formulare - Nextcloud](https://github.com/nextcloud/forms/assets/1855448/a2b0e19c-2c8f-4112-ae9c-307e968695a0)
