### PR TITLE
fix: remove positive lookbehind for finding unescaped slashes

### DIFF
--- a/src/utils/RegularExpression.js
+++ b/src/utils/RegularExpression.js
@@ -27,7 +27,7 @@ const REGEX_WITH_DELIMITERS = /^\/(.+)\/([smi]{0,3})$/
 /**
  * Find unescaped slashes within a string
  */
-const REGEX_UNESCAPED_SLASH = /(?<=(^|[^\\]))(\\\\)*\//
+const REGEX_UNESCAPED_SLASH = /(?:^|[^\\])(?:\\\\)*\//
 
 /**
  * Check if a regex is valid and enclosed with delimiters


### PR DESCRIPTION
This fixes #2032 by replacing a positive lookbehind for detecting unescaped `/` in custom validation fields.

Signed-off-by: GitHub <noreply@github.com>