### PR TITLE
Fix toggle between Summary and Responses Submission overview

### DIFF
--- a/src/views/Results.vue
+++ b/src/views/Results.vue
@@ -183,7 +183,7 @@
 			</header>
 
 			<!-- Summary view for visualization -->
-			<section v-if="showSummary">
+			<section v-if="activeResponseView.id === 'summary'">
 				<ResultsSummary v-for="question in form.questions"
 					:key="question.id"
 					:question="question"
@@ -322,7 +322,6 @@ export default {
 			loadingResults: true,
 
 			picker: null,
-			showSummary: true,
 			showConfirmDeleteDialog: false,
 			showLinkedFileNotAvailableDialog: false,
 


### PR DESCRIPTION
1. Go to Submission overview
2. Switch from Summary to Responses

Expected: view mode changed

Actual: nothing happened