### PR TITLE
feat: Allow to limit multiple question type

### DIFF
--- a/docs/DataStructure.md
+++ b/docs/DataStructure.md
@@ -194,9 +194,11 @@ Currently supported Question-Types are:
 ## Extra Settings
 Optional extra settings for some [Question Types](#question-types)
 
-| Extra Setting      | Question Type | Type   | Values | Description |
-|--------------------|---------------|--------|--------|-------------|
+| Extra Setting      | Question Type | Type    | Values | Description |
+|--------------------|---------------|---------|--------|-------------|
 | `allowOtherAnswer` | `multiple, multiple_unique` | Boolean | `true/false` | Allows the user to specify a custom answer |
 | `shuffleOptions`   | `dropdown, multiple, multiple_unique` | Boolean | `true/false` | The list of options should be shuffled |
+| `optionsLimitMax`  | `multiple`    | Integer | -      | Maximum number of options that can be selected |
+| `optionsLimitMin`  | `multiple`    | Integer | -      | Minimum number of options that must be selected |
 | `validationType`   | `short` | string | `null, 'phone', 'email', 'regex', 'number'` | Custom validation for checking a submission |
 | `validationRegex`  | `short` | string | regular expression | if `validationType` is 'regex' this defines the regular expression to apply |

--- a/lib/Constants.php
+++ b/lib/Constants.php
@@ -145,6 +145,8 @@ class Constants {
 
 	public const EXTRA_SETTINGS_MULTIPLE = [
 		'allowOtherAnswer' => ['boolean'],
+		'optionsLimitMax' => ['integer'],
+		'optionsLimitMin' => ['integer'],
 		'shuffleOptions' => ['boolean'],
 	];
 

--- a/lib/Constants.php
+++ b/lib/Constants.php
@@ -139,18 +139,18 @@ class Constants {
 
 	// This are allowed extra settings
 	public const EXTRA_SETTINGS_DROPDOWN = [
-		'allowOtherAnswer',
-		'shuffleOptions',
+		'allowOtherAnswer' => ['boolean'],
+		'shuffleOptions' => ['boolean'],
 	];
 
 	public const EXTRA_SETTINGS_MULTIPLE = [
-		'allowOtherAnswer',
-		'shuffleOptions',
+		'allowOtherAnswer' => ['boolean'],
+		'shuffleOptions' => ['boolean'],
 	];
 
 	public const EXTRA_SETTINGS_SHORT = [
-		'validationType',
-		'validationRegex'
+		'validationType' => ['string'],
+		'validationRegex' => ['string'],
 	];
 
 	/**

--- a/lib/Service/FormsService.php
+++ b/lib/Service/FormsService.php
@@ -613,8 +613,15 @@ class FormsService {
 			}
 		}
 
-		// Special handling of short input for validation
-		if ($questionType === Constants::ANSWER_TYPE_SHORT && isset($extraSettings['validationType'])) {
+		if ($questionType === Constants::ANSWER_TYPE_MULTIPLE) {
+			// Ensure limits are sane
+			if (isset($extraSettings['optionsLimitMax']) && isset($extraSettings['optionsLimitMin'])
+				&& $extraSettings['optionsLimitMax'] < $extraSettings['optionsLimitMin']) {
+				return false;
+			}
+
+			// Special handling of short input for validation
+		} elseif ($questionType === Constants::ANSWER_TYPE_SHORT && isset($extraSettings['validationType'])) {
 			// Ensure input validation type is known
 			if (!in_array($extraSettings['validationType'], Constants::SHORT_INPUT_TYPES)) {
 				return false;

--- a/lib/Service/FormsService.php
+++ b/lib/Service/FormsService.php
@@ -600,9 +600,17 @@ class FormsService {
 				$allowed = [];
 		}
 		// Number of keys in extraSettings but not in allowed (but not the other way round)
-		$diff = array_diff(array_keys($extraSettings), $allowed);
+		$diff = array_diff(array_keys($extraSettings), array_keys($allowed));
 		if (count($diff) > 0) {
 			return false;
+		}
+
+		// Check type of extra settings
+		foreach ($extraSettings as $key => $value) {
+			if (!in_array(gettype($value), $allowed[$key])) {
+				// Not allowed type
+				return false;
+			}
 		}
 
 		// Special handling of short input for validation

--- a/src/mixins/QuestionMixin.js
+++ b/src/mixins/QuestionMixin.js
@@ -215,6 +215,13 @@ export default {
 
 	methods: {
 		/**
+		 * Override to allow custom validation
+		 */
+		async validate() {
+			return true
+		},
+
+		/**
 		 * Forward the title change to the parent and store to db
 		 *
 		 * @param {string} text the title

--- a/tests/Unit/Service/FormsServiceTest.php
+++ b/tests/Unit/Service/FormsServiceTest.php
@@ -1251,6 +1251,45 @@ class FormsServiceTest extends TestCase {
 				'questionType' => Constants::ANSWER_TYPE_MULTIPLE,
 				'expected' => true
 			],
+			'valid-options-limit' => [
+				'extraSettings' => [
+					'optionsLimitMax' => 3,
+					'optionsLimitMin' => 2,
+				],
+				'questionType' => Constants::ANSWER_TYPE_MULTIPLE,
+				'expected' => true
+			],
+			'valid-options-limit-min' => [
+				'extraSettings' => [
+					'optionsLimitMin' => 4,
+				],
+				'questionType' => Constants::ANSWER_TYPE_MULTIPLE,
+				'expected' => true
+			],
+			'valid-options-limit-max' => [
+				'extraSettings' => [
+					'optionsLimitMax' => 2,
+				],
+				'questionType' => Constants::ANSWER_TYPE_MULTIPLE,
+				'expected' => true
+			],
+			'invalid-options-limit' => [
+				// max < min
+				'extraSettings' => [
+					'optionsLimitMax' => 2,
+					'optionsLimitMin' => 4,
+				],
+				'questionType' => Constants::ANSWER_TYPE_MULTIPLE,
+				'expected' => false
+			],
+			'invalid-settings-type' => [
+				'extraSettings' => [
+					'optionsLimitMax' => 'hello',
+					'optionsLimitMin' => false,
+				],
+				'questionType' => Constants::ANSWER_TYPE_MULTIPLE,
+				'expected' => false
+			],
 			'invalid subtype' => [
 				'extraSettings' => [
 					'validationType' => 'iban',

--- a/tests/Unit/Service/SubmissionServiceTest.php
+++ b/tests/Unit/Service/SubmissionServiceTest.php
@@ -715,6 +715,57 @@ class SubmissionServiceTest extends TestCase {
 				// Expected Result
 				false
 			],
+			'invalid-multiple-too-many-answers' => [
+				// Questions
+				[
+					['id' => 1, 'type' => 'multiple', 'isRequired' => false, 'extraSettings' => ['optionsLimitMax' => 2], 'options' => [
+						['id' => 3],
+						['id' => 5],
+						['id' => 7],
+						['id' => 9],
+					]]
+				],
+				// Answers
+				[
+					'1' => [3, 5, 7]
+				],
+				// Expected Result
+				false
+			],
+			'invalid-multiple-too-few-answers' => [
+				// Questions
+				[
+					['id' => 1, 'type' => 'multiple', 'isRequired' => false, 'extraSettings' => ['optionsLimitMin' => 2], 'options' => [
+						['id' => 3],
+						['id' => 5],
+						['id' => 7],
+						['id' => 9],
+					]]
+				],
+				// Answers
+				[
+					'1' => [3]
+				],
+				// Expected Result
+				false
+			],
+			'valid-multiple-with-limits' => [
+				// Questions
+				[
+					['id' => 1, 'type' => 'multiple', 'isRequired' => false, 'extraSettings' => ['optionsLimitMin' => 2, 'optionsLimitMax' => 3], 'options' => [
+						['id' => 3],
+						['id' => 5],
+						['id' => 7],
+						['id' => 9],
+					]]
+				],
+				// Answers
+				[
+					'1' => [3,9]
+				],
+				// Expected Result
+				true
+			],
 			'invalid-short-phone' => [
 				// Questions
 				[


### PR DESCRIPTION
* Resolves: https://github.com/nextcloud/forms/issues/616

This allows to set a minimum and maximum of options that can or must be selected.
E.g. you can enforce max. 3 options to be selected.

Other changes needed:
1. Add custom validation
2. Add validation of extra settings parameter types

### Screenshots

settings | error
---|---
![Screenshot_20240420_021429](https://github.com/nextcloud/forms/assets/1855448/801abe74-5e1c-4198-8465-3e6180f624c1)|![Screenshot_20240420_021446](https://github.com/nextcloud/forms/assets/1855448/8ad40a17-7171-49b4-82cd-2dc80b366107)
