### PR TITLE
fix: Parse momentFormat and storageFormat

### DIFF
--- a/src/components/Questions/QuestionDate.vue
+++ b/src/components/Questions/QuestionDate.vue
@@ -109,7 +109,7 @@ export default {
 		 * @return {Date}
 		 */
 		parse(dateString) {
-			return moment(dateString, this.answerType.momentFormat).toDate()
+			return moment(dateString, [this.answerType.momentFormat, this.answerType.storageFormat]).toDate()
 		},
 
 		/**


### PR DESCRIPTION
This fixes #2091 by parsing the momentFormat `L` or the storageFormat `YYYY-MM-DD`.