### PR TITLE
Add support of multi-columns descriptions

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -16,3 +16,4 @@ l10n/
 # PHP
 lib/
 **/*.php
+composer.lock

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "crypto-js": "^4.2.0",
         "debounce": "^2.1.0",
         "markdown-it": "^14.1.0",
+        "markdown-it-container": "^4.0.0",
         "p-debounce": "^4.0.0",
         "p-queue": "^8.0.1",
         "v-click-outside": "^3.2.0",
@@ -8562,6 +8563,11 @@
       "bin": {
         "markdown-it": "bin/markdown-it.mjs"
       }
+    },
+    "node_modules/markdown-it-container": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/markdown-it-container/-/markdown-it-container-4.0.0.tgz",
+      "integrity": "sha512-HaNccxUH0l7BNGYbFbjmGpf5aLHAMTinqRZQAEQbMr2cdD3z91Q6kIo1oUn1CQndkT03jat6ckrdRYuwwqLlQw=="
     },
     "node_modules/markdown-it/node_modules/argparse": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "crypto-js": "^4.2.0",
     "debounce": "^2.1.0",
     "markdown-it": "^14.1.0",
+    "markdown-it-container": "^4.0.0",
     "p-debounce": "^4.0.0",
     "p-queue": "^8.0.1",
     "v-click-outside": "^3.2.0",

--- a/src/mixins/ViewsMixin.js
+++ b/src/mixins/ViewsMixin.js
@@ -25,6 +25,7 @@ import { showError } from '@nextcloud/dialogs'
 import { emit } from '@nextcloud/event-bus'
 import axios from '@nextcloud/axios'
 import MarkdownIt from 'markdown-it'
+import MarkdownItContainer from 'markdown-it-container'
 
 import CancelableRequest from '../utils/CancelableRequest.js'
 import OcsResponse2Data from '../utils/OcsResponse2Data.js'
@@ -65,7 +66,12 @@ export default {
 			cancelFetchFullForm: () => {},
 
 			// markdown renderer for descriptions
-			markdownit: new MarkdownIt({ breaks: true }),
+			markdownit: new MarkdownIt({ breaks: true })
+				.use(MarkdownItContainer, 'columns', {})
+				.use(MarkdownItContainer, 'column-single', {})
+				.use(MarkdownItContainer, 'column-double', {})
+				.use(MarkdownItContainer, 'column-triple', {})
+				.use(MarkdownItContainer, 'column-quad', {}),
 		}
 	},
 

--- a/src/scssmixins/markdownOutput.scss
+++ b/src/scssmixins/markdownOutput.scss
@@ -84,5 +84,49 @@
 				list-style-type: square;
 			}
 		}
+
+		.columns {
+			display: flex;
+			flex-direction: row;
+			justify-content: space-between;
+			column-gap: 2em;
+
+			img {
+				max-width: 100%;
+				height: auto;
+			}
+
+			.column-single {
+				flex: 1 1;
+				overflow: hidden;
+			}
+
+			.column-double {
+				flex: 2 1;
+				overflow: hidden;
+			}
+
+			.column-triple {
+				flex: 3 1;
+				overflow: hidden;
+			}
+
+			.column-quad {
+				flex: 4 1;
+				overflow: hidden;
+			}
+
+			@media (max-width: 512px) {
+				flex-direction: column;
+				column-gap: 0;
+
+				.column-single,
+				.column-double,
+				.column-triple,
+				.column-quad {
+					flex: 1 1 100%;
+				}
+			}
+		}
 	}
 }


### PR DESCRIPTION
Now we can use multi-columns descriptions thankful to [markdown-it-container](https://github.com/markdown-it/markdown-it-container) plugin

```markdown
::::: columns
:::: column-double
first column has double relative width (ie 2/3 of total width) 
::::
:::: column-single
second column has single relative width (ie 1/3 of total width)
::::
:::::
```

<details>
  <summary>:mag:  Preview</summary>

  ![image](https://github.com/nextcloud/forms/assets/191082/74d44ed8-bd27-4141-aadb-c6d243bc5451)
  ![image](https://github.com/nextcloud/forms/assets/191082/71ee0faa-9fda-470d-9f3d-35339ba045ec)
</details>
