### PR TITLE
fix: don't filter expired forms in navigation

### DIFF
--- a/src/Forms.vue
+++ b/src/Forms.vue
@@ -205,22 +205,16 @@ export default {
 		 * All own active forms
 		 */
 		ownedForms() {
-			const now = Date.now() / 1000
-
 			return this.forms
 				.filter((form) => form.state !== FormState.FormArchived)
-				.filter((form) => form.expires === 0 || form.expires >= now)
 		},
 
 		/**
 		 * All active shared forms
 		 */
 		sharedForms() {
-			const now = Date.now() / 1000
-
 			return this.allSharedForms
 				.filter((form) => form.state !== FormState.FormArchived)
-				.filter((form) => form.expires === 0 || form.expires >= now)
 		},
 
 		/**


### PR DESCRIPTION
Expired forms are no longer shown in the navigation. This removes the filter and shows the epxired forms again.

Signed-off-by: Christian Hartmann <chris-hartmann@gmx.de>