### PR TITLE
Show expired shared forms to users with results permission

### DIFF
--- a/lib/Service/FormsService.php
+++ b/lib/Service/FormsService.php
@@ -389,8 +389,8 @@ class FormsService {
 			return false;
 		}
 
-		// Dont show expired forms.
-		if ($this->hasFormExpired($form)) {
+		// Dont show expired forms if user isn't allowed to see results.
+		if ($this->hasFormExpired($form) && !$this->canSeeResults($form)) {
 			return false;
 		}
 


### PR DESCRIPTION
This fixes #1991 by checking whether a user has the permission to see results.

Signed-off-by: Christian Hartmann <chris-hartmann@gmx.de>