### PR TITLE
fix(TopBar): provide optional button text via new slot syntax

### DIFF
--- a/src/components/TopBar.vue
+++ b/src/components/TopBar.vue
@@ -33,7 +33,7 @@
 				<template #icon>
 					<IconEye :size="20" />
 				</template>
-				<template v-if="!isMobile">
+				<template v-if="!isMobile" #default>
 					{{ t('forms', 'View') }}
 				</template>
 			</NcButton>
@@ -44,7 +44,7 @@
 				<template #icon>
 					<IconPencil :size="20" />
 				</template>
-				<template v-if="!isMobile">
+				<template v-if="!isMobile" #default>
 					{{ t('forms', 'Edit') }}
 				</template>
 			</NcButton>
@@ -55,7 +55,7 @@
 				<template #icon>
 					<IconPoll :size="20" />
 				</template>
-				<template v-if="!isMobile">
+				<template v-if="!isMobile" #default>
 					{{ t('forms', 'Results') }}
 				</template>
 			</NcButton>
@@ -67,7 +67,7 @@
 			<template #icon>
 				<IconShareVariant :size="20" />
 			</template>
-			<template v-if="!isMobile">
+			<template v-if="!isMobile" #default>
 				{{ t('forms', 'Share') }}
 			</template>
 		</NcButton>


### PR DESCRIPTION
* Fix: https://github.com/nextcloud/forms/issues/1699

This is an issue on `NcButton` side, but can also be fixed here. Passing conditional content always works better with explicit no-passing slot completely.

It is an old known issue in Vue 2 with deprecated slot syntax and checking `this.$slots`. Because there is a content passed via old slot syntax (not using `v-slot` directive), it handles `$slots` differently. It has icon rendering function in `$scopedSlots`, but the rendering result does not exist in `$slots`.

Unfortunately, I don't remember the Vue 2 issue link...