### PR TITLE
fix(a11y): Add missing page headings

### DIFF
--- a/src/views/Create.vue
+++ b/src/views/Create.vue
@@ -24,7 +24,7 @@
   -->
 
 <template>
-	<NcAppContent>
+	<NcAppContent :page-heading="form.title ? t('forms', 'Edit form') : t('forms', 'Create form')">
 		<!-- Show results & sidebar button -->
 		<TopBar :archived="isFormArchived"
 			:permissions="form?.permissions"

--- a/src/views/Results.vue
+++ b/src/views/Results.vue
@@ -23,7 +23,7 @@
   -->
 
 <template>
-	<NcAppContent>
+	<NcAppContent :page-heading="t('forms', 'Results')">
 		<NcDialog :open.sync="showLinkedFileNotAvailableDialog"
 			:name="t('forms', 'Linked file not available')"
 			:message="t('forms', 'Linked file is not available, would you like to link a new file?')"

--- a/src/views/Submit.vue
+++ b/src/views/Submit.vue
@@ -23,7 +23,7 @@
  -->
 
 <template>
-	<NcAppContent :class="{'app-content--public': publicView}">
+	<NcAppContent :class="{'app-content--public': publicView}" :page-heading="t('forms', 'Submit form')">
 		<TopBar v-if="!publicView"
 			:archived="isArchived"
 			:permissions="form?.permissions"


### PR DESCRIPTION
We need a h1 on the page, otherwise every `h2` or higher is invalid.
The h1 is visually hidden and only added for accessibility.