### PR TITLE
Update cypress.yml

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -61,7 +61,7 @@ jobs:
           TESTING=true npm run build --if-present
 
       - name: Save context
-        uses: buildjet/cache/save@e376f15c6ec6dc595375c78633174c7e5f92dc0e # v3
+        uses: buildjet/cache/save@v3 # v3
         with:
           key: cypress-context-${{ github.run_id }}
           path: ./
@@ -85,7 +85,7 @@ jobs:
 
     steps:
       - name: Restore context
-        uses: buildjet/cache/restore@e376f15c6ec6dc595375c78633174c7e5f92dc0e # v3
+        uses: buildjet/cache/restore@v3 # v3
         with:
           fail-on-cache-miss: true
           key: cypress-context-${{ github.run_id }}


### PR DESCRIPTION
Dependabot currently throws an error that it can't find the directly specified commit. This tries to fix the problem by only specifying a version

```
updater | 2024/02/17 02:34:32 ERROR <job_788230487> Error processing buildjet/cache (Dependabot::SharedHelpers::HelperSubprocessFailed)
updater | 2024/02/17 02:34:32 ERROR <job_788230487> error: no such commit e376f15c6ec6dc595375c78633174c7e5f92dc0e
```