### PR TITLE
fix: Update moment format for date parsing

### DIFF
--- a/src/components/Questions/QuestionDate.vue
+++ b/src/components/Questions/QuestionDate.vue
@@ -109,7 +109,7 @@ export default {
 		 * @return {Date}
 		 */
 		parse(dateString) {
-			return moment(dateString, this.answerType.storageFormat).toDate()
+			return moment(dateString, this.answerType.momentFormat).toDate()
 		},
 
 		/**

--- a/src/models/AnswerTypes.js
+++ b/src/models/AnswerTypes.js
@@ -141,7 +141,7 @@ export default {
 
 		pickerType: 'date',
 		storageFormat: 'YYYY-MM-DD',
-		momentFormat: 'LL',
+		momentFormat: 'L',
 	},
 
 	datetime: {


### PR DESCRIPTION
This fixes #1961 by changing the `momentFormat` from `LL` to `L` for `date` fields and adjusting the `parse` method to use the `momentFormat` instead of `storageFormat`

Signed-off-by: Christian Hartmann <chris-hartmann@gmx.de>