### PR TITLE
Fix fetching shared forms and return array values in ApiController.php

### DIFF
--- a/lib/Controller/ApiController.php
+++ b/lib/Controller/ApiController.php
@@ -115,7 +115,7 @@ class ApiController extends OCSController {
 	 */
 	public function getSharedForms(): DataResponse {
 		$forms = $this->formsService->getSharedForms($this->currentUser);
-		$result = array_map(fn (Form $form): array => $this->formsService->getPartialFormArray($form), $forms);
+		$result = array_values(array_map(fn (Form $form): array => $this->formsService->getPartialFormArray($form), $forms));
 
 		return new DataResponse($result);
 	}


### PR DESCRIPTION
This fixes #2075

Currently shared_forms were returned as an object containing forms objects. This adjusts it to returning an array of shared forms objects

Signed-off-by: Christian Hartmann <chris-hartmann@gmx.de>