### PR TITLE
Rename Circles to Teams in UI/logging

### DIFF
--- a/lib/Activity/Provider.php
+++ b/lib/Activity/Provider.php
@@ -99,7 +99,7 @@ class Provider implements IProvider {
 				return $l10n->t('{user} has shared the form {formTitle} with group {group}');
 
 			case ActivityConstants::SUBJECT_NEWCIRCLESHARE:
-				return $l10n->t('{user} has shared the form {formTitle} with circle {circle}');
+				return $l10n->t('{user} has shared the form {formTitle} with team {circle}');
 
 			case ActivityConstants::SUBJECT_NEWSUBMISSION:
 				return $l10n->t('{user} answered your form {formTitle}');

--- a/lib/Controller/ShareApiController.php
+++ b/lib/Controller/ShareApiController.php
@@ -162,13 +162,13 @@ class ShareApiController extends OCSController {
 
 			case IShare::TYPE_CIRCLE:
 				if (!$this->circlesService->isCirclesEnabled()) {
-					$this->logger->debug('Circles app is disabled, sharing to circles not possible.');
-					throw new OCSException('Circles app is disabled.');
+					$this->logger->debug('Teams app is disabled, sharing to teams not possible.');
+					throw new OCSException('Teams app is disabled.');
 				}
 				$circle = $this->circlesService->getCircle($shareWith);
 				if (is_null($circle)) {
-					$this->logger->debug('Invalid circle to share with.');
-					throw new OCSBadRequestException('Invalid circle to share with.');
+					$this->logger->debug('Invalid team to share with.');
+					throw new OCSBadRequestException('Invalid team to share with.');
 				}
 				break;
 

--- a/lib/Service/CirclesService.php
+++ b/lib/Service/CirclesService.php
@@ -106,7 +106,7 @@ class CirclesService {
 	 */
 	public function getCircleUsers(string $circleId): array {
 		if (!$this->circlesEnabled) {
-			$this->logger->debug('Circles app is disabled');
+			$this->logger->debug('Teams app is disabled');
 			return [];
 		}
 
@@ -122,7 +122,7 @@ class CirclesService {
 
 			$users = array_map(fn ($user) => $user->getUserId(), $members);
 		} catch (Throwable $error) {
-			$this->logger->debug('Could not fetch users of circle', ['error' => $error]);
+			$this->logger->debug('Could not fetch users of team', ['error' => $error]);
 		}
 		return $users;
 	}

--- a/src/components/SidebarTabs/SharingSearchDiv.vue
+++ b/src/components/SidebarTabs/SharingSearchDiv.vue
@@ -28,7 +28,7 @@
 			:loading="showLoadingCircle"
 			:get-option-key="(option) => option.key"
 			:options="options"
-			:placeholder="t('forms', 'Search for user, group or circle …')"
+			:placeholder="t('forms', 'Search for user, group or team …')"
 			:user-select="true"
 			:filter-by="() => true"
 			label="displayName"

--- a/src/components/SidebarTabs/SharingShareDiv.vue
+++ b/src/components/SidebarTabs/SharingShareDiv.vue
@@ -99,7 +99,7 @@ export default {
 			case this.SHARE_TYPES.SHARE_TYPE_GROUP:
 				return `(${t('forms', 'Group')})`
 			case this.SHARE_TYPES.SHARE_TYPE_CIRCLE:
-				return `(${t('forms', 'Circle')})`
+				return `(${t('forms', 'Team')})`
 			default:
 				return ''
 			}

--- a/tests/Unit/Activity/ProviderTest.php
+++ b/tests/Unit/Activity/ProviderTest.php
@@ -210,7 +210,7 @@ class ProviderTest extends TestCase {
 		return [
 			['newshare', '{user} has shared the form {formTitle} with you'],
 			['newgroupshare', '{user} has shared the form {formTitle} with group {group}'],
-			['newcircleshare', '{user} has shared the form {formTitle} with circle {circle}'],
+			['newcircleshare', '{user} has shared the form {formTitle} with team {circle}'],
 			['newsubmission', '{user} answered your form {formTitle}']
 		];
 	}


### PR DESCRIPTION
Changes all appearances of 'Circles' by 'Teams' as the app will be renamed in NC29

Signed-off-by: GitHub <noreply@github.com>