### PR TITLE
fix: Do not show trailing button for technical name input

### DIFF
--- a/src/components/Questions/Question.vue
+++ b/src/components/Questions/Question.vue
@@ -93,7 +93,11 @@
 						{{ t('forms', 'Required') }}
 					</NcActionCheckbox>
 					<slot name="actions" />
-					<NcActionInput :value="name" :label="t('forms', 'Technical name of the question')" @input="onNameChange">
+					<NcActionInput :label="t('forms', 'Technical name of the question')"
+						:label-outside="false"
+						:show-trailing-button="false"
+						:value="name"
+						@input="onNameChange">
 						<template #icon>
 							<IconIdentifier :size="20" />
 						</template>


### PR DESCRIPTION
* Resolves https://github.com/nextcloud/forms/issues/1973

Do not show the button - just save like all other elements do.

![Screenshot 2024-03-22 at 19-57-45 New form - Forms - Nextcloud](https://github.com/nextcloud/forms/assets/1855448/b494027c-2e59-49c3-912d-8f2c84689b67)

