### PR TITLE
chore: add API v3

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -25,353 +25,216 @@
  *
  */
 
+$apiBase = '/api/{apiVersion}/';
+$requirements_v3 = [
+	'apiVersion' => 'v3',
+	'formId' => '\d+',
+	'questionId' => '\d+',
+	'optionId' => '\d+',
+	'shareId' => '\d+',
+	'submissionId' => '\d+'
+];
+
 return [
 	'routes' => [
 		// Internal AppConfig routes
-		[
-			'name' => 'config#getAppConfig',
-			'url' => '/config',
-			'verb' => 'GET'
-		],
-		[
-			'name' => 'config#updateAppConfig',
-			'url' => '/config/update',
-			'verb' => 'PATCH'
-		],
+		['name' => 'config#getAppConfig', 'url' => '/config', 'verb' => 'GET'],
+		['name' => 'config#updateAppConfig', 'url' => '/config/update', 'verb' => 'PATCH'],
 
 		// Public Share Link
-		[
-			'name' => 'page#public_link_view',
-			'url' => '/s/{hash}',
-			'verb' => 'GET'
-		],
+		['name' => 'page#public_link_view', 'url' => '/s/{hash}', 'verb' => 'GET'],
 
 		// Embedded View
-		[
-			'name' => 'page#embedded_form_view',
-			'url' => '/embed/{hash}',
-			'verb' => 'GET'
-		],
+		['name' => 'page#embedded_form_view', 'url' => '/embed/{hash}', 'verb' => 'GET'],
 
 		// Internal views
-		[
-			'name' => 'page#views',
-			'url' => '/{hash}/{view}',
-			'verb' => 'GET'
-		],
+		['name' => 'page#views', 'url' => '/{hash}/{view}', 'verb' => 'GET'],
 		// Internal Form Link
-		[
-			'name' => 'page#internal_link_view',
-			'url' => '/{hash}',
-			'verb' => 'GET'
-		],
+		['name' => 'page#internal_link_view', 'url' => '/{hash}', 'verb' => 'GET'],
 		// App Root
-		[
-			'name' => 'page#index',
-			'url' => '/',
-			'verb' => 'GET'
-		],
+		['name' => 'page#index', 'url' => '/', 'verb' => 'GET'],
 	],
 
 	'ocs' => [
 		// CORS Preflight
-		[
-			'name' => 'api#preflightedCors',
-			'url' => '/api/{apiVersion}/{path}',
-			'verb' => 'OPTIONS',
-			'requirements' => [
-				'path' => '.+',
-				'apiVersion' => 'v2(\.[1-4])?'
-			]
-		],
+		['name' => 'api#preflightedCors', 'url' => $apiBase . '{path}', 'verb' => 'OPTIONS', 'requirements' => [
+			'path' => '.+',
+			'apiVersion' => 'v2(\.[1-4])?|v3'
+		]],
 
+		// API routes v3
 		// Forms
-		[
-			'name' => 'api#getForms',
-			'url' => '/api/{apiVersion}/forms',
-			'verb' => 'GET',
-			'requirements' => [
-				'apiVersion' => 'v2(\.[1-4])?'
-			]
-		],
-		[
-			'name' => 'api#newForm',
-			'url' => '/api/{apiVersion}/form',
-			'verb' => 'POST',
-			'requirements' => [
-				'apiVersion' => 'v2(\.[1-4])?'
-			]
-		],
-		[
-			'name' => 'api#getForm',
-			'url' => '/api/{apiVersion}/form/{id}',
-			'verb' => 'GET',
-			'requirements' => [
-				'apiVersion' => 'v2(\.[1-4])?'
-			]
-		],
-		[
-			'name' => 'api#cloneForm',
-			'url' => '/api/{apiVersion}/form/clone/{id}',
-			'verb' => 'POST',
-			'requirements' => [
-				'apiVersion' => 'v2(\.[1-4])?'
-			]
-		],
-		// TODO: Remove POST in next API release
-		[
-			'name' => 'api#updateForm',
-			'url' => '/api/{apiVersion}/form/update',
-			'verb' => 'POST',
-			'requirements' => [
-				'apiVersion' => 'v2(\.[1-4])?'
-			]
-		],
-		[
-			'name' => 'api#updateForm',
-			'url' => '/api/{apiVersion}/form/update',
-			'verb' => 'PATCH',
-			'requirements' => [
-				'apiVersion' => 'v2\.[2-4]'
-			]
-		],
-		[
-			'name' => 'api#transferOwner',
-			'url' => '/api/{apiVersion}/form/transfer',
-			'verb' => 'POST',
-			'requirements' => [
-				'apiVersion' => 'v2\.[2-4]'
-			]
-		],
-		[
-			'name' => 'api#deleteForm',
-			'url' => '/api/{apiVersion}/form/{id}',
-			'verb' => 'DELETE',
-			'requirements' => [
-				'apiVersion' => 'v2(\.[1-4])?'
-			]
-		],
-		[
-			'name' => 'api#getPartialForm',
-			'url' => '/api/{apiVersion}/partial_form/{hash}',
-			'verb' => 'GET',
-			'requirements' => [
-				'apiVersion' => 'v2(\.[1-4])?'
-			]
-		],
-		[
-			'name' => 'api#getSharedForms',
-			'url' => '/api/{apiVersion}/shared_forms',
-			'verb' => 'GET',
-			'requirements' => [
-				'apiVersion' => 'v2(\.[1-4])?'
-			]
-		],
+		['name' => 'api#getForms', 'url' => $apiBase . 'forms', 'verb' => 'GET', 'requirements' => $requirements_v3],
+		['name' => 'api#newForm', 'url' => $apiBase . 'forms', 'verb' => 'POST', 'requirements' => $requirements_v3],
+		['name' => 'api#getForm', 'url' => $apiBase . 'forms/{formId}', 'verb' => 'GET', 'requirements' => $requirements_v3],
+		['name' => 'api#updateForm', 'url' => $apiBase . 'forms/{formId}', 'verb' => 'PATCH', 'requirements' => $requirements_v3],
+		['name' => 'api#deleteForm', 'url' => $apiBase . 'forms/{formId}', 'verb' => 'DELETE', 'requirements' => $requirements_v3],
 
 		// Questions
-		[
-			'name' => 'api#newQuestion',
-			'url' => '/api/{apiVersion}/question',
-			'verb' => 'POST',
-			'requirements' => [
-				'apiVersion' => 'v2(\.[1-4])?'
-			]
-		],
-		// TODO: Remove POST in next API release
-		[
-			'name' => 'api#updateQuestion',
-			'url' => '/api/{apiVersion}/question/update',
-			'verb' => 'POST',
-			'requirements' => [
-				'apiVersion' => 'v2(\.[1-4])?'
-			]
-		],
-		[
-			'name' => 'api#updateQuestion',
-			'url' => '/api/{apiVersion}/question/update',
-			'verb' => 'PATCH',
-			'requirements' => [
-				'apiVersion' => 'v2\.[2-4]'
-			]
-		],
-		// TODO: Remove POST in next API release
-		[
-			'name' => 'api#reorderQuestions',
-			'url' => '/api/{apiVersion}/question/reorder',
-			'verb' => 'POST',
-			'requirements' => [
-				'apiVersion' => 'v2(\.[1-4])?'
-			]
-		],
-		[
-			'name' => 'api#reorderQuestions',
-			'url' => '/api/{apiVersion}/question/reorder',
-			'verb' => 'PUT',
-			'requirements' => [
-				'apiVersion' => 'v2\.[2-4]'
-			]
-		],
-		[
-			'name' => 'api#deleteQuestion',
-			'url' => '/api/{apiVersion}/question/{id}',
-			'verb' => 'DELETE',
-			'requirements' => [
-				'apiVersion' => 'v2(\.[1-4])?'
-			]
-		],
-		[
-			'name' => 'api#cloneQuestion',
-			'url' => '/api/{apiVersion}/question/clone/{id}',
-			'verb' => 'POST',
-			'requirements' => [
-				'apiVersion' => 'v2\.[3-4]'
-			]
-		],
+		['name' => 'api#getQuestions', 'url' => $apiBase . 'forms/{formId}/questions', 'verb' => 'GET', 'requirements' => $requirements_v3],
+		['name' => 'api#newQuestion', 'url' => $apiBase . 'forms/{formId}/questions', 'verb' => 'POST', 'requirements' => $requirements_v3],
+		['name' => 'api#getQuestion', 'url' => $apiBase . 'forms/{formId}/questions/{questionId}', 'verb' => 'GET', 'requirements' => $requirements_v3],
+		['name' => 'api#updateQuestion', 'url' => $apiBase . 'forms/{formId}/questions/{questionId}', 'verb' => 'PATCH', 'requirements' => $requirements_v3],
+		['name' => 'api#deleteQuestion', 'url' => $apiBase . 'forms/{formId}/questions/{questionId}', 'verb' => 'DELETE', 'requirements' => $requirements_v3],
+		['name' => 'api#reorderQuestions', 'url' => $apiBase . 'forms/{formId}/questions', 'verb' => 'PATCH', 'requirements' => $requirements_v3],
 
 		// Options
-		[
-			'name' => 'api#newOption',
-			'url' => '/api/{apiVersion}/option',
-			'verb' => 'POST',
-			'requirements' => [
-				'apiVersion' => 'v2(\.[1-4])?'
-			]
-		],
-		// TODO: Remove POST in next API release
-		[
-			'name' => 'api#updateOption',
-			'url' => '/api/{apiVersion}/option/update',
-			'verb' => 'POST',
-			'requirements' => [
-				'apiVersion' => 'v2(\.[1-4])?'
-			]
-		],
-		[
-			'name' => 'api#updateOption',
-			'url' => '/api/{apiVersion}/option/update',
-			'verb' => 'PATCH',
-			'requirements' => [
-				'apiVersion' => 'v2\.[2-4]'
-			]
-		],
-		[
-			'name' => 'api#deleteOption',
-			'url' => '/api/{apiVersion}/option/{id}',
-			'verb' => 'DELETE',
-			'requirements' => [
-				'apiVersion' => 'v2(\.[1-4])?'
-			]
-		],
+		// ['name' => 'api#getOptions', 'url' => $apiBase . 'forms/{formId}/questions/{questionId}/options', 'verb' => 'GET', 'requirements' => $requirements_v3],
+		['name' => 'api#newOption', 'url' => $apiBase . 'forms/{formId}/questions/{questionId}/options', 'verb' => 'POST', 'requirements' => $requirements_v3],
+		// ['name' => 'api#getOption', 'url' => $apiBase . 'forms/{formId}/questions/{questionId}/options/{optionId}', 'verb' => 'GET', 'requirements' => $requirements_v3],
+		['name' => 'api#updateOption', 'url' => $apiBase . 'forms/{formId}/questions/{questionId}/options/{optionId}', 'verb' => 'PATCH', 'requirements' => $requirements_v3],
+		['name' => 'api#deleteOption', 'url' => $apiBase . 'forms/{formId}/questions/{questionId}/options/{optionId}', 'verb' => 'DELETE', 'requirements' => $requirements_v3],
+		// ['name' => 'api#reorderOptions', 'url' => $apiBase . 'forms/{formId}/questions/{questionId}/options', 'verb' => 'PATCH', 'requirements' => $requirements_v3],
 
 		// Shares
-		[
-			'name' => 'shareApi#newShare',
-			'url' => '/api/{apiVersion}/share',
-			'verb' => 'POST',
-			'requirements' => [
-				'apiVersion' => 'v2(\.[1-4])?'
-			]
-		],
-		[
-			'name' => 'shareApi#deleteShare',
-			'url' => '/api/{apiVersion}/share/{id}',
-			'verb' => 'DELETE',
-			'requirements' => [
-				'apiVersion' => 'v2(\.[1-4])?'
-			]
-		],
-		// TODO: Remove POST in next API release
-		[
-			'name' => 'shareApi#updateShare',
-			'url' => '/api/{apiVersion}/share/update',
-			'verb' => 'POST',
-			'requirements' => [
-				'apiVersion' => 'v2\.[1-4]'
-			]
-		],
-		[
-			'name' => 'shareApi#updateShare',
-			'url' => '/api/{apiVersion}/share/update',
-			'verb' => 'PATCH',
-			'requirements' => [
-				'apiVersion' => 'v2\.[2-4]'
-			]
-		],
+		// ['name' => 'shareApi#getUserShares', 'url' => $apiBase . 'shares', 'verb' => 'GET', 'requirements' => $requirements_v3],
+		// ['name' => 'shareApi#getShares', 'url' => $apiBase . 'forms/{formId}/shares', 'verb' => 'GET', 'requirements' => $requirements_v3],
+		['name' => 'shareApi#newShare', 'url' => $apiBase . 'forms/{formId}/shares', 'verb' => 'POST', 'requirements' => $requirements_v3],
+		// ['name' => 'shareApi#getShare', 'url' => $apiBase . 'forms/{formId}/shares/{shareId}', 'verb' => 'GET', 'requirements' => $requirements_v3],
+		['name' => 'shareApi#updateShare', 'url' => $apiBase . 'forms/{formId}/shares/{shareId}', 'verb' => 'PATCH', 'requirements' => $requirements_v3],
+		['name' => 'shareApi#deleteShare', 'url' => $apiBase . 'forms/{formId}/shares/{shareId}', 'verb' => 'DELETE', 'requirements' => $requirements_v3],
 
 		// Submissions
-		[
-			'name' => 'api#getSubmissions',
-			'url' => '/api/{apiVersion}/submissions/{hash}',
-			'verb' => 'GET',
-			'requirements' => [
-				'apiVersion' => 'v2(\.[1-4])?'
-			]
-		],
-		[
-			'name' => 'api#exportSubmissions',
-			'url' => '/api/{apiVersion}/submissions/export/{hash}',
-			'verb' => 'GET',
-			'requirements' => [
-				'apiVersion' => 'v2(\.[1-4])?'
-			]
-		],
-		[
-			'name' => 'api#exportSubmissionsToCloud',
-			'url' => '/api/{apiVersion}/submissions/export',
-			'verb' => 'POST',
-			'requirements' => [
-				'apiVersion' => 'v2(\.[1-4])?'
-			]
-		],
-		[
-			'name' => 'api#deleteAllSubmissions',
-			'url' => '/api/{apiVersion}/submissions/{formId}',
-			'verb' => 'DELETE',
-			'requirements' => [
-				'apiVersion' => 'v2(\.[1-4])?'
-			]
-		],
-		[
-			'name' => 'api#uploadFiles',
-			'url' => '/api/{apiVersion}/uploadFiles/{formId}/{questionId}',
-			'verb' => 'POST',
-			'requirements' => [
-				'apiVersion' => 'v2.5'
-			]
-		],
-		[
-			'name' => 'api#insertSubmission',
-			'url' => '/api/{apiVersion}/submission/insert',
-			'verb' => 'POST',
-			'requirements' => [
-				'apiVersion' => 'v2(\.[1-4])?'
-			]
-		],
-		[
-			'name' => 'api#deleteSubmission',
-			'url' => '/api/{apiVersion}/submission/{id}',
-			'verb' => 'DELETE',
-			'requirements' => [
-				'apiVersion' => 'v2(\.[1-4])?'
-			]
-		],
+		['name' => 'api#getSubmissions', 'url' => $apiBase . 'forms/{formId}/submissions', 'verb' => 'GET', 'requirements' => $requirements_v3],
+		['name' => 'api#newSubmission', 'url' => $apiBase . 'forms/{formId}/submissions', 'verb' => 'POST', 'requirements' => $requirements_v3],
+		['name' => 'api#deleteAllSubmissions', 'url' => $apiBase . 'forms/{formId}/submissions', 'verb' => 'DELETE', 'requirements' => $requirements_v3],
+		//['name' => 'api#getSubmission', 'url' => $apiBase . 'forms/{formId}/submissions/{submissionId}', 'verb' => 'GET', 'requirements' => $requirements_v3],
+		//['name' => 'api#updateSubmission', 'url' => $apiBase . 'forms/{formId}/submissions/{submissionId}', 'verb' => 'PATCH', 'requirements' => $requirements_v3],
+		['name' => 'api#deleteSubmission', 'url' => $apiBase . 'forms/{formId}/submissions/{submissionId}', 'verb' => 'DELETE', 'requirements' => $requirements_v3],
+		['name' => 'api#exportSubmissionsToCloud', 'url' => $apiBase . 'forms/{formId}/submissions/export', 'verb' => 'POST', 'requirements' => $requirements_v3],
+		['name' => 'api#uploadFiles', 'url' => $apiBase . 'forms/{formId}/submissions/files/{questionId}', 'verb' => 'POST', 'requirements' => $requirements_v3],
+
+		// Legacy v2 routes (TODO: remove with Forms v5)
+		// Forms
+		['name' => 'api#getFormsLegacy', 'url' => $apiBase . 'forms', 'verb' => 'GET', 'requirements' => [
+			'apiVersion' => 'v2(\.[1-4])?'
+		]],
+		['name' => 'api#newFormLegacy', 'url' => $apiBase . 'form', 'verb' => 'POST', 'requirements' => [
+			'apiVersion_path' => 'v2(\.[1-4])?'
+		]],
+		['name' => 'api#getFormLegacy', 'url' => $apiBase . 'form/{id}', 'verb' => 'GET', 'requirements' => [
+			'apiVersion_path' => 'v2(\.[1-4])?',
+			'id' => '\d+'
+		]],
+		['name' => 'api#cloneFormLegacy', 'url' => $apiBase . 'form/clone/{id}', 'verb' => 'POST', 'requirements' => [
+			'apiVersion' => 'v2(\.[1-4])?',
+			'id' => '\d+'
+		]],
+		['name' => 'api#updateFormLegacy', 'url' => $apiBase . 'form/update', 'verb' => 'POST', 'requirements' => [
+			'apiVersion' => 'v2(\.[1-4])?'
+		]],
+		['name' => 'api#updateFormLegacy', 'url' => $apiBase . 'form/update', 'verb' => 'PATCH', 'requirements' => [
+			'apiVersion' => 'v2\.[2-4]'
+		]],
+		['name' => 'api#transferOwnerLegacy', 'url' => $apiBase . 'form/transfer', 'verb' => 'POST', 'requirements' => [
+			'apiVersion' => 'v2\.[2-4]'
+		]],
+		['name' => 'api#deleteFormLegacy', 'url' => $apiBase . 'form/{id}', 'verb' => 'DELETE', 'requirements' => [
+			'apiVersion' => 'v2(\.[1-4])?',
+			'id' => '\d+'
+		]],
+		['name' => 'api#getPartialFormLegacy', 'url' => $apiBase . 'partial_form/{hash}', 'verb' => 'GET', 'requirements' => [
+			'apiVersion' => 'v2(\.[1-4])?',
+			'hash' => '[a-zA-Z0-9]{16}'
+		]],
+		['name' => 'api#getSharedFormsLegacy', 'url' => $apiBase . 'shared_forms', 'verb' => 'GET', 'requirements' => [
+			'apiVersion' => 'v2(\.[1-4])?'
+		]],
+
+		// Questions
+		['name' => 'api#newQuestionLegacy', 'url' => $apiBase . 'question', 'verb' => 'POST', 'requirements' => [
+			'apiVersion' => 'v2(\.[1-4])?'
+		]],
+		// TODO: Remove POST in next API release
+		['name' => 'api#updateQuestionLegacy', 'url' => $apiBase . 'question/update', 'verb' => 'POST', 'requirements' => [
+			'apiVersion' => 'v2(\.[1-4])?'
+		]],
+		['name' => 'api#updateQuestionLegacy', 'url' => $apiBase . 'question/update', 'verb' => 'PATCH', 'requirements' => [
+			'apiVersion' => 'v2\.[2-4]'
+		]],
+		// TODO: Remove POST in next API release
+		['name' => 'api#reorderQuestionsLegacy', 'url' => $apiBase . 'question/reorder', 'verb' => 'POST', 'requirements' => [
+			'apiVersion' => 'v2(\.[1-4])?'
+		]],
+		['name' => 'api#reorderQuestionsLegacy', 'url' => $apiBase . 'question/reorder', 'verb' => 'PUT', 'requirements' => [
+			'apiVersion' => 'v2\.[2-4]'
+		]],
+		['name' => 'api#deleteQuestionLegacy', 'url' => $apiBase . 'question/{id}', 'verb' => 'DELETE', 'requirements' => [
+			'apiVersion' => 'v2(\.[1-4])?',
+			'id' => '\d+'
+		]],
+		['name' => 'api#cloneQuestionLegacy', 'url' => $apiBase . 'question/clone/{id}', 'verb' => 'POST', 'requirements' => [
+			'apiVersion' => 'v2\.[3-4]',
+			'id' => '\d+'
+		]],
+
+		// Options
+		['name' => 'api#newOptionLegacy', 'url' => $apiBase . 'option', 'verb' => 'POST', 'requirements' => [
+			'apiVersion' => 'v2(\.[1-4])?'
+		]],
+		// TODO: Remove POST in next API release
+		['name' => 'api#updateOptionLegacy', 'url' => $apiBase . 'option/update', 'verb' => 'POST', 'requirements' => [
+			'apiVersion' => 'v2(\.[1-4])?'
+		]],
+		['name' => 'api#updateOptionLegacy', 'url' => $apiBase . 'option/update', 'verb' => 'PATCH', 'requirements' => [
+			'apiVersion' => 'v2\.[2-4]'
+		]],
+		['name' => 'api#deleteOptionLegacy', 'url' => $apiBase . 'option/{id}', 'verb' => 'DELETE', 'requirements' => [
+			'apiVersion' => 'v2(\.[1-4])?',
+			'id' => '\d+'
+		]],
+
+		// Shares
+		['name' => 'shareApi#newShareLegacy', 'url' => $apiBase . 'share', 'verb' => 'POST', 'requirements' => [
+			'apiVersion' => 'v2(\.[1-4])?'
+		]],
+		['name' => 'shareApi#deleteShareLegacy', 'url' => $apiBase . 'share/{id}', 'verb' => 'DELETE', 'requirements' => [
+			'apiVersion' => 'v2(\.[1-4])?',
+			'id' => '\d+'
+		]],
+		// TODO: Remove POST in next API release
+		['name' => 'shareApi#updateShareLegacy', 'url' => $apiBase . 'share/update', 'verb' => 'POST', 'requirements' => [
+			'apiVersion' => 'v2\.[1-4]'
+		]],
+		['name' => 'shareApi#updateShareLegacy', 'url' => $apiBase . 'share/update', 'verb' => 'PATCH', 'requirements' => [
+			'apiVersion' => 'v2\.[2-4]'
+		]],
+
+		// Submissions
+		['name' => 'api#getSubmissionsLegacy', 'url' => $apiBase . 'submissions/{hash}', 'verb' => 'GET', 'requirements' => [
+			'apiVersion' => 'v2(\.[1-4])?',
+			'hash' => '[a-zA-Z0-9]{16}'
+		]],
+		['name' => 'api#exportSubmissionsLegacy', 'url' => $apiBase . 'submissions/export/{hash}', 'verb' => 'GET', 'requirements' => [
+			'apiVersion' => 'v2(\.[1-4])?',
+			'hash' => '[a-zA-Z0-9]{16}'
+		]],
+		['name' => 'api#exportSubmissionsToCloudLegacy', 'url' => $apiBase . 'submissions/export', 'verb' => 'POST', 'requirements' => [
+			'apiVersion' => 'v2(\.[1-4])?'
+		]],
+		['name' => 'api#deleteAllSubmissionsLegacy', 'url' => $apiBase . 'submissions/{formId}', 'verb' => 'DELETE', 'requirements' => [
+			'apiVersion' => 'v2(\.[1-4])?',
+			'formId' => '\d+'
+		]],
+		['name' => 'api#uploadFilesLegacy', 'url' => $apiBase . 'uploadFiles/{formId}/{questionId}', 'verb' => 'POST', 'requirements' => [
+			'apiVersion' => 'v2.5',
+			'formId' => '\d+',
+			'questionId' => '\d+'
+		]],
+		['name' => 'api#insertSubmissionLegacy', 'url' => $apiBase . 'submission/insert', 'verb' => 'POST', 'requirements' => [
+			'apiVersion' => 'v2(\.[1-4])?'
+		]],
+		['name' => 'api#deleteSubmissionLegacy', 'url' => $apiBase . 'submission/{id}', 'verb' => 'DELETE', 'requirements' => [
+			'apiVersion' => 'v2(\.[1-4])?',
+			'id' => '\d+'
+		]],
 		// Submissions linking with file in cloud
-		[
-			'name' => 'api#linkFile',
-			'url' => '/api/{apiVersion}/form/link/{fileFormat}',
-			'verb' => 'POST',
-			'requirements' => [
-				'apiVersion' => 'v2.4',
-				'fileFormat' => 'csv|ods|xlsx'
-			]
-		],
-		[
-			'name' => 'api#unlinkFile',
-			'url' => '/api/{apiVersion}/form/unlink',
-			'verb' => 'POST',
-			'requirements' => [
-				'apiVersion' => 'v2.4',
-			]
-		]
+		['name' => 'api#linkFileLegacy', 'url' => $apiBase . 'form/link/{fileFormat}', 'verb' => 'POST', 'requirements' => [
+			'apiVersion' => 'v2.4',
+			'fileFormat' => 'csv|ods|xlsx'
+		]],
+		['name' => 'api#unlinkFileLegacy', 'url' => $apiBase . 'form/unlink', 'verb' => 'POST', 'requirements' => [
+			'apiVersion' => 'v2.4',
+		]]
 	]
 ];

--- a/docs/API_v3.md
+++ b/docs/API_v3.md
@@ -1,7 +1,5 @@
 # Forms Public API
 
-## API v2 is now deprecated and will be removed with Forms v5. Please see documentation for [API v3](API_v3.md)
-
 This file contains the API-Documentation. For more information on the returned Data-Structures, please refer to the [corresponding Documentation](DataStructure.md).
 
 ## Generals
@@ -29,21 +27,31 @@ This file contains the API-Documentation. For more information on the returned D
 
 ### Deprecation info
 
--   Starting with Forms v4.3 API v2 will be deprecated and removed with Forms v5: Please see the documentation for [API v3](API_v3.md)
+-   Starting with Forms v4.3 API v2 will be deprecated and removed with Forms v5
 -   Starting with API v2.2 all endpoints that update data will use PATCH/PUT as method. POST is now deprecated and will be removed in API v3
 
-### Breaking Changes on API v2
+### Breaking changes on API v3
+
+-   Most routes changed from API v2 to v3. Please adjust your applications accordingly.
+-   Removed possibility to get a single partial form
+
+### Breaking changes on API v2
 
 -   The `mandatory` property of questions has been removed. It is replaced by `isRequired`.
 -   Completely new way of handling access & shares.
 
 ### Other API changes
 
+-   In API version 3.0 the following endpoints were introduced/changed:
+    -   `GET /api/v3/forms/{formId}/questions` to get all questions of a form
+    -   `GET /api/v3/forms/{formId}/questions/{questionId}` to get a single question
+    -   `POST /api/v3/forms/{formId}/questions/{questionId}/options` does now accept more options at once
+    -   `POST /api/v3/forms/{formId}/submissions/files/{questionId}` to upload a file to a file question before submitting the form
 -   In API version 2.5 the following endpoints were introduced:
-    -   `POST /api/2.5/uploadFiles/{formId}/{questionId}` to upload files to answer before form submitting
+    -   `POST /api/v2.5/uploadFiles/{formId}/{questionId}` to upload files to answer before form submitting
 -   In API version 2.4 the following endpoints were introduced:
-    -   `POST /api/2.4/form/link/{fileFormat}` to link form to a file
-    -   `POST /api/2.4/form/unlink` to unlink form from a file
+    -   `POST /api/v2.4/form/link/{fileFormat}` to link form to a file
+    -   `POST /api/v2.4/form/unlink` to unlink form from a file
 -   In API version 2.4 the following endpoints were changed:
     -   `GET /api/v2.4/submissions/export/{hash}` was extended with optional parameter `fileFormat` to export submissions in different formats
     -   `GET /api/v2.4/submissions/export` was extended with optional parameter `fileFormat` to export submissions to cloud in different formats
@@ -58,7 +66,7 @@ This file contains the API-Documentation. For more information on the returned D
 
 Returns condensed objects of all Forms beeing owned by the authenticated user.
 
--   Endpoint: `/api/v2.4/forms`
+-   Endpoint: `/api/v3/forms[?type=owned]`
 -   Method: `GET`
 -   Parameters: None
 -   Response: Array of condensed Form Objects, sorted as newest first.
@@ -98,7 +106,7 @@ Returns condensed objects of all Forms beeing owned by the authenticated user.
 
 Returns condensed objects of all Forms, that are shared & shown to the authenticated user and that have not expired yet.
 
--   Endpoint: `/api/v2.4/shared_forms`
+-   Endpoint: `/api/v3/forms?type=shared`
 -   Method: `GET`
 -   Parameters: None
 -   Response: Array of condensed Form Objects, sorted as newest first, similar to [List owned Forms](#list-owned-forms).
@@ -107,35 +115,9 @@ Returns condensed objects of all Forms, that are shared & shown to the authentic
 See above, 'List owned forms'
 ```
 
-### Get a partial Form
-
-Returns a single partial form object, corresponding to owned/shared form-listings.
-
--   Endpoint: `/api/v2.4/partial_form/{hash}`
--   Method: `GET`
--   Url-Parameter:
-    | Parameter | Type | Description |
-    |-----------|---------|-------------|
-    | _hash_ | String | Hash of the form to request |
--   Response: Partial form object, similar to form-list elements.
-
-```
-"data": {
-  "id": 6,
-  "hash": "yWeMwcwCwoqRs8T2",
-  "title": "Form 2",
-  "expires": 0,
-  "permissions": [
-    "submit"
-  ],
-  "partial": true,
-  "state": 0
-}
-```
-
 ### Create a new Form
 
--   Endpoint: `/api/v2.4/form`
+-   Endpoint: `/api/v3/forms`
 -   Method: `POST`
 -   Parameters: None
 -   Response: The new form object, similar to requesting an existing form.
@@ -148,12 +130,12 @@ See next section, 'Request full data of a form'
 
 Returns the full-depth object of the requested form (without submissions).
 
--   Endpoint: `/api/v2.4/form/{id}`
--   Url-Parameter:
+-   Endpoint: `/api/v3/forms/{formId}`
+-   Method: `GET`
+-   Url-Parameters:
     | Parameter | Type | Description |
     |-----------|---------|-------------|
-    | _id_ | Integer | ID of the form to request |
--   Method: `GET`
+    | _formId_ | Integer | ID of the form to request |
 -   Response: A full object of the form, including access, questions and options in full depth.
 
 ```
@@ -243,12 +225,12 @@ Returns the full-depth object of the requested form (without submissions).
 
 Creates a clone of a form (without submissions).
 
--   Endpoint: `/api/v2.4/form/clone/{id}`
--   Url-Parameter:
+-   Endpoint: `/api/v3/forms?fromId={formId}`
+-   Method: `POST`
+-   Url-Parameters:
     | Parameter | Type | Description |
     |-----------|---------|-------------|
-    | _id_ | Integer | ID of the form to clone |
--   Method: `POST`
+    | _formId_ | Integer | ID of the form to clone |
 -   Response: Returns the full object of the new form. See [Request full data of a Form](#request-full-data-of-a-form)
 
 ```
@@ -259,99 +241,106 @@ See section 'Request full data of a form'.
 
 Update a single or multiple properties of a form-object. Concerns **only** the Form-Object, properties of Questions, Options and Submissions, as well as their creation or deletion, are handled separately.
 
--   Endpoint: `/api/v2.4/form/update`
+-   Endpoint: `/api/v3/forms/{formId}`
 -   Method: `PATCH`
--   _Method: `POST` deprecated_
+-   Url-Parameters:
+    | Parameter | Type | Description |
+    |-----------|---------|-------------|
+    | _formId_ | Integer | ID of the form to update |
 -   Parameters:
     | Parameter | Type | Description |
     |-----------|---------|-------------|
-    | _id_ | Integer | ID of the form to update |
     | _keyValuePairs_ | Array | Array of key-value pairs to update |
--   Restrictions: It is **not allowed** to update one of the following key-value pairs: _id, hash, ownerId, created_
+-   Restrictions:
+    -   It is **not allowed** to update one of the following key-value pairs: _id, hash, ownerId, created_
+    -   To transfer the ownership of a form to another user, you must only send a single _keyValuePair_ containing the key `ownerId` and the user id of the new owner.
+    -   To link a file for submissions, the _keyValuePairs_ need to contain the keys `path` and `fileFormat`
+    -   To unlink a file for submissions, the _keyValuePairs_ need to contain the keys `fileId` and `fileFormat` need to contain the value `null`
 -   Response: **Status-Code OK**, as well as the id of the updated form.
 
 ```
 "data": 3
 ```
 
-### Transfer form ownership
-
-Transfer the ownership of a form to another user
-
--   Endpoint: `/api/v2.4/form/transfer`
--   Method: `POST`
--   Parameters:
-    | Parameter | Type | Description |
-    |-----------|---------|-------------|
-    | _formId_ | Integer | ID of the form to tranfer |
-    | _uid_ | Integer | ID of the new form owner |
--   Restrictions: The initiator must be the current form owner.
--   Response: **Status-Code OK**, as well as the id of the new owner.
-
-```
-"data": "user1"
-```
-
 ### Delete a form
 
--   Endpoint: `/api/v2.4/form/{id}`
--   Url-Parameter:
+-   Endpoint: `/api/v3/forms/{formId}`
+-   Method: `DELETE`
+-   Url-Parameters:
     | Parameter | Type | Description |
     |-----------|---------|-------------|
-    | _id_ | Integer | ID of the form to delete |
--   Method: `DELETE`
+    | _formId_ | Integer | ID of the form to delete |
 -   Response: **Status-Code OK**, as well as the id of the deleted form.
 
 ```
 "data": 3
 ```
 
-### Link a form to a file
-
--   Endpoint: `/api/v2.4/form/link/{fileFormat}`
--   Url-Parameter:
-    | Parameter | Type | Description |
-    |--------------|---------|--------------|
-    | _fileFormat_ | String | csv|ods|xlsx |
--   Method: `POST`
--   Parameters:
-    | Parameter | Type | Description |
-    |-----------|---------|--------------------------------------------|
-    | _hash_ | String | Hash of the form to update |
-    | _path_ | String | Path within User-Dir, to store the file to |
--   Response: The new question object.
-
-```
-"data": {
-  "fileFormat": "csv",
-  "fileId": 157,
-  "filePath": "foo/bar",
-  "fileName": "Form 1 (responses).csv"
-}
-```
-
-### Unlink file from form
-
--   Endpoint: `/api/v2.4/form/unlink`
--   Method: `POST`
--   Parameters:
-    | Parameter | Type | Description |
-    |-----------|---------|----------------------------|
-    | _hash_ | String | Hash of the form to update |
--   Response: **Status-Code OK**
-
 ## Question Endpoints
 
-Contains only manipulative question-endpoints. To retrieve questions, request the full form data.
+### Get all questions of a form
+
+Returns the questions and options of the given form (without submissions).
+
+-   Endpoint: `/api/v3/forms/{formId}/questions`
+-   Method: `GET`
+-   Url-Parameters:
+    | Parameter | Type | Description |
+    |-----------|---------|-------------|
+    | _formId_ | Integer | ID of the form |
+-   Response: An array of all questions of the form including options.
+
+```
+"data": [
+  {
+    "id": 1,
+    "formId": 3,
+    "order": 1,
+    "type": "dropdown",
+    "isRequired": false,
+    "text": "Question 1",
+    "name": "something",
+    "options": [
+      {
+        "id": 1,
+        "questionId": 1,
+        "text": "Option 1"
+      },
+      {
+        "id": 2,
+        "questionId": 1,
+        "text": "Option 2"
+      }
+    ],
+    "accept": [],
+    "extraSettings": {}
+  },
+  {
+    "id": 2,
+    "formId": 3,
+    "order": 2,
+    "type": "file",
+    "isRequired": true,
+    "text": "Question 2",
+    "name": "something_other",
+    "options": [],
+    "extraSettings": {}
+    "accept": ["image/*", ".pdf"],
+  }
+]
+```
 
 ### Create a new question
 
--   Endpoint: `/api/v2.4/question`
+-   Endpoint: `/api/v3/forms/{formId}/questions`
 -   Method: `POST`
+-   Url-Parameters:
+    | Parameter | Type | Description |
+    |-----------|---------|-------------|
+    | _formId_ | Integer | ID of the form |
 -   Parameters:
     | Parameter | Type | Optional | Description |
     |-----------|---------|----------|-------------|
-    | _formId_ | Integer | | ID of the form, the new question will belong to |
     | _type_ | [QuestionType](DataStructure.md#question-types) | | The question-type of the new question |
     | _text_ | String | yes | _Optional_ The text of the new question. |
 -   Response: The new question object.
@@ -370,17 +359,59 @@ Contains only manipulative question-endpoints. To retrieve questions, request th
 }
 ```
 
+### Get all questions of a form
+
+Returns the requested question and options of the given form (without submissions).
+
+-   Endpoint: `/api/v3/forms/{formId}/questions/{questionId}`
+-   Method: `GET`
+-   Url-Parameters:
+    | Parameter | Type | Description |
+    |-----------|---------|-------------|
+    | _formId_ | Integer | ID of the form |
+    | _questionId_ | Integer | ID of the question |
+-   Response: An object of the requested question including options.
+
+```
+"data": {
+    "id": 1,
+    "formId": 3,
+    "order": 1,
+    "type": "dropdown",
+    "isRequired": false,
+    "text": "Question 1",
+    "name": "something",
+    "options": [
+      {
+        "id": 1,
+        "questionId": 1,
+        "text": "Option 1"
+      },
+      {
+        "id": 2,
+        "questionId": 1,
+        "text": "Option 2"
+      }
+    ],
+    "accept": [],
+    "extraSettings": {}
+}
+```
+
 ### Update question properties
 
 Update a single or multiple properties of a question-object.
 
--   Endpoint: `/api/v2.4/question/update`
+-   Endpoint: `/api/v3/forms/{formId}/questions/{questionId}`
 -   Method: `PATCH`
--   _Method: `POST` deprecated_
+-   Url-Parameters:
+    | Parameter | Type | Description |
+    |-----------|---------|-------------|
+    | _formId_ | Integer | ID of the form to request |
+    | _questionId_ | Integer | Id of the
 -   Parameters:
     | Parameter | Type | Description |
     |-----------|---------|-------------|
-    | _id_ | Integer | ID of the question to update |
     | _keyValuePairs_ | Array | Array of key-value pairs to update |
 -   Restrictions: It is **not allowed** to update one of the following key-value pairs: _id, formId, order_.
 -   Response: **Status-Code OK**, as well as the id of the updated question.
@@ -393,13 +424,15 @@ Update a single or multiple properties of a question-object.
 
 Reorders all Questions of a single form
 
--   Endpoint: `/api/v2.4/question/reorder`
--   Method: `PUT`
--   _Method: `POST` deprecated_
--   Parameters:
+-   Endpoint: `/api/v3/forms/{formId}/questions`
+-   Method: `PATCH`
+-   Url-Parameters:
     | Parameter | Type | Description |
     |-----------|---------|-------------|
     | _formId_ | Integer | ID of the form, the questions belong to |
+-   Parameters:
+    | Parameter | Type | Description |
+    |-----------|---------|-------------|
     | _newOrder_ | Array | Array of **all** Question-IDs, ordered in the desired order |
 -   Restrictions: The Array **must** contain all Question-IDs corresponding to the specified form and **must not** contain any duplicates.
 -   Response: Array of questionIDs and their corresponding order.
@@ -420,12 +453,13 @@ Reorders all Questions of a single form
 
 ### Delete a question
 
--   Endpoint: `/api/v2.4/question/{id}`
--   Url-Parameter:
+-   Endpoint: `/api/v3/forms/{formId}/questions/{questionId}`
+-   Method: `DELETE`
+-   Url-Parameters:
     | Parameter | Type | Description |
     |-----------|---------|-------------|
-    | _id_ | Integer | ID of the question to delete |
--   Method: `DELETE`
+    | _formId_ | Integer | ID of the form containing the question |
+    | _questionId_ | Integer | ID of the question to delete |
 -   Response: **Status-Code OK**, as well as the id of the deleted question.
 
 ```
@@ -436,12 +470,13 @@ Reorders all Questions of a single form
 
 Creates a clone of a question with all its options.
 
--   Endpoint: `/api/v2.4/question/clone/{id}`
--   Url-Parameter:
+-   Endpoint: `/api/v3/forms/{formId}/questions?fromId={questionId}`
+-   Method: `POST`
+-   Url-Parameters:
     | Parameter | Type | Description |
     |-----------|---------|-------------|
-    | _id_ | Integer | ID of the question to clone |
--   Method: `POST`
+    | _formId_ | Integer | ID of the form containing the question |
+    | _questionId_ | Integer | ID of the question to clone |
 -   Response: Returns cloned question object with the new ID set.
 
 ```
@@ -454,14 +489,18 @@ Contains only manipulative question-endpoints. To retrieve options, request the 
 
 ### Create a new Option
 
--   Endpoint: `/api/v2.4/option`
+-   Endpoint: `/api/v3/forms/{formId}/questions/{questionId}/options`
 -   Method: `POST`
+-   Url-Parameters:
+    | Parameter | Type | Description |
+    |-----------|---------|-------------|
+    | _formId_ | Integer | ID of the form containing the question |
+    | _questionId_ | Integer | ID of the question, the new option will belong to |
 -   Parameters:
     | Parameter | Type | Description |
     |-----------|---------|-------------|
-    | _questionId_ | Integer | ID of the question, the new option will belong to |
-    | _text_ | String | The text of the new option |
--   Response: The new option object
+    | _text_ | Array | Array of strings containing the new options |
+-   Response: The new array of option objects
 
 ```
 "data": {
@@ -475,13 +514,17 @@ Contains only manipulative question-endpoints. To retrieve options, request the 
 
 Update a single or all properties of an option-object
 
--   Endpoint: `/api/v2.4/option/update`
+-   Endpoint: `/api/v3/forms/{formId}/questions/{questionId}/options/{optionId}`
 -   Method: `PATCH`
--   _Method: `POST` deprecated_
+-   Url-Parameters:
+    | Parameter | Type | Description |
+    |-----------|---------|-------------|
+    | _formId_ | Integer | ID of the form containing the question and option |
+    | _questionId_ | Integer | ID of the question, the new option will belong to |
+    | _optionId_ | Integer | ID of the option to update |
 -   Parameters:
     | Parameter | Type | Description |
     |-----------|---------|-------------|
-    | _id_ | Integer | ID of the option to update |
     | _keyValuePairs_ | Array | Array of key-value pairs to update |
 -   Restrictions: It is **not allowed** to update one of the following key-value pairs: _id, questionId_.
 -   Response: **Status-Code OK**, as well as the id of the updated option.
@@ -492,12 +535,14 @@ Update a single or all properties of an option-object
 
 ### Delete an option
 
--   Endpoint: `/api/v2.4/option/{id}`
--   Url-Parameter:
+-   Endpoint: `/api/v3/forms/{formId}/questions/{questionId}/options/{optionId}`
+-   Method: `DELETE`
+-   Url-Parameters:
     | Parameter | Type | Description |
     |-----------|---------|-------------|
-    | _id_ | Integer | ID of the option to delete |
--   Method: `DELETE`
+    | _formId_ | Integer | ID of the form containing the question and option |
+    | _questionId_ | Integer | ID of the question, the new option will belong to |
+    | _optionId_ | Integer | ID of the option to delete |
 -   Response: **Status-Code OK**, as well as the id of the deleted option.
 
 ```
@@ -508,12 +553,15 @@ Update a single or all properties of an option-object
 
 ### Add a new Share
 
--   Endpoint: `/api/v2.4/share`
+-   Endpoint: `/api/v3/forms/{formId}/shares`
 -   Method: `POST`
+-   Url-Parameters:
+    | Parameter | Type | Description |
+    |--------------|----------|-------------|
+    | _formId_ | Integer | ID of the form to share |
 -   Parameters:
     | Parameter | Type | Description |
     |--------------|----------|-------------|
-    | _formId_ | Integer | Id of the form to share |
     | _shareType_ | String | NC-shareType, out of the used shareTypes. |
     | _shareWith_ | String | User/Group for the share. Not used for link-shares. |
     | _permissions_ | String[] | Permissions of the sharees, see [DataStructure](DataStructure.md#Permissions). |
@@ -530,34 +578,36 @@ Update a single or all properties of an option-object
 }
 ```
 
-### Delete a Share
+### Update a Share
 
--   Endpoint: `/api/v2.4/share/{id}`
--   Url-Parameter:
+-   Endpoint: `/api/v3/forms/{formId}/shares/{shareId}`
+-   Method: `PATCH`
+-   Url-Parameters:
     | Parameter | Type | Description |
-    |-----------|---------|-------------|
-    | _id_ | Integer | ID of the share to delete |
--   Method: `DELETE`
--   Response: **Status-Code OK**, as well as the id of the deleted share.
+    |------------------|----------|-------------|
+    | _formId_ | Integer | ID of the form containing the share |
+    | _shareId_ | Integer | ID of the share to update |
+-   Parameters:
+    | Parameter | Type | Description |
+    |------------------|----------|-------------|
+    | _keyValuePairs_ | Array | Array of key-value pairs to update |
+-   Restrictions: Currently only the _permissions_ can be updated.
+-   Response: **Status-Code OK**, as well as the id of the share object.
 
 ```
 "data": 5
 ```
 
-### Update a Share
+### Delete a Share
 
--   Endpoint: `/api/v2.4/share/update`
--   Parameters:
+-   Endpoint: `/api/v3/forms/{formId}/shares/{shareId}`
+-   Method: `DELETE`
+-   Url-Parameters:
     | Parameter | Type | Description |
-    |------------------|----------|-------------|
-    | _id_ | Integer | ID of the share to update |
-    | *keyValuePairs*¹ | Array | Array of key-value pairs to update |
-
-    ¹Currently only the _permissions_ can be updated.
-
--   Method: `PATCH`
--   _Method: `POST` deprecated_
--   Response: **Status-Code OK**, as well as the id of the share object.
+    |-----------|---------|-------------|
+    | _formId_ | Integer | ID of the form containing the share |
+    | _shareId_ | Integer | ID of the share to delete |
+-   Response: **Status-Code OK**, as well as the id of the deleted share.
 
 ```
 "data": 5
@@ -569,12 +619,12 @@ Update a single or all properties of an option-object
 
 Get all Submissions to a Form
 
--   Endpoint: `/api/v2.4/submissions/{hash}`
--   Url-Parameter:
+-   Endpoint: `/api/v3/forms/{formId}/submissions`
+-   Method: `GET`
+-   Url-Parameters:
     | Parameter | Type | Description |
     |-----------|---------|-------------|
-    | _hash_ | String | Hash of the form to get the submissions for |
--   Method: `GET`
+    | _formId_ | Integer | ID of the form to get the submissions for |
 -   Response: An Array of all submissions, sorted as newest first, as well as an array of the corresponding questions.
 
 ```
@@ -668,14 +718,14 @@ Get all Submissions to a Form
 
 Returns all submissions to the form in form of a csv-file.
 
--   Endpoint: `/api/v2.4/submissions/export/{hash}`
--   Url-Parameter:
+-   Endpoint: `/api/v3/forms/{formId}/submissions?fileFormat={fileFormat}`
+-   Method: `GET`
+-   Url-Parameters:
     | Parameter | Type | Description |
     |--------------|---------|-------------|
-    | _hash_ | String | Hash of the form to get the submissions for |
-    | _fileFormat_ | String | csv|ods|xlsx |
--   Method: `GET`
--   Response: A Data Download Response containing the headers `Content-Disposition: attachment; filename="Form 1 (responses).csv"` and `Content-Type: text/csv;charset=UTF-8`. The actual data contains all submissions to the referred form, formatted as comma separated and escaped csv.
+    | _formId_ | Integer | Id of the form to get the submissions for |
+    | _fileFormat_ | String | `csv|ods|xlsx` |
+-   Response: A Data Download Response containing the headers `Content-Disposition: attachment; filename="Form 1 (responses).csv"` and `Content-Type: text/csv;charset=UTF-8`. The actual data contains all submissions to the referred form, formatted as comma separated and escaped csv. For file format `ods` or `xlsx` the Download Response contains an Open Document Spreadsheet or an Office Open XML Spreadsheet file.
 
 ```
 "User display name","Timestamp","Question 1","Question 2"
@@ -687,12 +737,15 @@ Returns all submissions to the form in form of a csv-file.
 
 Creates a csv file and stores it to the cloud, resp. Files-App.
 
--   Endpoint: `/api/v2.4/submissions/export`
+-   Endpoint: `/api/v3/forms/{formId}/submissions/export`
 -   Method: `POST`
+-   Url-Parameters:
+    | Parameter | Type | Description |
+    |--------------|---------|-------------|
+    | _formId_ | Integer | ID of the form to get the submissions for |
 -   Parameters:
     | Parameter | Type | Description |
     |--------------|---------|-------------|
-    | _hash_ | String | Hash of the form to get the submissions for |
     | _path_ | String | Path within User-Dir, to store the file to |
     | _fileFormat_ | String | csv|ods|xlsx |
 -   Response: Stores the file to the given path and returns the fileName.
@@ -705,12 +758,12 @@ Creates a csv file and stores it to the cloud, resp. Files-App.
 
 Delete all Submissions to a form
 
--   Endpoint: `/api/v2.4/submissions/{formId}`
--   Url-Parameter:
+-   Endpoint: `/api/v3/forms/{formId}/submissions`
+-   Method: `DELETE`
+-   Url-Parameters:
     | Parameter | Type | Description |
     |-----------|---------|-------------|
     | _formId_ | Integer | ID of the form to delete the submissions for |
--   Method: `DELETE`
 -   Response: **Status-Code OK**, as well as the id of the corresponding form.
 
 ```
@@ -719,15 +772,18 @@ Delete all Submissions to a form
 
 ### Upload a file
 
-Upload a files to answer before form submitting
+Upload a file to an answer before form submission
 
--   Endpoint: `/api/2.5/uploadFiles/{formId}/{questionId}`
+-   Endpoint: `/api/v3/forms/{formId}/submissions/files/{questionId}`
 -   Method: `POST`
--   Parameters:
+-   Url-Parameters:
     | Parameter | Type | Description |
     |--------------|----------------|-------------|
     | _formId_ | Integer | ID of the form to upload the file to |
     | _questionId_ | Integer | ID of the question to upload the file to |
+-   Parameters:
+    | Parameter | Type | Description |
+    |--------------|----------------|-------------|
     | _files_ | Array of files | Files to upload |
 -   Response: **Status-Code OK**, as well as the id of the uploaded file and it's name.
 
@@ -739,24 +795,24 @@ Upload a files to answer before form submitting
 
 Store Submission to Database
 
--   Endpoint: `/api/v2.4/submission/insert`
+-   Endpoint: `/api/v3/forms/{formId}/submissions`
 -   Method: `POST`
+-   Url-Parameters:
+    | Parameter | Type | Description |
+    |--------------|----------------|-------------|
+    | _formId_ | Integer | ID of the form to upload the file to |
 -   Parameters:
     | Parameter | Type | Description |
     |-----------|---------|-------------|
-    | _formId_ | Integer | ID of the form to submit into |
-    | _answers_ | Array | Array of Answers |
+    | _answers_ | Array | Array of answers |
     | _shareHash_ | String | optional, only neccessary for submissions to a public share link |
-
-    The Array of Answers has the following structure:
-
+-   Restrictions: The array of answers has the following structure:
     -   QuestionID as key
     -   An **array** of values as value --> Even for short Text Answers, wrapped into Array.
     -   For Question-Types with pre-defined answers (`multiple`, `multiple_unique`, `dropdown`), the array contains the corresponding option-IDs.
-
     -   For File-Uploads, the array contains the objects with key `uploadedFileId` (value from Upload a file endpoint).
 
-````
+```
   {
     "1":[27,32],              // dropdown or multiple
     "2":["ShortTextAnswer"],  // All Text-Based Question-Types
@@ -765,24 +821,23 @@ Store Submission to Database
       {"uploadedFileId": integer}
   ],
 }
-  ```
+```
 
 -   Response: **Status-Code OK**.
 
 ### Delete a single Submission
 
--   Endpoint: `/api/v2.4/submission/{id}`
--   Url-Parameter:
-  | Parameter | Type | Description |
-  |-----------|---------|-------------|
-  | _id_ | Integer | ID of the submission to delete |
+-   Endpoint: `/api/v3/forms/{formId}/submissions/{submissionId}`
 -   Method: `DELETE`
+-   Url-Parameters:
+    | Parameter | Type | Description |
+    |-----------|---------|-------------|
+    | _formId_ | Integer | ID of the form containing the submission |
+    | _submissionId_ | Integer | ID of the submission to delete |
 -   Response: **Status-Code OK**, as well as the id of the deleted submission.
 
 ````
-
 "data": 5
-
 ```
 
 ## Error Responses
@@ -842,3 +897,4 @@ This Error is not produed by the Forms-API, but comes from Nextclouds OCS API. T
 ```
 
 ```
+````

--- a/lib/Controller/ApiController.php
+++ b/lib/Controller/ApiController.php
@@ -1,8 +1,10 @@
 <?php
+
 /**
  * @copyright Copyright (c) 2017 Vinzenz Rosenkranz <vinzenz.rosenkranz@gmail.com>
  *
  * @author affan98 <affan98@gmail.com>
+ * @author Christian Hartmann <chris-hartmann@gmx.de>
  * @author Ferdinand Thiessen <opensource@fthiessen.de>
  * @author Jan-Christoph Borchardt <hey@jancborchardt.net>
  * @author John Molakvoæ (skjnldsv) <skjnldsv@protonmail.com>
@@ -68,7 +70,7 @@ use Psr\Log\LoggerInterface;
 
 class ApiController extends OCSController {
 	private ?IUser $currentUser;
-	
+
 	public function __construct(
 		string $appName,
 		IRequest $request,
@@ -93,6 +95,8 @@ class ApiController extends OCSController {
 		$this->currentUser = $userSession->getUser();
 	}
 
+	// API v3 methods
+	// Forms
 	/**
 	 * @CORS
 	 * @NoAdminRequired
@@ -101,7 +105,1237 @@ class ApiController extends OCSController {
 	 * Return only with necessary information for Listing.
 	 * @return DataResponse
 	 */
-	public function getForms(): DataResponse {
+	public function getForms(string $type = 'owned'): DataResponse {
+		if ($type === 'owned') {
+			$forms = $this->formMapper->findAllByOwnerId($this->currentUser->getUID());
+			$result = [];
+			foreach ($forms as $form) {
+				$result[] = $this->formsService->getPartialFormArray($form);
+			}
+			return new DataResponse($result);
+		} elseif ($type === 'shared') {
+			$forms = $this->formsService->getSharedForms($this->currentUser);
+			$result = array_values(array_map(fn (Form $form): array => $this->formsService->getPartialFormArray($form), $forms));
+			return new DataResponse($result);
+		} else {
+			throw new OCSBadRequestException();
+		}
+	}
+
+	/**
+	 * @CORS
+	 * @NoAdminRequired
+	 *
+	 * Create a new Form and return the Form to edit.
+	 * Return a cloned Form if the parameter $fromId is set
+	 *
+	 * @param int $fromId (optional) ID of the Form that should be cloned
+	 * @return DataResponse
+	 * @throws OCSBadRequestException
+	 * @throws OCSForbiddenException
+	 */
+	public function newForm(?int $fromId = null): DataResponse {
+		// Check if user is allowed
+		if (!$this->configService->canCreateForms()) {
+			$this->logger->debug('This user is not allowed to create Forms.');
+			throw new OCSForbiddenException();
+		}
+
+		if ($fromId === null) {
+			// Create Form
+			$form = new Form();
+			$form->setOwnerId($this->currentUser->getUID());
+			$form->setCreated(time());
+			$form->setHash($this->formsService->generateFormHash());
+			$form->setTitle('');
+			$form->setDescription('');
+			$form->setAccess([
+				'permitAllUsers' => false,
+				'showToAllUsers' => false,
+			]);
+			$form->setSubmitMultiple(false);
+			$form->setShowExpiration(false);
+			$form->setExpires(0);
+			$form->setIsAnonymous(false);
+			$form->setLastUpdated(time());
+
+			$this->formMapper->insert($form);
+		} else {
+			$oldForm = $this->getFormIfAllowed($fromId);
+
+			// Read Form, set new Form specific data, extend Title.
+			$formData = $oldForm->read();
+			unset($formData['id']);
+			$formData['created'] = time();
+			$formData['lastUpdated'] = time();
+			$formData['hash'] = $this->formsService->generateFormHash();
+			// TRANSLATORS Appendix to the form Title of a duplicated/copied form.
+			$formData['title'] .= ' - ' . $this->l10n->t('Copy');
+
+			$form = Form::fromParams($formData);
+			$this->formMapper->insert($form);
+
+			// Get Questions, set new formId, reinsert
+			$questions = $this->questionMapper->findByForm($oldForm->getId());
+			foreach ($questions as $oldQuestion) {
+				$questionData = $oldQuestion->read();
+
+				unset($questionData['id']);
+				$questionData['formId'] = $form->getId();
+				$newQuestion = Question::fromParams($questionData);
+				$this->questionMapper->insert($newQuestion);
+
+				// Get Options, set new QuestionId, reinsert
+				$options = $this->optionMapper->findByQuestion($oldQuestion->getId());
+				foreach ($options as $oldOption) {
+					$optionData = $oldOption->read();
+
+					unset($optionData['id']);
+					$optionData['questionId'] = $newQuestion->getId();
+					$newOption = Option::fromParams($optionData);
+					$this->optionMapper->insert($newOption);
+				}
+			}
+		}
+		return $this->getForm($form->getId());
+	}
+
+	/**
+	 * @CORS
+	 * @NoAdminRequired
+	 *
+	 * Read all information to edit a Form (form, questions, options, except submissions/answers).
+	 *
+	 * @param int $formId Id of the form
+	 * @return DataResponse
+	 * @throws OCSBadRequestException
+	 * @throws OCSForbiddenException
+	 */
+	public function getForm(int $formId): DataResponse {
+		try {
+			$form = $this->formMapper->findById($formId);
+		} catch (IMapperException $e) {
+			$this->logger->debug('Could not find form');
+			throw new OCSBadRequestException();
+		}
+
+		if (!$this->formsService->hasUserAccess($form)) {
+			$this->logger->debug('User has no permissions to get this form');
+			throw new OCSForbiddenException();
+		}
+
+		$formData = $this->formsService->getForm($form);
+
+		return new DataResponse($formData);
+	}
+
+	/**
+	 * @CORS
+	 * @NoAdminRequired
+	 *
+	 * Writes the given key-value pairs into Database.
+	 *
+	 * @param int $formId FormId of form to update
+	 * @param array $keyValuePairs Array of key=>value pairs to update.
+	 * @return DataResponse
+	 * @throws OCSBadRequestException
+	 * @throws OCSForbiddenException
+	 */
+	public function updateForm(int $formId, array $keyValuePairs): DataResponse {
+		$this->logger->debug('Updating form: formId: {formId}, values: {keyValuePairs}', [
+			'formId' => $formId,
+			'keyValuePairs' => $keyValuePairs
+		]);
+
+		$form = $this->getFormIfAllowed($formId);
+
+		// Don't allow empty array
+		if (sizeof($keyValuePairs) === 0) {
+			$this->logger->info('Empty keyValuePairs, will not update.');
+			throw new OCSForbiddenException();
+		}
+
+		// Process owner transfer
+		if (sizeof($keyValuePairs) === 1 && key_exists('ownerId', $keyValuePairs)) {
+			$this->logger->debug('Updating owner: formId: {formId}, userId: {uid}', [
+				'formId' => $formId,
+				'uid' => $keyValuePairs['ownerId']
+			]);
+
+			$form = $this->getFormIfAllowed($formId);
+			$user = $this->userManager->get($keyValuePairs['ownerId']);
+			if ($user == null) {
+				$this->logger->debug('Could not find new form owner');
+				throw new OCSBadRequestException('Could not find new form owner');
+			}
+
+			// update form owner
+			$form->setOwnerId($keyValuePairs['ownerId']);
+
+			// Update changed Columns in Db.
+			$this->formMapper->update($form);
+
+			return new DataResponse($form->getOwnerId());
+		}
+
+		// Don't allow to change params id, hash, ownerId, created, lastUpdated, fileId
+		if (
+			key_exists('id', $keyValuePairs) || key_exists('hash', $keyValuePairs) ||
+			key_exists('ownerId', $keyValuePairs) || key_exists('created', $keyValuePairs) ||
+			isset($keyValuePairs['fileId']) || key_exists('lastUpdated', $keyValuePairs)
+		) {
+			$this->logger->info('Not allowed to update id, hash, ownerId, created, fileId or lastUpdated');
+			throw new OCSForbiddenException();
+		}
+
+		// Process file linking
+		if (isset($keyValuePairs['path']) && isset($keyValuePairs['fileFormat'])) {
+			$file = $this->submissionService->writeFileToCloud($form, $keyValuePairs['path'], $keyValuePairs['fileFormat']);
+
+			$form->setFileId($file->getId());
+			$form->setFileFormat($keyValuePairs['fileFormat']);
+		}
+
+		// Process file unlinking
+		if (key_exists('fileId', $keyValuePairs) && key_exists('fileFormat', $keyValuePairs) && !isset($keyValuePairs['fileId']) && !isset($keyValuePairs['fileFormat'])) {
+			$form->setFileId(null);
+			$form->setFileFormat(null);
+		}
+
+		unset($keyValuePairs['path']);
+		unset($keyValuePairs['fileId']);
+		unset($keyValuePairs['fileFormat']);
+
+		// Create FormEntity with given Params & Id.
+		foreach ($keyValuePairs as $key => $value) {
+			$method = 'set' . ucfirst($key);
+			$form->$method($value);
+		}
+
+		// Update changed Columns in Db.
+		$this->formMapper->update($form);
+		$this->formsService->setLastUpdatedTimestamp($formId);
+
+		return new DataResponse($form->getId());
+	}
+
+	/**
+	 * @CORS
+	 * @NoAdminRequired
+	 *
+	 * Delete a form
+	 *
+	 * @param int $formId the form id
+	 * @return DataResponse
+	 * @throws OCSBadRequestException
+	 * @throws OCSForbiddenException
+	 */
+	public function deleteForm(int $formId): DataResponse {
+		$this->logger->debug('Delete Form: {formId}', [
+			'formId' => $formId,
+		]);
+
+		$form = $this->getFormIfAllowed($formId);
+		$this->formMapper->deleteForm($form);
+
+		return new DataResponse($formId);
+	}
+
+	// Questions
+	/**
+	 * @CORS
+	 * @NoAdminRequired
+	 *
+	 * Read all questions (including options)
+	 *
+	 * @param int $formId FormId
+	 * @return DataResponse
+	 * @throws OCSBadRequestException
+	 * @throws OCSForbiddenException
+	 */
+	public function getQuestions(int $formId): DataResponse {
+		try {
+			$form = $this->formMapper->findById($formId);
+		} catch (IMapperException $e) {
+			$this->logger->debug('Could not find form');
+			throw new OCSBadRequestException();
+		}
+
+		if (!$this->formsService->hasUserAccess($form)) {
+			$this->logger->debug('User has no permissions to get this form');
+			throw new OCSForbiddenException();
+		}
+
+		$questionData = $this->formsService->getQuestions($formId);
+
+		return new DataResponse($questionData);
+	}
+
+	/**
+	 * @CORS
+	 * @NoAdminRequired
+	 *
+	 * Read a specific question (including options)
+	 *
+	 * @param int $formId FormId
+	 * @param int $questionId QuestionId
+	 * @return DataResponse
+	 * @throws OCSBadRequestException
+	 * @throws OCSForbiddenException
+	 */
+	public function getQuestion(int $formId, int $questionId): DataResponse {
+		try {
+			$form = $this->formMapper->findById($formId);
+		} catch (IMapperException $e) {
+			$this->logger->debug('Could not find form');
+			throw new OCSBadRequestException();
+		}
+
+		if (!$this->formsService->hasUserAccess($form)) {
+			$this->logger->debug('User has no permissions to get this form');
+			throw new OCSForbiddenException();
+		}
+
+		$question = $this->formsService->getQuestion($questionId);
+
+		if ($question['formId'] !== $formId) {
+			throw new OCSBadRequestException('Question doesn\'t belong to given Form');
+		}
+
+		return new DataResponse($question);
+	}
+
+	/**
+	 * @CORS
+	 * @NoAdminRequired
+	 *
+	 * Add a new question
+	 *
+	 * @param int $formId the form id
+	 * @param string $type the new question type
+	 * @param string $text the new question title
+	 * @param int $fromId (optional) id of the question that should be cloned
+	 * @return DataResponse
+	 * @throws OCSBadRequestException
+	 * @throws OCSForbiddenException
+	 */
+	public function newQuestion(int $formId, ?string $type = null, string $text = '', ?int $fromId = null): DataResponse {
+		$form = $this->getFormIfAllowed($formId);
+		if ($this->formsService->isFormArchived($form)) {
+			$this->logger->debug('This form is archived and can not be modified');
+			throw new OCSForbiddenException();
+		}
+
+		if ($fromId === null) {
+			$this->logger->debug('Adding new question: formId: {formId}, type: {type}, text: {text}', [
+				'formId' => $formId,
+				'type' => $type,
+				'text' => $text,
+			]);
+
+			if (array_search($type, Constants::ANSWER_TYPES) === false) {
+				$this->logger->debug('Invalid type');
+				throw new OCSBadRequestException('Invalid type');
+			}
+
+			// Block creation of datetime questions
+			if ($type === 'datetime') {
+				$this->logger->debug('Datetime question type no longer supported');
+				throw new OCSBadRequestException('Datetime question type no longer supported');
+			}
+
+			// Retrieve all active questions sorted by Order. Takes the order of the last array-element and adds one.
+			$questions = $this->questionMapper->findByForm($formId);
+			$lastQuestion = array_pop($questions);
+			if ($lastQuestion) {
+				$questionOrder = $lastQuestion->getOrder() + 1;
+			} else {
+				$questionOrder = 1;
+			}
+
+			$question = new Question();
+
+			$question->setFormId($formId);
+			$question->setOrder($questionOrder);
+			$question->setType($type);
+			$question->setText($text);
+			$question->setDescription('');
+			$question->setIsRequired(false);
+			$question->setExtraSettings([]);
+
+			$question = $this->questionMapper->insert($question);
+
+			$response = $question->read();
+			$response['options'] = [];
+			$response['accept'] = [];
+
+			$this->formsService->setLastUpdatedTimestamp($formId);
+		} else {
+			$this->logger->debug('Question to be cloned: {fromId}', [
+				'fromId' => $fromId
+			]);
+
+			try {
+				$sourceQuestion = $this->questionMapper->findById($fromId);
+				$sourceOptions = $this->optionMapper->findByQuestion($fromId);
+			} catch (IMapperException $e) {
+				$this->logger->debug('Could not find question');
+				throw new OCSNotFoundException('Could not find question');
+			}
+
+			$allQuestions = $this->questionMapper->findByForm($formId);
+
+			$questionData = $sourceQuestion->read();
+			unset($questionData['id']);
+			$questionData['order'] = end($allQuestions)->getOrder() + 1;
+
+			$newQuestion = Question::fromParams($questionData);
+			$this->questionMapper->insert($newQuestion);
+
+			$response = $newQuestion->read();
+			$response['options'] = [];
+			$response['accept'] = [];
+
+			foreach ($sourceOptions as $sourceOption) {
+				$optionData = $sourceOption->read();
+
+				unset($optionData['id']);
+				$optionData['questionId'] = $newQuestion->getId();
+				$newOption = Option::fromParams($optionData);
+				$insertedOption = $this->optionMapper->insert($newOption);
+
+				$response['options'][] = $insertedOption->read();
+			}
+		}
+
+		return new DataResponse($response);
+	}
+
+	/**
+	 * @CORS
+	 * @NoAdminRequired
+	 *
+	 * Writes the given key-value pairs into Database.
+	 * Key 'order' should only be changed by reorderQuestions() and is not allowed here.
+	 *
+	 * @param int $formId the form id
+	 * @param int $questionId id of question to update
+	 * @param array $keyValuePairs Array of key=>value pairs to update.
+	 * @return DataResponse
+	 * @throws OCSBadRequestException
+	 * @throws OCSForbiddenException
+	 */
+	public function updateQuestion(int $formId, int $questionId, array $keyValuePairs): DataResponse {
+		$this->logger->debug('Updating question: formId: {formId}, questionId: {questionId}, values: {keyValuePairs}', [
+			'formId' => $formId,
+			'questionId' => $questionId,
+			'keyValuePairs' => $keyValuePairs
+		]);
+
+		try {
+			$question = $this->questionMapper->findById($questionId);
+		} catch (IMapperException $e) {
+			$this->logger->debug('Could not find question');
+			throw new OCSBadRequestException('Could not find question');
+		}
+
+		if ($question->getFormId() !== $formId) {
+			throw new OCSBadRequestException('Question doesn\'t belong to given Form');
+		}
+
+		$form = $this->getFormIfAllowed($formId);
+		if ($this->formsService->isFormArchived($form)) {
+			$this->logger->debug('This form is archived and can not be modified');
+			throw new OCSForbiddenException();
+		}
+
+		// Don't allow empty array
+		if (sizeof($keyValuePairs) === 0) {
+			$this->logger->info('Empty keyValuePairs, will not update.');
+			throw new OCSForbiddenException();
+		}
+
+		//Don't allow to change id or formId
+		if (key_exists('id', $keyValuePairs) || key_exists('formId', $keyValuePairs)) {
+			$this->logger->debug('Not allowed to update \'id\' or \'formId\'');
+			throw new OCSForbiddenException();
+		}
+
+		// Don't allow to reorder here
+		if (key_exists('order', $keyValuePairs)) {
+			$this->logger->debug('Key \'order\' is not allowed on updateQuestion. Please use reorderQuestions() to change order.');
+			throw new OCSForbiddenException('Please use reorderQuestions() to change order');
+		}
+
+		if (key_exists('extraSettings', $keyValuePairs) && !$this->formsService->areExtraSettingsValid($keyValuePairs['extraSettings'], $question->getType())) {
+			throw new OCSBadRequestException('Invalid extraSettings, will not update.');
+		}
+
+		// Create QuestionEntity with given Params & Id.
+		$question = Question::fromParams($keyValuePairs);
+		$question->setId($questionId);
+
+		// Update changed Columns in Db.
+		$this->questionMapper->update($question);
+
+		$this->formsService->setLastUpdatedTimestamp($formId);
+
+		return new DataResponse($question->getId());
+	}
+
+	/**
+	 * @CORS
+	 * @NoAdminRequired
+	 *
+	 * Delete a question
+	 *
+	 * @param int $formId the form id
+	 * @param int $questionId the question id
+	 * @return DataResponse
+	 * @throws OCSBadRequestException
+	 * @throws OCSForbiddenException
+	 */
+	public function deleteQuestion(int $formId, int $questionId): DataResponse {
+		$this->logger->debug('Mark question as deleted: {questionId}', [
+			'questionId' => $questionId,
+		]);
+
+		try {
+			$question = $this->questionMapper->findById($questionId);
+		} catch (IMapperException $e) {
+			$this->logger->debug('Could not find question');
+			throw new OCSBadRequestException('Could not find question');
+		}
+
+		if ($question->getFormId() !== $formId) {
+			throw new OCSBadRequestException('Question doesn\'t belong to given Form');
+		}
+
+		$form = $this->getFormIfAllowed($formId);
+		if ($this->formsService->isFormArchived($form)) {
+			$this->logger->debug('This form is archived and can not be modified');
+			throw new OCSForbiddenException();
+		}
+
+		// Store Order of deleted Question
+		$deletedOrder = $question->getOrder();
+
+		// Mark question as deleted
+		$question->setOrder(0);
+		$this->questionMapper->update($question);
+
+		// Update all question-order > deleted order.
+		$formQuestions = $this->questionMapper->findByForm($formId);
+		foreach ($formQuestions as $question) {
+			$questionOrder = $question->getOrder();
+			if ($questionOrder > $deletedOrder) {
+				$question->setOrder($questionOrder - 1);
+				$this->questionMapper->update($question);
+			}
+		}
+
+		$this->formsService->setLastUpdatedTimestamp($formId);
+
+		return new DataResponse($questionId);
+	}
+
+	/**
+	 * @CORS
+	 * @NoAdminRequired
+	 *
+	 * Updates the Order of all Questions of a Form.
+	 *
+	 * @param int $formId Id of the form to reorder
+	 * @param Array<int, int> $newOrder Array of Question-Ids in new order.
+	 * @return DataResponse
+	 * @throws OCSBadRequestException
+	 * @throws OCSForbiddenException
+	 */
+	public function reorderQuestions(int $formId, array $newOrder): DataResponse {
+		$this->logger->debug('Reordering Questions on Form {formId} as Question-Ids {newOrder}', [
+			'formId' => $formId,
+			'newOrder' => $newOrder
+		]);
+
+		$form = $this->getFormIfAllowed($formId);
+		if ($this->formsService->isFormArchived($form)) {
+			$this->logger->debug('This form is archived and can not be modified');
+			throw new OCSForbiddenException();
+		}
+
+		// Check if array contains duplicates
+		if (array_unique($newOrder) !== $newOrder) {
+			$this->logger->debug('The given array contains duplicates');
+			throw new OCSBadRequestException('The given array contains duplicates');
+		}
+
+		// Check if all questions are given in Array.
+		$questions = $this->questionMapper->findByForm($formId);
+		if (sizeof($questions) !== sizeof($newOrder)) {
+			$this->logger->debug('The length of the given array does not match the number of stored questions');
+			throw new OCSBadRequestException('The length of the given array does not match the number of stored questions');
+		}
+
+		$questions = []; // Clear Array of Entities
+		$response = []; // Array of ['questionId' => ['order' => newOrder]]
+
+		// Store array of Question-Entities and check the Questions FormId & old Order.
+		foreach ($newOrder as $arrayKey => $questionId) {
+			try {
+				$questions[$arrayKey] = $this->questionMapper->findById($questionId);
+			} catch (IMapperException $e) {
+				$this->logger->debug('Could not find question. Id: {questionId}', [
+					'questionId' => $questionId
+				]);
+				throw new OCSBadRequestException();
+			}
+
+			// Abort if a question is not part of the Form.
+			if ($questions[$arrayKey]->getFormId() !== $formId) {
+				$this->logger->debug('This Question is not part of the given Form: questionId: {questionId}', [
+					'questionId' => $questionId
+				]);
+				throw new OCSBadRequestException();
+			}
+
+			// Abort if a question is already marked as deleted (order==0)
+			$oldOrder = $questions[$arrayKey]->getOrder();
+			if ($oldOrder === 0) {
+				$this->logger->debug('This Question has already been marked as deleted: Id: {questionId}', [
+					'questionId' => $questions[$arrayKey]->getId()
+				]);
+				throw new OCSBadRequestException();
+			}
+
+			// Only set order, if it changed.
+			if ($oldOrder !== $arrayKey + 1) {
+				// Set Order. ArrayKey counts from zero, order counts from 1.
+				$questions[$arrayKey]->setOrder($arrayKey + 1);
+			}
+		}
+
+		// Write to Database
+		foreach ($questions as $question) {
+			$this->questionMapper->update($question);
+
+			$response[$question->getId()] = [
+				'order' => $question->getOrder()
+			];
+		}
+
+		$this->formsService->setLastUpdatedTimestamp($formId);
+
+		return new DataResponse($response);
+	}
+
+	// Options
+
+	/**
+	 * @NoAdminRequired
+	 *
+	 * Add a new option to a question
+	 *
+	 * @param int $formId id of the form
+	 * @param int $questionId id of the question
+	 * @param array<string> $optionTexts the new option text
+	 * @return DataResponse Returns a DataResponse containing the added options
+	 * @throws OCSBadRequestException
+	 * @throws OCSForbiddenException
+	 */
+	public function newOption(int $formId, int $questionId, array $optionTexts): DataResponse {
+		$this->logger->debug('Adding new options: formId: {formId}, questionId: {questionId}, text: {text}', [
+			'formId' => $formId,
+			'questionId' => $questionId,
+			'text' => $optionTexts,
+		]);
+
+		try {
+			$question = $this->questionMapper->findById($questionId);
+			$form = $this->formMapper->findById($formId);
+		} catch (IMapperException $e) {
+			$this->logger->debug('Could not find form or question');
+			throw new OCSBadRequestException('Could not find form or question');
+		}
+
+		if ($question->getFormId() !== $formId) {
+			$this->logger->debug('This Question is not part of the given Form: questionId: {questionId}', [
+				'questionId' => $questionId
+			]);
+			throw new OCSBadRequestException();
+		}
+
+		if ($form->getOwnerId() !== $this->currentUser->getUID()) {
+			$this->logger->debug('This form is not owned by the current user');
+			throw new OCSForbiddenException();
+		}
+
+		if ($this->formsService->isFormArchived($form)) {
+			$this->logger->debug('This form is archived and can not be modified');
+			throw new OCSForbiddenException();
+		}
+
+		$addedOptions = [];
+		foreach ($optionTexts as $text) {
+			$option = new Option();
+
+			$option->setQuestionId($questionId);
+			$option->setText($text);
+
+			try {
+				$option = $this->optionMapper->insert($option);
+				// Add the stored option to the collection of added options
+				$addedOptions[] = $option->read();
+			} catch (IMapperException $e) {
+				$this->logger->error("Failed to add option: {$e->getMessage()}");
+				// Optionally handle the error, e.g., by continuing to the next iteration or returning an error response
+			}
+		}
+
+		$this->formsService->setLastUpdatedTimestamp($formId);
+
+		return new DataResponse($addedOptions);
+	}
+
+	/**
+	 * @CORS
+	 * @NoAdminRequired
+	 *
+	 * Writes the given key-value pairs into Database.
+	 *
+	 * @param int $formId id of form
+	 * @param int $questionId id of question
+	 * @param int $optionId id of option to update
+	 * @param array $keyValuePairs Array of key=>value pairs to update.
+	 * @return DataResponse
+	 * @throws OCSBadRequestException
+	 * @throws OCSForbiddenException
+	 */
+	public function updateOption(int $formId, int $questionId, int $optionId, array $keyValuePairs): DataResponse {
+		$this->logger->debug('Updating option: form: {formId}, question: {questionId}, option: {optionId}, values: {keyValuePairs}', [
+			'formId' => $formId,
+			'questionId' => $questionId,
+			'optionId' => $optionId,
+			'keyValuePairs' => $keyValuePairs
+		]);
+
+		try {
+			$option = $this->optionMapper->findById($optionId);
+			$question = $this->questionMapper->findById($questionId);
+			$form = $this->formMapper->findById($formId);
+		} catch (IMapperException $e) {
+			$this->logger->debug('Could not find option, question or form');
+			throw new OCSBadRequestException('Could not find option, question or form');
+		}
+
+		if ($option->getQuestionId() !== $questionId || $question->getFormId() !== $formId) {
+			$this->logger->debug('The given option id doesn\'t match the question or form.');
+			throw new OCSBadRequestException();
+		}
+
+		if ($form->getOwnerId() !== $this->currentUser->getUID()) {
+			$this->logger->debug('This form is not owned by the current user');
+			throw new OCSForbiddenException();
+		}
+
+		if ($this->formsService->isFormArchived($form)) {
+			$this->logger->debug('This form is archived and can not be modified');
+			throw new OCSForbiddenException();
+		}
+
+		// Don't allow empty array
+		if (sizeof($keyValuePairs) === 0) {
+			$this->logger->info('Empty keyValuePairs, will not update.');
+			throw new OCSForbiddenException();
+		}
+
+		//Don't allow to change id or questionId
+		if (key_exists('id', $keyValuePairs) || key_exists('questionId', $keyValuePairs)) {
+			$this->logger->debug('Not allowed to update id or questionId');
+			throw new OCSForbiddenException();
+		}
+
+		// Create OptionEntity with given Params & Id.
+		$option = Option::fromParams($keyValuePairs);
+		$option->setId($optionId);
+
+		// Update changed Columns in Db.
+		$this->optionMapper->update($option);
+
+		$this->formsService->setLastUpdatedTimestamp($formId);
+
+		return new DataResponse($option->getId());
+	}
+
+	/**
+	 * @CORS
+	 * @NoAdminRequired
+	 *
+	 * Delete an option
+	 *
+	 * @param int $formId id of form
+	 * @param int $questionId id of question
+	 * @param int $optionId id of option to update
+	 * @return DataResponse
+	 * @throws OCSBadRequestException
+	 * @throws OCSForbiddenException
+	 */
+	public function deleteOption(int $formId, int $questionId, int $optionId): DataResponse {
+		$this->logger->debug('Deleting option: {optionId}', [
+			'optionId' => $optionId
+		]);
+
+		try {
+			$option = $this->optionMapper->findById($optionId);
+			$question = $this->questionMapper->findById($questionId);
+			$form = $this->formMapper->findById($formId);
+		} catch (IMapperException $e) {
+			$this->logger->debug('Could not find form, question or option');
+			throw new OCSBadRequestException('Could not find form, question or option');
+		}
+
+		if ($option->getQuestionId() !== $questionId || $question->getFormId() !== $formId) {
+			$this->logger->debug('The given option id doesn\'t match the question or form.');
+			throw new OCSBadRequestException();
+		}
+
+		if ($form->getOwnerId() !== $this->currentUser->getUID()) {
+			$this->logger->debug('This form is not owned by the current user');
+			throw new OCSForbiddenException();
+		}
+
+		if ($this->formsService->isFormArchived($form)) {
+			$this->logger->debug('This form is archived and can not be modified');
+			throw new OCSForbiddenException();
+		}
+
+		$this->optionMapper->delete($option);
+
+		$this->formsService->setLastUpdatedTimestamp($formId);
+
+		return new DataResponse($optionId);
+	}
+
+	// Submissions
+
+	/**
+	 * @CORS
+	 * @NoAdminRequired
+	 *
+	 * Get all the submissions of a given form
+	 *
+	 * @param int $formId of the form
+	 * @return DataResponse|DataDownloadResponse
+	 * @throws OCSNotFoundException
+	 * @throws OCSForbiddenException
+	 */
+	public function getSubmissions(int $formId, ?string $fileFormat = null): DataResponse|DataDownloadResponse {
+		try {
+			$form = $this->formMapper->findById($formId);
+		} catch (IMapperException $e) {
+			$this->logger->debug('Could not find form');
+			throw new OCSNotFoundException();
+		}
+
+		if (!$this->formsService->canSeeResults($form)) {
+			$this->logger->debug('The current user has no permission to get the results for this form');
+			throw new OCSForbiddenException();
+		}
+
+		if ($fileFormat !== null) {
+			$submissionsData = $this->submissionService->getSubmissionsData($form, $fileFormat);
+			$fileName = $this->formsService->getFileName($form, $fileFormat);
+
+			return new DataDownloadResponse($submissionsData, $fileName, Constants::SUPPORTED_EXPORT_FORMATS[$fileFormat]);
+		}
+
+		// Load submissions and currently active questions
+		$submissions = $this->submissionService->getSubmissions($formId);
+		$questions = $this->formsService->getQuestions($formId);
+
+		// Append Display Names
+		foreach ($submissions as $key => $submission) {
+			if (substr($submission['userId'], 0, 10) === 'anon-user-') {
+				// Anonymous User
+				// TRANSLATORS On Results when listing the single Responses to the form, this text is shown as heading of the Response.
+				$submissions[$key]['userDisplayName'] = $this->l10n->t('Anonymous response');
+			} else {
+				$userEntity = $this->userManager->get($submission['userId']);
+
+				if ($userEntity instanceof IUser) {
+					$submissions[$key]['userDisplayName'] = $userEntity->getDisplayName();
+				} else {
+					// Fallback, should not occur regularly.
+					$submissions[$key]['userDisplayName'] = $submission['userId'];
+				}
+			}
+		}
+
+		$response = [
+			'submissions' => $submissions,
+			'questions' => $questions,
+		];
+
+		return new DataResponse($response);
+	}
+
+	/**
+	 * @CORS
+	 * @NoAdminRequired
+	 *
+	 * Delete all submissions of a specified form
+	 *
+	 * @param int $formId the form id
+	 * @return DataResponse
+	 * @throws OCSBadRequestException
+	 * @throws OCSForbiddenException
+	 */
+	public function deleteAllSubmissions(int $formId): DataResponse {
+		$this->logger->debug('Delete all submissions to form: {formId}', [
+			'formId' => $formId,
+		]);
+
+		try {
+			$form = $this->formMapper->findById($formId);
+		} catch (IMapperException $e) {
+			$this->logger->debug('Could not find form');
+			throw new OCSBadRequestException();
+		}
+
+		// The current user has permissions to remove submissions
+		if (!$this->formsService->canDeleteResults($form)) {
+			$this->logger->debug('This form is not owned by the current user and user has no `results_delete` permission');
+			throw new OCSForbiddenException();
+		}
+
+		// Delete all submissions (incl. Answers)
+		$this->submissionMapper->deleteByForm($formId);
+
+		$this->formsService->setLastUpdatedTimestamp($formId);
+
+		return new DataResponse($formId);
+	}
+
+	/**
+	 * @CORS
+	 * @NoAdminRequired
+	 * @NoCSRFRequired
+	 * @PublicPage
+	 *
+	 * Process a new submission
+	 *
+	 * @param int $formId the form id
+	 * @param array $answers [question_id => arrayOfString]
+	 * @param string $shareHash public share-hash -> Necessary to submit on public link-shares.
+	 * @return DataResponse
+	 * @throws OCSBadRequestException
+	 * @throws OCSForbiddenException
+	 */
+	public function newSubmission(int $formId, array $answers, string $shareHash = ''): DataResponse {
+		$this->logger->debug('Inserting submission: formId: {formId}, answers: {answers}, shareHash: {shareHash}', [
+			'formId' => $formId,
+			'answers' => $answers,
+			'shareHash' => $shareHash,
+		]);
+
+		$form = $this->loadFormForSubmission($formId, $shareHash);
+
+		$questions = $this->formsService->getQuestions($formId);
+		// Is the submission valid
+		$isSubmissionValid = $this->submissionService->validateSubmission($questions, $answers, $form->getOwnerId());
+		if (is_string($isSubmissionValid)) {
+			throw new OCSBadRequestException($isSubmissionValid);
+		}
+		if ($isSubmissionValid === false) {
+			throw new OCSBadRequestException('At least one submitted answer is not valid');
+		}
+
+		// Create Submission
+		$submission = new Submission();
+		$submission->setFormId($formId);
+		$submission->setTimestamp(time());
+
+		// If not logged in, anonymous, or embedded use anonID
+		if (!$this->currentUser || $form->getIsAnonymous()) {
+			$anonID = 'anon-user-' .  hash('md5', strval(time() + rand()));
+			$submission->setUserId($anonID);
+		} else {
+			$submission->setUserId($this->currentUser->getUID());
+		}
+
+		// Does the user have permissions to submit
+		// This is done right before insert so we minimize race conditions for submitting on unique-submission forms
+		if (!$this->formsService->canSubmit($form)) {
+			throw new OCSForbiddenException('Already submitted');
+		}
+
+		// Insert new submission
+		$this->submissionMapper->insert($submission);
+
+		// Ensure the form is unique if needed.
+		// If we can not submit anymore then the submission must be unique
+		if (!$this->formsService->canSubmit($form) && $this->submissionMapper->hasMultipleFormSubmissionsByUser($form, $submission->getUserId())) {
+			$this->submissionMapper->delete($submission);
+			throw new OCSForbiddenException('Already submitted');
+		}
+
+		// Process Answers
+		foreach ($answers as $questionId => $answerArray) {
+			// Search corresponding Question, skip processing if not found
+			$questionIndex = array_search($questionId, array_column($questions, 'id'));
+			if ($questionIndex === false) {
+				continue;
+			}
+
+			$this->storeAnswersForQuestion($form, $submission->getId(), $questions[$questionIndex], $answerArray);
+		}
+
+		$this->formsService->setLastUpdatedTimestamp($formId);
+
+		//Create Activity
+		$this->formsService->notifyNewSubmission($form, $submission->getUserId());
+
+		if ($form->getFileId() !== null) {
+			try {
+				$filePath = $this->formsService->getFilePath($form);
+				$fileFormat = $form->getFileFormat();
+				$ownerId = $form->getOwnerId();
+
+				$this->submissionService->writeFileToCloud($form, $filePath, $fileFormat, $ownerId);
+			} catch (NotFoundException $e) {
+				$this->logger->notice('Form {formId} linked to a file that doesn\'t exist anymore', [
+					'formId' => $formId
+				]);
+			}
+		}
+
+		return new DataResponse();
+	}
+
+	/**
+	 * @CORS
+	 * @NoAdminRequired
+	 *
+	 * Delete a specific submission
+	 *
+	 * @param int $formId the form id
+	 * @param int $submissionId the submission id
+	 * @return DataResponse
+	 * @throws OCSBadRequestException
+	 * @throws OCSForbiddenException
+	 */
+	public function deleteSubmission(int $formId, int $submissionId): DataResponse {
+		$this->logger->debug('Delete Submission: {submissionId}', [
+			'submissionId' => $submissionId,
+		]);
+
+		try {
+			$submission = $this->submissionMapper->findById($submissionId);
+			$form = $this->formMapper->findById($formId);
+		} catch (IMapperException $e) {
+			$this->logger->debug('Could not find form or submission');
+			throw new OCSBadRequestException();
+		}
+
+		if ($formId !== $submission->getFormId()) {
+			$this->logger->debug('Submission doesn\'t belong to given form');
+			throw new OCSBadRequestException('Submission doesn\'t belong to given form');
+		}
+
+		// The current user has permissions to remove submissions
+		if (!$this->formsService->canDeleteResults($form)) {
+			$this->logger->debug('This form is not owned by the current user and user has no `results_delete` permission');
+			throw new OCSForbiddenException();
+		}
+
+		// Delete submission (incl. Answers)
+		$this->submissionMapper->deleteById($submissionId);
+
+		$this->formsService->setLastUpdatedTimestamp($formId);
+
+		return new DataResponse($submissionId);
+	}
+
+	/**
+	 * @CORS
+	 * @NoAdminRequired
+	 *
+	 * Export Submissions to the Cloud
+	 *
+	 * @param int $formId of the form
+	 * @param string $path The Cloud-Path to export to
+	 * @param string $fileFormat File format used for export
+	 * @return DataResponse
+	 * @throws OCSBadRequestException
+	 * @throws OCSForbiddenException
+	 */
+	public function exportSubmissionsToCloud(int $formId, string $path, string $fileFormat = Constants::DEFAULT_FILE_FORMAT) {
+		try {
+			$form = $this->formMapper->findById($formId);
+		} catch (IMapperException $e) {
+			$this->logger->debug('Could not find form');
+			throw new OCSNotFoundException();
+		}
+
+		if (!$this->formsService->canSeeResults($form)) {
+			$this->logger->debug('The current user has no permission to get the results for this form');
+			throw new OCSForbiddenException();
+		}
+
+		$file = $this->submissionService->writeFileToCloud($form, $path, $fileFormat);
+
+		return new DataResponse($file->getName());
+	}
+
+	/**
+	 * @CORS
+	 * @NoAdminRequired
+	 * @PublicPage
+	 *
+	 * Uploads a temporary files to the server during form filling
+	 *
+	 * @param int $formId id of the form
+	 * @param int $questionId id of the question
+	 * @param string $shareHash hash of the form share
+	 * @return Response
+	 */
+	public function uploadFiles(int $formId, int $questionId, string $shareHash = ''): Response {
+		$this->logger->debug('Uploading files for formId: {formId}, questionId: {questionId}', [
+			'formId' => $formId,
+			'questionId' => $questionId
+		]);
+
+		$uploadedFiles = [];
+		foreach ($this->request->getUploadedFile('files') as $key => $files) {
+			foreach ($files as $i => $value) {
+				$uploadedFiles[$i][$key] = $value;
+			}
+		}
+
+		if (!count($uploadedFiles)) {
+			throw new OCSBadRequestException('No files provided');
+		}
+
+		$form = $this->loadFormForSubmission($formId, $shareHash);
+
+		if (!$this->formsService->canSubmit($form)) {
+			throw new OCSForbiddenException('Already submitted');
+		}
+
+		try {
+			$question = $this->questionMapper->findById($questionId);
+		} catch (IMapperException $e) {
+			$this->logger->debug('Could not find question with id {questionId}', [
+				'questionId' => $questionId
+			]);
+			throw new OCSBadRequestException(previous: $e instanceof \Exception ? $e : null);
+		}
+
+		if ($formId !== $question->getFormId()) {
+			$this->logger->debug('Question doesn\'t belong to the given form');
+			throw new OCSBadRequestException('Question doesn\'t belong to the given form');
+		}
+
+		$path = $this->formsService->getTemporaryUploadedFilePath($form, $question);
+
+		$response = [];
+		foreach ($uploadedFiles as $uploadedFile) {
+			$error = $uploadedFile['error'] ?? 0;
+			if ($error !== UPLOAD_ERR_OK) {
+				$this->logger->error(
+					'Failed to get the uploaded file. PHP file upload error code: ' . $error,
+					['file_name' => $uploadedFile['name']]
+				);
+
+				throw new OCSBadRequestException(sprintf('Failed to upload the file "%s".', $uploadedFile['name']));
+			}
+
+			if (!is_uploaded_file($uploadedFile['tmp_name'])) {
+				throw new OCSBadRequestException('Invalid file provided');
+			}
+
+			$userFolder = $this->storage->getUserFolder($form->getOwnerId());
+			$userFolder->getStorage()->verifyPath($path, $uploadedFile['name']);
+
+			$extraSettings = $question->getExtraSettings();
+			if (($extraSettings['maxFileSize'] ?? 0) > 0 && $uploadedFile['size'] > $extraSettings['maxFileSize']) {
+				throw new OCSBadRequestException(sprintf('File size exceeds the maximum allowed size of %s bytes.', $extraSettings['maxFileSize']));
+			}
+
+			if (!empty($extraSettings['allowedFileTypes']) || !empty($extraSettings['allowedFileExtensions'])) {
+				$mimeType = $this->mimeTypeDetector->detectContent($uploadedFile['tmp_name']);
+				$aliases = $this->mimeTypeDetector->getAllAliases();
+
+				$valid = false;
+				foreach ($extraSettings['allowedFileTypes'] ?? [] as $allowedFileType) {
+					if (str_starts_with($aliases[$mimeType] ?? '', $allowedFileType)) {
+						$valid = true;
+						break;
+					}
+				}
+
+				if (!$valid && !empty($extraSettings['allowedFileExtensions'])) {
+					$mimeTypesPerExtension = method_exists($this->mimeTypeDetector, 'getAllMappings')
+						? $this->mimeTypeDetector->getAllMappings() : [];
+					foreach ($extraSettings['allowedFileExtensions'] as $allowedFileExtension) {
+						if (
+							isset($mimeTypesPerExtension[$allowedFileExtension])
+							&& in_array($mimeType, $mimeTypesPerExtension[$allowedFileExtension])
+						) {
+							$valid = true;
+							break;
+						}
+					}
+				}
+
+				if (!$valid) {
+					throw new OCSBadRequestException(sprintf(
+						'File type is not allowed. Allowed file types: %s',
+						implode(', ', array_merge($extraSettings['allowedFileTypes'] ?? [], $extraSettings['allowedFileExtensions'] ?? []))
+					));
+				}
+			}
+
+			if ($userFolder->nodeExists($path)) {
+				$folder = $userFolder->get($path);
+			} else {
+				$folder = $userFolder->newFolder($path);
+			}
+			/** @var \OCP\Files\Folder $folder */
+
+			$fileName = $folder->getNonExistingName($uploadedFile['name']);
+			$file = $folder->newFile($fileName, file_get_contents($uploadedFile['tmp_name']));
+
+			$uploadedFileEntity = new UploadedFile();
+			$uploadedFileEntity->setFormId($formId);
+			$uploadedFileEntity->setOriginalFileName($fileName);
+			$uploadedFileEntity->setFileId($file->getId());
+			$uploadedFileEntity->setCreated(time());
+			$this->uploadedFileMapper->insert($uploadedFileEntity);
+
+			$response[] = [
+				'uploadedFileId' => $uploadedFileEntity->getId(),
+				'fileName' => $fileName,
+			];
+		}
+
+		return new DataResponse($response);
+	}
+
+	/*
+	 *
+	 * Legacy API v2 methods (TODO: remove with Forms v5)
+	 *
+	 */
+
+	/**
+	 * @CORS
+	 * @NoAdminRequired
+	 *
+	 * Read Form-List of owned forms
+	 * Return only with necessary information for Listing.
+	 * @return DataResponse
+	 */
+	public function getFormsLegacy(): DataResponse {
 		$forms = $this->formMapper->findAllByOwnerId($this->currentUser->getUID());
 
 		$result = [];
@@ -120,7 +1354,7 @@ class ApiController extends OCSController {
 	 * Return only with necessary information for Listing.
 	 * @return DataResponse
 	 */
-	public function getSharedForms(): DataResponse {
+	public function getSharedFormsLegacy(): DataResponse {
 		$forms = $this->formsService->getSharedForms($this->currentUser);
 		$result = array_values(array_map(fn (Form $form): array => $this->formsService->getPartialFormArray($form), $forms));
 
@@ -137,7 +1371,7 @@ class ApiController extends OCSController {
 	 * @return DataResponse
 	 * @throws OCSBadRequestException if forbidden or not found
 	 */
-	public function getPartialForm(string $hash): DataResponse {
+	public function getPartialFormLegacy(string $hash): DataResponse {
 		try {
 			$form = $this->formMapper->findByHash($hash);
 		} catch (IMapperException $e) {
@@ -164,7 +1398,7 @@ class ApiController extends OCSController {
 	 * @throws OCSBadRequestException
 	 * @throws OCSForbiddenException
 	 */
-	public function getForm(int $id): DataResponse {
+	public function getFormLegacy(int $id): DataResponse {
 		try {
 			$form = $this->formMapper->findById($id);
 			$formData = $this->formsService->getForm($form);
@@ -191,7 +1425,7 @@ class ApiController extends OCSController {
 	 * @throws OCSBadRequestException
 	 * @throws OCSForbiddenException
 	 */
-	public function newForm(): DataResponse {
+	public function newFormLegacy(): DataResponse {
 		// Check if user is allowed
 		if (!$this->configService->canCreateForms()) {
 			$this->logger->debug('This user is not allowed to create Forms.');
@@ -232,7 +1466,7 @@ class ApiController extends OCSController {
 	 * @throws OCSBadRequestException
 	 * @throws OCSForbiddenException
 	 */
-	public function cloneForm(int $id): DataResponse {
+	public function cloneFormLegacy(int $id): DataResponse {
 		$this->logger->debug('Cloning Form: {id}', [
 			'id' => $id
 		]);
@@ -295,7 +1529,7 @@ class ApiController extends OCSController {
 	 * @throws OCSBadRequestException
 	 * @throws OCSForbiddenException
 	 */
-	public function updateForm(int $id, array $keyValuePairs): DataResponse {
+	public function updateFormLegacy(int $id, array $keyValuePairs): DataResponse {
 		$this->logger->debug('Updating form: FormId: {id}, values: {keyValuePairs}', [
 			'id' => $id,
 			'keyValuePairs' => $keyValuePairs
@@ -310,9 +1544,11 @@ class ApiController extends OCSController {
 		}
 
 		// Don't allow to change params id, hash, ownerId, created, lastUpdated
-		if (key_exists('id', $keyValuePairs) || key_exists('hash', $keyValuePairs) ||
+		if (
+			key_exists('id', $keyValuePairs) || key_exists('hash', $keyValuePairs) ||
 			key_exists('ownerId', $keyValuePairs) || key_exists('created', $keyValuePairs) ||
-			key_exists('lastUpdated', $keyValuePairs)) {
+			key_exists('lastUpdated', $keyValuePairs)
+		) {
 			$this->logger->info('Not allowed to update id, hash, ownerId or created');
 			throw new OCSForbiddenException();
 		}
@@ -341,7 +1577,7 @@ class ApiController extends OCSController {
 	 * @throws OCSBadRequestException
 	 * @throws OCSForbiddenException
 	 */
-	public function transferOwner(int $formId, string $uid): DataResponse {
+	public function transferOwnerLegacy(int $formId, string $uid): DataResponse {
 		$this->logger->debug('Updating owner: formId: {formId}, userId: {uid}', [
 			'formId' => $formId,
 			'uid' => $uid
@@ -374,7 +1610,7 @@ class ApiController extends OCSController {
 	 * @throws OCSBadRequestException
 	 * @throws OCSForbiddenException
 	 */
-	public function deleteForm(int $id): DataResponse {
+	public function deleteFormLegacy(int $id): DataResponse {
 		$this->logger->debug('Delete Form: {id}', [
 			'id' => $id,
 		]);
@@ -398,7 +1634,7 @@ class ApiController extends OCSController {
 	 * @throws OCSBadRequestException
 	 * @throws OCSForbiddenException
 	 */
-	public function newQuestion(int $formId, string $type, string $text = ''): DataResponse {
+	public function newQuestionLegacy(int $formId, string $type, string $text = ''): DataResponse {
 		$this->logger->debug('Adding new question: formId: {formId}, type: {type}, text: {text}', [
 			'formId' => $formId,
 			'type' => $type,
@@ -464,7 +1700,7 @@ class ApiController extends OCSController {
 	 * @throws OCSBadRequestException
 	 * @throws OCSForbiddenException
 	 */
-	public function reorderQuestions(int $formId, array $newOrder): DataResponse {
+	public function reorderQuestionsLegacy(int $formId, array $newOrder): DataResponse {
 		$this->logger->debug('Reordering Questions on Form {formId} as Question-Ids {newOrder}', [
 			'formId' => $formId,
 			'newOrder' => $newOrder
@@ -554,7 +1790,7 @@ class ApiController extends OCSController {
 	 * @throws OCSBadRequestException
 	 * @throws OCSForbiddenException
 	 */
-	public function updateQuestion(int $id, array $keyValuePairs): DataResponse {
+	public function updateQuestionLegacy(int $id, array $keyValuePairs): DataResponse {
 		$this->logger->debug('Updating question: questionId: {id}, values: {keyValuePairs}', [
 			'id' => $id,
 			'keyValuePairs' => $keyValuePairs
@@ -618,7 +1854,7 @@ class ApiController extends OCSController {
 	 * @throws OCSBadRequestException
 	 * @throws OCSForbiddenException
 	 */
-	public function deleteQuestion(int $id): DataResponse {
+	public function deleteQuestionLegacy(int $id): DataResponse {
 		$this->logger->debug('Mark question as deleted: {id}', [
 			'id' => $id,
 		]);
@@ -669,7 +1905,7 @@ class ApiController extends OCSController {
 	 * @return DataResponse
 	 * @throws OCSBadRequestException|OCSForbiddenException
 	 */
-	public function cloneQuestion(int $id): DataResponse {
+	public function cloneQuestionLegacy(int $id): DataResponse {
 		$this->logger->debug('Question to be cloned: {id}', [
 			'id' => $id
 		]);
@@ -731,7 +1967,7 @@ class ApiController extends OCSController {
 	 * @throws OCSBadRequestException
 	 * @throws OCSForbiddenException
 	 */
-	public function newOption(int $questionId, string $text): DataResponse {
+	public function newOptionLegacy(int $questionId, string $text): DataResponse {
 		$this->logger->debug('Adding new option: questionId: {questionId}, text: {text}', [
 			'questionId' => $questionId,
 			'text' => $text,
@@ -779,7 +2015,7 @@ class ApiController extends OCSController {
 	 * @throws OCSBadRequestException
 	 * @throws OCSForbiddenException
 	 */
-	public function updateOption(int $id, array $keyValuePairs): DataResponse {
+	public function updateOptionLegacy(int $id, array $keyValuePairs): DataResponse {
 		$this->logger->debug('Updating option: option: {id}, values: {keyValuePairs}', [
 			'id' => $id,
 			'keyValuePairs' => $keyValuePairs
@@ -839,7 +2075,7 @@ class ApiController extends OCSController {
 	 * @throws OCSBadRequestException
 	 * @throws OCSForbiddenException
 	 */
-	public function deleteOption(int $id): DataResponse {
+	public function deleteOptionLegacy(int $id): DataResponse {
 		$this->logger->debug('Deleting option: {id}', [
 			'id' => $id
 		]);
@@ -881,7 +2117,7 @@ class ApiController extends OCSController {
 	 * @throws OCSBadRequestException
 	 * @throws OCSForbiddenException
 	 */
-	public function getSubmissions(string $hash): DataResponse {
+	public function getSubmissionsLegacy(string $hash): DataResponse {
 		try {
 			$form = $this->formMapper->findByHash($hash);
 		} catch (IMapperException $e) {
@@ -925,66 +2161,6 @@ class ApiController extends OCSController {
 	}
 
 	/**
-	 * Insert answers for a question
-	 *
-	 * @param Form $form
-	 * @param int $submissionId
-	 * @param array $question
-	 * @param string[]|array<array{uploadedFileId: string, uploadedFileName: string}> $answerArray
-	 */
-	private function storeAnswersForQuestion(Form $form, $submissionId, array $question, array $answerArray) {
-		foreach ($answerArray as $answer) {
-			$answerEntity = new Answer();
-			$answerEntity->setSubmissionId($submissionId);
-			$answerEntity->setQuestionId($question['id']);
-
-			$answerText = '';
-			$uploadedFile = null;
-			// Are we using answer ids as values
-			if (in_array($question['type'], Constants::ANSWER_TYPES_PREDEFINED)) {
-				// Search corresponding option, skip processing if not found
-				$optionIndex = array_search($answer, array_column($question['options'], 'id'));
-				if ($optionIndex !== false) {
-					$answerText = $question['options'][$optionIndex]['text'];
-				} elseif (!empty($question['extraSettings']['allowOtherAnswer']) && strpos($answer, Constants::QUESTION_EXTRASETTINGS_OTHER_PREFIX) === 0) {
-					$answerText = str_replace(Constants::QUESTION_EXTRASETTINGS_OTHER_PREFIX, '', $answer);
-				}
-			} elseif ($question['type'] === Constants::ANSWER_TYPE_FILE) {
-				$uploadedFile = $this->uploadedFileMapper->getByUploadedFileId($answer['uploadedFileId']);
-				$answerEntity->setFileId($uploadedFile->getFileId());
-
-				$userFolder = $this->storage->getUserFolder($form->getOwnerId());
-				$path = $this->formsService->getUploadedFilePath($form, $submissionId, $question['id'], $question['name'], $question['text']);
-
-				if ($userFolder->nodeExists($path)) {
-					$folder = $userFolder->get($path);
-				} else {
-					$folder = $userFolder->newFolder($path);
-				}
-				/** @var \OCP\Files\Folder $folder */
-
-				$file = $userFolder->getById($uploadedFile->getFileId())[0];
-				$name = $folder->getNonExistingName($file->getName());
-				$file->move($folder->getPath() . '/' . $name);
-
-				$answerText = $name;
-			} else {
-				$answerText = $answer; // Not a multiple-question, answerText is given answer
-			}
-
-			if ($answerText === '') {
-				continue;
-			}
-
-			$answerEntity->setText($answerText);
-			$this->answerMapper->insert($answerEntity);
-			if ($uploadedFile) {
-				$this->uploadedFileMapper->delete($uploadedFile);
-			}
-		}
-	}
-
-	/**
 	 * @CORS
 	 * @NoAdminRequired
 	 * @PublicPage
@@ -993,9 +2169,11 @@ class ApiController extends OCSController {
 	 *
 	 * @return Response
 	 */
-	public function uploadFiles(int $formId, int $questionId, string $shareHash = ''): Response {
-		$this->logger->debug('Uploading files for formId: {formId}, questionId: {questionId}',
-			['formId' => $formId, 'questionId' => $questionId]);
+	public function uploadFilesLegacy(int $formId, int $questionId, string $shareHash = ''): Response {
+		$this->logger->debug(
+			'Uploading files for formId: {formId}, questionId: {questionId}',
+			['formId' => $formId, 'questionId' => $questionId]
+		);
 
 		$uploadedFiles = [];
 		foreach ($this->request->getUploadedFile('files') as $key => $files) {
@@ -1027,8 +2205,10 @@ class ApiController extends OCSController {
 		foreach ($uploadedFiles as $uploadedFile) {
 			$error = $uploadedFile['error'] ?? 0;
 			if ($error !== UPLOAD_ERR_OK) {
-				$this->logger->error('Failed to get the uploaded file. PHP file upload error code: ' . $error,
-					['file_name' => $uploadedFile['name']]);
+				$this->logger->error(
+					'Failed to get the uploaded file. PHP file upload error code: ' . $error,
+					['file_name' => $uploadedFile['name']]
+				);
 
 				throw new OCSBadRequestException(sprintf('Failed to upload the file "%s".', $uploadedFile['name']));
 			}
@@ -1061,8 +2241,10 @@ class ApiController extends OCSController {
 					$mimeTypesPerExtension = method_exists($this->mimeTypeDetector, 'getAllMappings')
 						? $this->mimeTypeDetector->getAllMappings() : [];
 					foreach ($extraSettings['allowedFileExtensions'] as $allowedFileExtension) {
-						if (isset($mimeTypesPerExtension[$allowedFileExtension])
-							&& in_array($mimeType, $mimeTypesPerExtension[$allowedFileExtension])) {
+						if (
+							isset($mimeTypesPerExtension[$allowedFileExtension])
+							&& in_array($mimeType, $mimeTypesPerExtension[$allowedFileExtension])
+						) {
 							$valid = true;
 							break;
 						}
@@ -1070,7 +2252,8 @@ class ApiController extends OCSController {
 				}
 
 				if (!$valid) {
-					throw new OCSBadRequestException(sprintf('File type is not allowed. Allowed file types: %s',
+					throw new OCSBadRequestException(sprintf(
+						'File type is not allowed. Allowed file types: %s',
 						implode(', ', array_merge($extraSettings['allowedFileTypes'] ?? [], $extraSettings['allowedFileExtensions'] ?? []))
 					));
 				}
@@ -1117,7 +2300,7 @@ class ApiController extends OCSController {
 	 * @throws OCSBadRequestException
 	 * @throws OCSForbiddenException
 	 */
-	public function insertSubmission(int $formId, array $answers, string $shareHash = ''): DataResponse {
+	public function insertSubmissionLegacy(int $formId, array $answers, string $shareHash = ''): DataResponse {
 		$this->logger->debug('Inserting submission: formId: {formId}, answers: {answers}, shareHash: {shareHash}', [
 			'formId' => $formId,
 			'answers' => $answers,
@@ -1143,7 +2326,7 @@ class ApiController extends OCSController {
 
 		// If not logged in, anonymous, or embedded use anonID
 		if (!$this->currentUser || $form->getIsAnonymous()) {
-			$anonID = 'anon-user-'.  hash('md5', strval(time() + rand()));
+			$anonID = 'anon-user-' .  hash('md5', strval(time() + rand()));
 			$submission->setUserId($anonID);
 		} else {
 			$submission->setUserId($this->currentUser->getUID());
@@ -1207,7 +2390,7 @@ class ApiController extends OCSController {
 	 * @throws OCSBadRequestException
 	 * @throws OCSForbiddenException
 	 */
-	public function deleteSubmission(int $id): DataResponse {
+	public function deleteSubmissionLegacy(int $id): DataResponse {
 		$this->logger->debug('Delete Submission: {id}', [
 			'id' => $id,
 		]);
@@ -1245,7 +2428,7 @@ class ApiController extends OCSController {
 	 * @throws OCSBadRequestException
 	 * @throws OCSForbiddenException
 	 */
-	public function deleteAllSubmissions(int $formId): DataResponse {
+	public function deleteAllSubmissionsLegacy(int $formId): DataResponse {
 		$this->logger->debug('Delete all submissions to form: {formId}', [
 			'formId' => $formId,
 		]);
@@ -1283,7 +2466,7 @@ class ApiController extends OCSController {
 	 * @throws OCSBadRequestException
 	 * @throws OCSForbiddenException
 	 */
-	public function exportSubmissions(string $hash, string $fileFormat = Constants::DEFAULT_FILE_FORMAT): DataDownloadResponse {
+	public function exportSubmissionsLegacy(string $hash, string $fileFormat = Constants::DEFAULT_FILE_FORMAT): DataDownloadResponse {
 		$this->logger->debug('Export submissions for form: {hash}', [
 			'hash' => $hash,
 		]);
@@ -1319,7 +2502,7 @@ class ApiController extends OCSController {
 	 * @throws OCSBadRequestException
 	 * @throws OCSForbiddenException
 	 */
-	public function exportSubmissionsToCloud(string $hash, string $path, string $fileFormat = Constants::DEFAULT_FILE_FORMAT) {
+	public function exportSubmissionsToCloudLegacy(string $hash, string $path, string $fileFormat = Constants::DEFAULT_FILE_FORMAT) {
 		try {
 			$form = $this->formMapper->findByHash($hash);
 		} catch (IMapperException $e) {
@@ -1342,7 +2525,7 @@ class ApiController extends OCSController {
 	 *
 	 * @param string $hash of the form
 	 */
-	public function unlinkFile(string $hash): DataResponse {
+	public function unlinkFileLegacy(string $hash): DataResponse {
 		try {
 			$form = $this->formMapper->findByHash($hash);
 		} catch (IMapperException $e) {
@@ -1382,7 +2565,7 @@ class ApiController extends OCSController {
 	 * @throws OCSBadRequestException
 	 * @throws OCSForbiddenException
 	 */
-	public function linkFile(string $hash, string $path, string $fileFormat): DataResponse {
+	public function linkFileLegacy(string $hash, string $path, string $fileFormat): DataResponse {
 		$this->logger->debug('Linking form {hash} to file at /{path} in format {fileFormat}', [
 			'hash' => $hash,
 			'path' => $path,
@@ -1418,6 +2601,68 @@ class ApiController extends OCSController {
 			'fileName' => $file->getName(),
 			'filePath' => $filePath,
 		]);
+	}
+
+	// private functions
+
+	/**
+	 * Insert answers for a question
+	 *
+	 * @param Form $form
+	 * @param int $submissionId
+	 * @param array $question
+	 * @param string[]|array<array{uploadedFileId: string, uploadedFileName: string}> $answerArray
+	 */
+	private function storeAnswersForQuestion(Form $form, $submissionId, array $question, array $answerArray) {
+		foreach ($answerArray as $answer) {
+			$answerEntity = new Answer();
+			$answerEntity->setSubmissionId($submissionId);
+			$answerEntity->setQuestionId($question['id']);
+
+			$answerText = '';
+			$uploadedFile = null;
+			// Are we using answer ids as values
+			if (in_array($question['type'], Constants::ANSWER_TYPES_PREDEFINED)) {
+				// Search corresponding option, skip processing if not found
+				$optionIndex = array_search($answer, array_column($question['options'], 'id'));
+				if ($optionIndex !== false) {
+					$answerText = $question['options'][$optionIndex]['text'];
+				} elseif (!empty($question['extraSettings']['allowOtherAnswer']) && strpos($answer, Constants::QUESTION_EXTRASETTINGS_OTHER_PREFIX) === 0) {
+					$answerText = str_replace(Constants::QUESTION_EXTRASETTINGS_OTHER_PREFIX, '', $answer);
+				}
+			} elseif ($question['type'] === Constants::ANSWER_TYPE_FILE) {
+				$uploadedFile = $this->uploadedFileMapper->getByUploadedFileId($answer['uploadedFileId']);
+				$answerEntity->setFileId($uploadedFile->getFileId());
+
+				$userFolder = $this->storage->getUserFolder($form->getOwnerId());
+				$path = $this->formsService->getUploadedFilePath($form, $submissionId, $question['id'], $question['name'], $question['text']);
+
+				if ($userFolder->nodeExists($path)) {
+					$folder = $userFolder->get($path);
+				} else {
+					$folder = $userFolder->newFolder($path);
+				}
+				/** @var \OCP\Files\Folder $folder */
+
+				$file = $userFolder->getById($uploadedFile->getFileId())[0];
+				$name = $folder->getNonExistingName($file->getName());
+				$file->move($folder->getPath() . '/' . $name);
+
+				$answerText = $name;
+			} else {
+				$answerText = $answer; // Not a multiple-question, answerText is given answer
+			}
+
+			if ($answerText === '') {
+				continue;
+			}
+
+			$answerEntity->setText($answerText);
+			$this->answerMapper->insert($answerEntity);
+			if ($uploadedFile) {
+				$this->uploadedFileMapper->delete($uploadedFile);
+			}
+		}
 	}
 
 	private function loadFormForSubmission(int $formId, string $shareHash): Form {
@@ -1465,13 +2710,13 @@ class ApiController extends OCSController {
 	/**
 	 * Helper that retrieves a form if the current user is allowed to edit it
 	 * This throws an exception in case either the form is not found or permissions are missing.
-	 * @param int $id The form ID to retrieve
+	 * @param int $formId The form ID to retrieve
 	 * @throws OCSNotFoundException If the form was not found
 	 * @throws OCSForbiddenException If the current user has no permission to edit
 	 */
-	private function getFormIfAllowed(int $id): Form {
+	private function getFormIfAllowed(int $formId): Form {
 		try {
-			$form = $this->formMapper->findById($id);
+			$form = $this->formMapper->findById($formId);
 		} catch (IMapperException $e) {
 			$this->logger->debug('Could not find form');
 			throw new OCSNotFoundException();

--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -79,13 +79,16 @@ class PageController extends Controller {
 	 *
 	 * @return TemplateResponse
 	 */
-	public function index(): TemplateResponse {
+	public function index(?string $hash = null): TemplateResponse {
 		Util::addScript($this->appName, 'forms-main');
 		Util::addStyle($this->appName, 'forms');
 		Util::addStyle($this->appName, 'forms-style');
 		$this->insertHeaderOnIos();
 		$this->initialState->provideInitialState('maxStringLengths', Constants::MAX_STRING_LENGTHS);
 		$this->initialState->provideInitialState('appConfig', $this->configService->getAppConfig());
+		if (isset($hash)) {
+			$this->initialState->provideInitialState('formId', $this->formMapper->findByHash($hash)->id);
+		}
 		return new TemplateResponse($this->appName, self::TEMPLATE_MAIN, [
 			'id-app-content' => '#app-content-vue',
 			'id-app-navigation' => '#app-navigation-vue',
@@ -98,8 +101,8 @@ class PageController extends Controller {
 	 *
 	 * @return TemplateResponse
 	 */
-	public function views(): TemplateResponse {
-		return $this->index();
+	public function views(string $hash): TemplateResponse {
+		return $this->index($hash);
 	}
 
 	/**

--- a/lib/Controller/ShareApiController.php
+++ b/lib/Controller/ShareApiController.php
@@ -207,6 +207,274 @@ class ShareApiController extends OCSController {
 	 * @CORS
 	 * @NoAdminRequired
 	 *
+	 * Update permissions of a share
+	 *
+	 * @param int $formId of the form
+	 * @param int $shareId of the share to update
+	 * @param array $keyValuePairs Array of key=>value pairs to update.
+	 * @return DataResponse
+	 * @throws OCSBadRequestException
+	 * @throws OCSForbiddenException
+	 */
+	public function updateShare(int $formId, int $shareId, array $keyValuePairs): DataResponse {
+		$this->logger->debug('Updating share: {shareId} of form {formId}, permissions: {permissions}', [
+			'formId' => $formId,
+			'shareId' => $shareId,
+			'keyValuePairs' => $keyValuePairs
+		]);
+
+		try {
+			$formShare = $this->shareMapper->findById($shareId);
+			$form = $this->formMapper->findById($formId);
+		} catch (IMapperException $e) {
+			$this->logger->debug('Could not find share', ['exception' => $e]);
+			throw new OCSBadRequestException('Could not find share');
+		}
+
+		if ($formId !== $formShare->getFormId()) {
+			$this->logger->debug('This share doesn\'t belong to the given Form');
+			throw new OCSBadRequestException('Share doesn\'t belong to given Form');
+		}
+
+		if ($form->getOwnerId() !== $this->currentUser->getUID()) {
+			$this->logger->debug('This form is not owned by the current user');
+			throw new OCSForbiddenException();
+		}
+
+		// Don't allow empty array
+		if (sizeof($keyValuePairs) === 0) {
+			$this->logger->info('Empty keyValuePairs, will not update.');
+			throw new OCSForbiddenException();
+		}
+
+		//Don't allow to change other properties than permissions
+		if (count($keyValuePairs) > 1 || !key_exists('permissions', $keyValuePairs)) {
+			$this->logger->debug('Not allowed to update other properties than permissions');
+			throw new OCSForbiddenException();
+		}
+
+		if (!$this->validatePermissions($keyValuePairs['permissions'], $formShare->getShareType())) {
+			throw new OCSBadRequestException('Invalid permission given');
+		}
+
+		$formShare->setPermissions($keyValuePairs['permissions']);
+		$formShare = $this->shareMapper->update($formShare);
+
+		if (in_array($formShare->getShareType(), [IShare::TYPE_USER, IShare::TYPE_GROUP, IShare::TYPE_USERGROUP, IShare::TYPE_CIRCLE], true)) {
+			$userFolder = $this->storage->getUserFolder($form->getOwnerId());
+			$uploadedFilesFolderPath = $this->formsService->getFormUploadedFilesFolderPath($form);
+			if ($userFolder->nodeExists($uploadedFilesFolderPath)) {
+				$folder = $userFolder->get($uploadedFilesFolderPath);
+			} else {
+				$folder = $userFolder->newFolder($uploadedFilesFolderPath);
+			}
+			/** @var \OCP\Files\Folder $folder */
+
+			if (in_array(Constants::PERMISSION_RESULTS, $keyValuePairs['permissions'], true)) {
+				$folderShare = $this->shareManager->newShare();
+				$folderShare->setShareType($formShare->getShareType());
+				$folderShare->setSharedWith($formShare->getShareWith());
+				$folderShare->setSharedBy($form->getOwnerId());
+				$folderShare->setPermissions(\OCP\Constants::PERMISSION_READ);
+				$folderShare->setNode($folder);
+				$folderShare->setShareOwner($form->getOwnerId());
+
+				$this->shareManager->createShare($folderShare);
+			} else {
+				$folderShares = $this->shareManager->getSharesBy($form->getOwnerId(), $formShare->getShareType(), $folder);
+				foreach ($folderShares as $folderShare) {
+					if ($folderShare->getSharedWith() === $formShare->getShareWith()) {
+						$this->shareManager->deleteShare($folderShare);
+					}
+				}
+			}
+		}
+
+		$this->formsService->setLastUpdatedTimestamp($formId);
+
+		return new DataResponse($formShare->getId());
+	}
+
+	/**
+	 * @CORS
+	 * @NoAdminRequired
+	 *
+	 * Delete a share
+	 *
+	 * @param int $formId of the form
+	 * @param int $shareId of the share to delete
+	 * @return DataResponse
+	 * @throws OCSBadRequestException
+	 * @throws OCSForbiddenException
+	 */
+	public function deleteShare(int $formId, int $shareId): DataResponse {
+		$this->logger->debug('Deleting share: {shareId} of form {formId}', [
+			'formId' => $formId,
+			'shareId' => $shareId,
+		]);
+
+		try {
+			$share = $this->shareMapper->findById($shareId);
+			$form = $this->formMapper->findById($formId);
+		} catch (IMapperException $e) {
+			$this->logger->debug('Could not find share', ['exception' => $e]);
+			throw new OCSBadRequestException('Could not find share');
+		}
+
+		if ($formId !== $share->getFormId()) {
+			$this->logger->debug('This share doesn\'t belong to the given Form');
+			throw new OCSBadRequestException('Share doesn\'t belong to given Form');
+		}
+
+		if ($form->getOwnerId() !== $this->currentUser->getUID()) {
+			$this->logger->debug('This form is not owned by the current user');
+			throw new OCSForbiddenException();
+		}
+
+		$this->shareMapper->deleteById($shareId);
+
+		$this->formsService->setLastUpdatedTimestamp($formId);
+
+		return new DataResponse($shareId);
+	}
+
+	/*
+	 *
+	 * Legacy API v2 methods (TODO: remove with Forms v5)
+	 *
+	 */
+	
+	/**
+	 * @CORS
+	 * @NoAdminRequired
+	 *
+	 * Add a new share
+	 *
+	 * @param int $formId The form to share
+	 * @param int $shareType Nextcloud-ShareType
+	 * @param string $shareWith ID of user/group/... to share with. For Empty shareWith and shareType Link, this will be set as RandomID.
+	 * @return DataResponse
+	 * @throws OCSBadRequestException
+	 * @throws OCSForbiddenException
+	 */
+	public function newShareLegacy(int $formId, int $shareType, string $shareWith = '', array $permissions = [Constants::PERMISSION_SUBMIT]): DataResponse {
+		$this->logger->debug('Adding new share: formId: {formId}, shareType: {shareType}, shareWith: {shareWith}, permissions: {permissions}', [
+			'formId' => $formId,
+			'shareType' => $shareType,
+			'shareWith' => $shareWith,
+			'permissions' => $permissions,
+		]);
+
+		// Only accept usable shareTypes
+		if (array_search($shareType, Constants::SHARE_TYPES_USED) === false) {
+			$this->logger->debug('Invalid shareType');
+			throw new OCSBadRequestException('Invalid shareType');
+		}
+
+		// Block LinkShares if not allowed
+		if ($shareType === IShare::TYPE_LINK && !$this->configService->getAllowPublicLink()) {
+			$this->logger->debug('Link Share not allowed.');
+			throw new OCSForbiddenException('Link Share not allowed.');
+		}
+
+		try {
+			$form = $this->formMapper->findById($formId);
+		} catch (IMapperException $e) {
+			$this->logger->debug('Could not find form', ['exception' => $e]);
+			throw new OCSBadRequestException('Could not find form');
+		}
+
+		// Check for permission to share form
+		if ($form->getOwnerId() !== $this->currentUser->getUID()) {
+			$this->logger->debug('This form is not owned by the current user');
+			throw new OCSForbiddenException();
+		}
+
+		if (!$this->validatePermissions($permissions, $shareType)) {
+			throw new OCSBadRequestException('Invalid permission given');
+		}
+
+		// Create public-share hash, if necessary.
+		if ($shareType === IShare::TYPE_LINK) {
+			$shareWith = $this->secureRandom->generate(
+				24,
+				ISecureRandom::CHAR_HUMAN_READABLE
+			);
+		}
+
+		// Check for valid shareWith, needs to be done separately per shareType
+		switch ($shareType) {
+			case IShare::TYPE_USER:
+				if (!($this->userManager->get($shareWith) instanceof IUser)) {
+					$this->logger->debug('Invalid user to share with.');
+					throw new OCSBadRequestException('Invalid user to share with.');
+				}
+				break;
+
+			case IShare::TYPE_GROUP:
+				if (!($this->groupManager->get($shareWith) instanceof IGroup)) {
+					$this->logger->debug('Invalid group to share with.');
+					throw new OCSBadRequestException('Invalid group to share with.');
+				}
+				break;
+
+			case IShare::TYPE_LINK:
+				// Check if hash already exists. (Unfortunately not possible here by unique index on db.)
+				try {
+					// Try loading a share to the hash.
+					$nonex = $this->shareMapper->findPublicShareByHash($shareWith);
+
+					// If we come here, a share has been found --> The share hash already exists, thus aborting.
+					$this->logger->debug('Share Hash already exists.');
+					throw new OCSException('Share Hash exists. Please retry.');
+				} catch (DoesNotExistException $e) {
+					// Just continue, this is what we expect to happen (share hash not existing yet).
+				}
+				break;
+
+			case IShare::TYPE_CIRCLE:
+				if (!$this->circlesService->isCirclesEnabled()) {
+					$this->logger->debug('Teams app is disabled, sharing to teams not possible.');
+					throw new OCSException('Teams app is disabled.');
+				}
+				$circle = $this->circlesService->getCircle($shareWith);
+				if (is_null($circle)) {
+					$this->logger->debug('Invalid team to share with.');
+					throw new OCSBadRequestException('Invalid team to share with.');
+				}
+				break;
+
+			default:
+				// This passed the check for used shareTypes, but has not been found here.
+				$this->logger->warning('Unknown, but used shareType: {shareType}. Please file an issue on GitHub.', [ 'shareType' => $shareType ]);
+				throw new OCSException('Unknown shareType.');
+		}
+
+		$share = new Share();
+		$share->setFormId($formId);
+		$share->setShareType($shareType);
+		$share->setShareWith($shareWith);
+		$share->setPermissions($permissions);
+
+		/** @var Share */
+		$share = $this->shareMapper->insert($share);
+
+		// Create share-notifications (activity)
+		$this->formsService->notifyNewShares($form, $share);
+
+		$this->formsService->setLastUpdatedTimestamp($formId);
+
+		// Append displayName for Frontend
+		$shareData = $share->read();
+		$shareData['displayName'] = $this->formsService->getShareDisplayName($shareData);
+
+		return new DataResponse($shareData);
+	}
+
+	/**
+	 * @CORS
+	 * @NoAdminRequired
+	 *
 	 * Delete a share
 	 *
 	 * @param int $id of the share to delete
@@ -214,7 +482,7 @@ class ShareApiController extends OCSController {
 	 * @throws OCSBadRequestException
 	 * @throws OCSForbiddenException
 	 */
-	public function deleteShare(int $id): DataResponse {
+	public function deleteShareLegacy(int $id): DataResponse {
 		$this->logger->debug('Deleting share: {id}', [
 			'id' => $id
 		]);
@@ -251,7 +519,7 @@ class ShareApiController extends OCSController {
 	 * @throws OCSBadRequestException
 	 * @throws OCSForbiddenException
 	 */
-	public function updateShare(int $id, array $keyValuePairs): DataResponse {
+	public function updateShareLegacy(int $id, array $keyValuePairs): DataResponse {
 		$this->logger->debug('Updating share: {id}, permissions: {permissions}', [
 			'id' => $id,
 			'keyValuePairs' => $keyValuePairs

--- a/lib/Service/FormsService.php
+++ b/lib/Service/FormsService.php
@@ -145,6 +145,40 @@ class FormsService {
 	}
 
 	/**
+	 * Load specific question
+	 *
+	 * @param integer $questionId id of the question
+	 * @return array
+	 */
+	public function getQuestion(int $questionId): array {
+		$question = [];
+		try {
+			$questionEntity = $this->questionMapper->findById($questionId);
+			$question = $questionEntity->read();
+			$question['options'] = $this->getOptions($question['id']);
+			$question['accept'] = [];
+			if ($question['type'] === Constants::ANSWER_TYPE_FILE) {
+				if ($question['extraSettings']['allowedFileTypes'] ?? null) {
+					$question['accept'] = array_keys(array_intersect(
+						$this->mimeTypeDetector->getAllAliases(),
+						$question['extraSettings']['allowedFileTypes']
+					));
+				}
+
+				if ($question['extraSettings']['allowedFileExtensions'] ?? null) {
+					foreach ($question['extraSettings']['allowedFileExtensions'] as $extension) {
+						$question['accept'][] = '.' . $extension;
+					}
+				}
+			}
+		} catch (DoesNotExistException $e) {
+			//handle silently
+		} finally {
+			return $question;
+		}
+	}
+
+	/**
 	 * Load shares corresponding to form
 	 *
 	 * @param integer $formId

--- a/playwright/support/sections/FormSection.ts
+++ b/playwright/support/sections/FormSection.ts
@@ -60,7 +60,7 @@ export class FormSection {
 				response
 					.request()
 					.url()
-					.endsWith('/ocs/v2.php/apps/forms/api/v2.4/form/update'),
+					.includes('/ocs/v2.php/apps/forms/api/v3/forms/'),
 		)
 	}
 }

--- a/src/Forms.vue
+++ b/src/Forms.vue
@@ -362,7 +362,7 @@ export default {
 			// Load Owned forms
 			try {
 				const response = await axios.get(
-					generateOcsUrl('apps/forms/api/v2.4/forms'),
+					generateOcsUrl('apps/forms/api/v3/forms'),
 				)
 				this.forms = OcsResponse2Data(response)
 			} catch (error) {
@@ -375,7 +375,7 @@ export default {
 			// Load shared forms
 			try {
 				const response = await axios.get(
-					generateOcsUrl('apps/forms/api/v2.4/shared_forms'),
+					generateOcsUrl('apps/forms/api/v3/forms?type=shared'),
 				)
 				this.allSharedForms = OcsResponse2Data(response)
 			} catch (error) {
@@ -413,8 +413,8 @@ export default {
 			) {
 				try {
 					const response = await axios.get(
-						generateOcsUrl('apps/forms/api/v2.4/partial_form/{hash}', {
-							hash,
+						generateOcsUrl('apps/forms/api/v3/forms/{id}', {
+							id: loadState(appName, 'formId'),
 						}),
 					)
 					const form = OcsResponse2Data(response)
@@ -447,7 +447,7 @@ export default {
 			try {
 				// Request a new empty form
 				const response = await axios.post(
-					generateOcsUrl('apps/forms/api/v2.4/form'),
+					generateOcsUrl('apps/forms/api/v3/forms'),
 				)
 				const newForm = OcsResponse2Data(response)
 				this.forms.unshift(newForm)
@@ -467,7 +467,7 @@ export default {
 		async onCloneForm(id) {
 			try {
 				const response = await axios.post(
-					generateOcsUrl('apps/forms/api/v2.4/form/clone/{id}', { id }),
+					generateOcsUrl('apps/forms/api/v3/forms?fromId={id}', { id }),
 				)
 				const newForm = OcsResponse2Data(response)
 				this.forms.unshift(newForm)

--- a/src/components/AppNavigationForm.vue
+++ b/src/components/AppNavigationForm.vue
@@ -301,9 +301,10 @@ export default {
 			try {
 				// TODO: add loading status feedback ?
 				await axios.patch(
-					generateOcsUrl('apps/forms/api/v2.4/form/update'),
-					{
+					generateOcsUrl('apps/forms/api/v3/forms/{id}', {
 						id: this.form.id,
+					}),
+					{
 						keyValuePairs: {
 							state: this.isArchived
 								? FormState.FormClosed
@@ -326,7 +327,7 @@ export default {
 			this.loading = true
 			try {
 				await axios.delete(
-					generateOcsUrl('apps/forms/api/v2.4/form/{id}', {
+					generateOcsUrl('apps/forms/api/v3/forms/{id}', {
 						id: this.form.id,
 					}),
 				)

--- a/src/components/Questions/AnswerInput.vue
+++ b/src/components/Questions/AnswerInput.vue
@@ -68,6 +68,10 @@ export default {
 			type: Number,
 			required: true,
 		},
+		formId: {
+			type: Number,
+			required: true,
+		},
 		isUnique: {
 			type: Boolean,
 			required: true,
@@ -168,17 +172,22 @@ export default {
 		async createAnswer(answer) {
 			try {
 				const response = await axios.post(
-					generateOcsUrl('apps/forms/api/v2.4/option'),
+					generateOcsUrl(
+						'apps/forms/api/v3/forms/{id}/questions/{questionId}/options',
+						{
+							id: this.formId,
+							questionId: answer.questionId,
+						},
+					),
 					{
-						questionId: answer.questionId,
-						text: answer.text,
+						optionTexts: [answer.text],
 					},
 				)
 				logger.debug('Created answer', { answer })
 
 				// Was synced once, this is now up to date with the server
 				delete answer.local
-				return Object.assign({}, answer, OcsResponse2Data(response))
+				return Object.assign({}, answer, OcsResponse2Data(response)[0])
 			} catch (error) {
 				logger.error('Error while saving answer', { answer, error })
 				showError(t('forms', 'Error while saving the answer'))
@@ -199,9 +208,15 @@ export default {
 		async updateAnswer(answer) {
 			try {
 				await axios.patch(
-					generateOcsUrl('apps/forms/api/v2.4/option/update'),
+					generateOcsUrl(
+						'apps/forms/api/v3/forms/{id}/questions/{questionId}/options/{optionId}',
+						{
+							id: this.formId,
+							questionId: answer.questionId,
+							optionId: answer.id,
+						},
+					),
 					{
-						id: this.answer.id,
 						keyValuePairs: {
 							text: answer.text,
 						},

--- a/src/components/Questions/QuestionDropdown.vue
+++ b/src/components/Questions/QuestionDropdown.vue
@@ -66,6 +66,7 @@
 					"
 					ref="input"
 					:answer="answer"
+					:form-id="formId"
 					:index="index"
 					:is-unique="!isMultiple"
 					:is-dropdown="true"
@@ -304,9 +305,14 @@ export default {
 				// let's not await, deleting in background
 				axios
 					.delete(
-						generateOcsUrl('apps/forms/api/v2.4/option/{id}', {
-							id: option.id,
-						}),
+						generateOcsUrl(
+							'apps/forms/api/v3/forms/{id}/questions/{questionId}/options/{optionId}',
+							{
+								id: this.formId,
+								questionId: this.id,
+								optionId: option.id,
+							},
+						),
 					)
 					.catch((error) => {
 						logger.error('Error while deleting an option', {

--- a/src/components/Questions/QuestionFile.vue
+++ b/src/components/Questions/QuestionFile.vue
@@ -303,9 +303,9 @@ export default {
 			formData.append('shareHash', loadState('forms', 'shareHash', null))
 
 			const url = generateOcsUrl(
-				'apps/forms/api/v2.5/uploadFiles/{formId}/{questionId}',
+				'apps/forms/api/v3/forms/{id}/submissions/files/{questionId}',
 				{
-					formId: this.formId,
+					id: this.formId,
 					questionId: this.id,
 				},
 			)

--- a/src/components/Questions/QuestionMultiple.vue
+++ b/src/components/Questions/QuestionMultiple.vue
@@ -144,6 +144,7 @@
 						"
 						ref="input"
 						:answer="answer"
+						:form-id="formId"
 						:index="index"
 						:is-unique="isUnique"
 						:is-dropdown="false"
@@ -611,9 +612,14 @@ export default {
 				// let's not await, deleting in background
 				axios
 					.delete(
-						generateOcsUrl('apps/forms/api/v2.4/option/{id}', {
-							id: option.id,
-						}),
+						generateOcsUrl(
+							'apps/forms/api/v3/forms/{id}/questions/{questionId}/options/{optionId}',
+							{
+								id: this.formId,
+								questionId: this.id,
+								optionId: option.id,
+							},
+						),
 					)
 					.catch((error) => {
 						logger.error('Error while deleting an option', {

--- a/src/components/SidebarTabs/SharingSidebarTab.vue
+++ b/src/components/SidebarTabs/SharingSidebarTab.vue
@@ -320,9 +320,10 @@ export default {
 
 			try {
 				const response = await axios.post(
-					generateOcsUrl('apps/forms/api/v2.4/share'),
+					generateOcsUrl('apps/forms/api/v3/forms/{id}/shares', {
+						id: this.form.id,
+					}),
 					{
-						formId: this.form.id,
 						shareType: newShare.shareType,
 						shareWith: newShare.shareWith,
 					},
@@ -347,9 +348,10 @@ export default {
 
 			try {
 				const response = await axios.post(
-					generateOcsUrl('apps/forms/api/v2.4/share'),
+					generateOcsUrl('apps/forms/api/v3/forms/{id}/shares', {
+						id: this.form.id,
+					}),
 					{
-						formId: this.form.id,
 						shareType: this.SHARE_TYPES.SHARE_TYPE_LINK,
 					},
 				)
@@ -389,9 +391,11 @@ export default {
 
 			try {
 				const response = await axios.patch(
-					generateOcsUrl('apps/forms/api/v2.4/share/update'),
+					generateOcsUrl('apps/forms/api/v3/forms/{id}/shares/{shareId}', {
+						id: this.form.id,
+						shareId: updatedShare.id,
+					}),
 					{
-						id: updatedShare.id,
 						keyValuePairs: {
 							permissions: updatedShare.permissions,
 						},
@@ -424,8 +428,9 @@ export default {
 
 			try {
 				await axios.delete(
-					generateOcsUrl('apps/forms/api/v2.4/share/{id}', {
-						id: share.id,
+					generateOcsUrl('apps/forms/api/v3/forms/{id}/shares/{shareId}', {
+						id: this.form.id,
+						shareId: share.id,
 					}),
 				)
 				this.$emit('remove-share', share)

--- a/src/components/SidebarTabs/TransferOwnership.vue
+++ b/src/components/SidebarTabs/TransferOwnership.vue
@@ -183,11 +183,12 @@ export default {
 			if (this.form.id && this.selected.shareWith) {
 				try {
 					emit('forms:last-updated:set', this.form.id)
-					await axios.post(
-						generateOcsUrl('apps/forms/api/v2.4/form/transfer'),
+					await axios.patch(
+						generateOcsUrl('apps/forms/api/v3/forms/{id}', {
+							id: this.form.id,
+						}),
 						{
-							formId: this.form.id,
-							uid: this.selected.shareWith,
+							ownerId: this.selected.shareWith,
 						},
 					)
 					showSuccess(

--- a/src/mixins/ViewsMixin.js
+++ b/src/mixins/ViewsMixin.js
@@ -154,7 +154,7 @@ export default {
 
 			try {
 				const response = await request(
-					generateOcsUrl('apps/forms/api/v2.4/form/{id}', { id }),
+					generateOcsUrl('apps/forms/api/v3/forms/{id}', { id }),
 				)
 				this.$emit('update:form', OcsResponse2Data(response))
 				this.isLoadingForm = false
@@ -178,9 +178,10 @@ export default {
 			try {
 				// TODO: add loading status feedback ?
 				await axios.patch(
-					generateOcsUrl('apps/forms/api/v2.4/form/update'),
-					{
+					generateOcsUrl('apps/forms/api/v3/forms/{id}', {
 						id: this.form.id,
+					}),
+					{
 						keyValuePairs: {
 							[key]: this.form[key],
 						},

--- a/src/views/Results.vue
+++ b/src/views/Results.vue
@@ -474,9 +474,17 @@ export default {
 
 	methods: {
 		async onUnlinkFile() {
-			await axios.post(generateOcsUrl('apps/forms/api/v2.4/form/unlink'), {
-				hash: this.form.hash,
-			})
+			await axios.update(
+				generateOcsUrl('apps/forms/api/v3/forms/{id}', {
+					id: this.form.id,
+				}),
+				{
+					keyValuePairs: {
+						fileId: null,
+						fileFormat: null,
+					},
+				},
+			)
 
 			this.form.fileFormat = null
 			this.form.fileId = null
@@ -489,8 +497,8 @@ export default {
 
 			try {
 				const response = await axios.get(
-					generateOcsUrl('apps/forms/api/v2.4/submissions/{hash}', {
-						hash: this.form.hash,
+					generateOcsUrl('apps/forms/api/v3/forms/{id}/submissions', {
+						id: this.form.id,
 					}),
 				)
 
@@ -515,8 +523,8 @@ export default {
 
 		async onDownloadFile(fileFormat) {
 			const exportUrl =
-				generateOcsUrl('apps/forms/api/v2.4/submissions/export/{hash}', {
-					hash: this.form.hash,
+				generateOcsUrl('apps/forms/api/v3/forms/{id}/submissions', {
+					id: this.form.id,
 				}) +
 				'?requesttoken=' +
 				encodeURIComponent(getRequestToken()) +
@@ -531,14 +539,15 @@ export default {
 					.pick()
 					.then(async (path) => {
 						try {
-							const response = await axios.post(
-								generateOcsUrl(
-									'apps/forms/api/v2.4/form/link/{fileFormat}',
-									{ fileFormat },
-								),
+							const response = await axios.patch(
+								generateOcsUrl('apps/forms/api/v3/forms/{id}', {
+									id: this.form.id,
+								}),
 								{
-									hash: this.form.hash,
-									path,
+									keyValuePairs: {
+										path,
+										fileFormat,
+									},
 								},
 							)
 							const responseData = OcsResponse2Data(response)
@@ -581,9 +590,15 @@ export default {
 						try {
 							const response = await axios.post(
 								generateOcsUrl(
-									'apps/forms/api/v2.4/submissions/export',
+									'apps/forms/api/v3/forms/{id}/submissions/export',
+									{
+										id: this.form.id,
+									},
 								),
-								{ hash: this.form.hash, path, fileFormat },
+								{
+									path,
+									fileFormat,
+								},
 							)
 							showSuccess(
 								t('forms', 'Export successful to {file}', {
@@ -608,7 +623,7 @@ export default {
 
 		async fetchLinkedFileInfo() {
 			const response = await axios.get(
-				generateOcsUrl('apps/forms/api/v2.4/form/{id}', {
+				generateOcsUrl('apps/forms/api/v3/forms/{id}', {
 					id: this.form.id,
 				}),
 			)
@@ -628,9 +643,13 @@ export default {
 			}
 			try {
 				const response = await axios.post(
-					generateOcsUrl('apps/forms/api/v2.4/submissions/export'),
+					generateOcsUrl(
+						'apps/forms/api/v3/forms/{id}/submissions/export',
+						{
+							id: this.form.id,
+						},
+					),
 					{
-						hash: this.form.hash,
 						path: this.form.filePath,
 						fileFormat: this.form.fileFormat,
 					},
@@ -651,7 +670,13 @@ export default {
 
 			try {
 				await axios.delete(
-					generateOcsUrl('apps/forms/api/v2.4/submission/{id}', { id }),
+					generateOcsUrl(
+						'apps/forms/api/v3/forms/{id}/submissions/{submissionId}',
+						{
+							id: this.form.id,
+							submissionId: id,
+						},
+					),
 				)
 				showSuccess(t('forms', 'Submission deleted'))
 				const index = this.form.submissions.findIndex(
@@ -678,8 +703,8 @@ export default {
 			this.loadingResults = true
 			try {
 				await axios.delete(
-					generateOcsUrl('apps/forms/api/v2.4/submissions/{formId}', {
-						formId: this.form.id,
+					generateOcsUrl('apps/forms/api/v3/forms/{id}/submissions', {
+						id: this.form.id,
 					}),
 				)
 				this.form.submissions = []

--- a/src/views/Submit.vue
+++ b/src/views/Submit.vue
@@ -624,9 +624,10 @@ export default {
 
 			try {
 				await axios.post(
-					generateOcsUrl('apps/forms/api/v2.4/submission/insert'),
+					generateOcsUrl('apps/forms/api/v3/forms/{id}/submissions', {
+						id: this.form.id,
+					}),
 					{
-						formId: this.form.id,
 						answers: this.answers,
 						shareHash: this.shareHash,
 					},

--- a/tests/Unit/Controller/ShareApiControllerTest.php
+++ b/tests/Unit/Controller/ShareApiControllerTest.php
@@ -551,7 +551,7 @@ class ShareApiControllerTest extends TestCase {
 			->with('8');
 
 		$response = new DataResponse(8);
-		$this->assertEquals($response, $this->shareApiController->deleteShare(8));
+		$this->assertEquals($response, $this->shareApiController->deleteShare(5, 8));
 	}
 
 	/**
@@ -565,7 +565,7 @@ class ShareApiControllerTest extends TestCase {
 		;
 
 		$this->expectException(OCSBadRequestException::class);
-		$this->shareApiController->deleteShare(8);
+		$this->shareApiController->deleteShare(1, 8);
 	}
 
 	/**
@@ -589,7 +589,7 @@ class ShareApiControllerTest extends TestCase {
 			->willReturn($form);
 
 		$this->expectException(OCSForbiddenException::class);
-		$this->shareApiController->deleteShare(8);
+		$this->shareApiController->deleteShare(5, 8);
 	}
 
 	public function dataUpdateShare() {
@@ -824,10 +824,10 @@ class ShareApiControllerTest extends TestCase {
 
 		if ($exception === null) {
 			$expectedResponse = new DataResponse($expected);
-			$this->assertEquals($expectedResponse, $this->shareApiController->updateShare($share['id'], $keyValuePairs));
+			$this->assertEquals($expectedResponse, $this->shareApiController->updateShare($share['formId'], $share['id'], $keyValuePairs));
 		} else {
 			$this->expectException($exception);
-			$this->shareApiController->updateShare($share['id'], $keyValuePairs);
+			$this->shareApiController->updateShare($share['formId'], $share['id'], $keyValuePairs);
 		}
 	}
 
@@ -846,7 +846,7 @@ class ShareApiControllerTest extends TestCase {
 			->method('debug');
 
 		$this->expectException(OCSBadRequestException::class);
-		$this->shareApiController->updateShare(1337, [Constants::PERMISSION_SUBMIT]);
+		$this->shareApiController->updateShare(1, 1337, [Constants::PERMISSION_SUBMIT]);
 	}
 
 	/**
@@ -876,6 +876,6 @@ class ShareApiControllerTest extends TestCase {
 			->method('debug');
 
 		$this->expectException(OCSBadRequestException::class);
-		$this->shareApiController->updateShare(1337, [Constants::PERMISSION_SUBMIT]);
+		$this->shareApiController->updateShare(7331, 1337, [Constants::PERMISSION_SUBMIT]);
 	}
 }


### PR DESCRIPTION
This closes #2079

### Forms
- [x] Get forms `GET /forms[?type=owned]`
- [x] Get shared forms `GET /forms?type=shared`
- [x] New form `POST /forms`
- [x] Get form `GET /forms/:form-id:`
- ~~[x] Get partial form `GET /forms/0?hash=:form-hash:`~~
- [x] Clone form `POST /forms?fromId=:form-id:`
- [x] Update form `PATCH /forms/:form-id:`
- [x] Transfer ownership `- (just use patch/update)`
- [x] Delete form `DELETE /forms/:form-id:`
- [x] Link file to form `- (just use patch/update)`
- [x] Unlink file `- (just use patch/update)`

### Questions
- [x] Get questions `GET /forms/:form-id:/questions`
- [x] New question `POST /forms/:form-id:/questions`
- [x] Get question `GET /forms/:form-id:/questions/:question-id:`
- [x] Update question `PATCH /forms/:form-id:/questions/:question-id:`
- [x] Reorder questions `PATCH /forms/:form-id:/questions`
- [x] Clone question `POST /forms/:form-id:/questions?fromId=:question-id:`
- [x] Delete question `DELETE /forms/:form-id:/questions/:question-id:`

### Options
- [ ] Get options `GET /forms/:form-id:/questions/:question-id:/options` (currently not used)
- [x] New option(s) `POST /forms/:form-id:/questions/:question-id:/options`
- [ ] Get option `GET /forms/:form-id:/questions/:question-id:/options/:option-id:` (currently not used)
- [x] Update option `PATCH /forms/:form-id:/questions/:question-id:/options/:option-id:`
- [ ] Reorder options `PATCH /forms/:form-id:/questions/:question-id:/options` (currently not used)
- [ ] Clone option `POST /forms/:form-id:/questions/:question-id:/options?fromId=:option-id:` (currently not used)
- [x] Delete option `DELETE /forms/:form-id:/questions/:question-id:/options/:option-id:`

### Sharing
- [ ] Get user's shares `GET /shares` (currently not used)
- [ ] Get shares of a form `GET /forms/:form-id:/shares` (currently not used)
- [x] New share `POST /forms/:form-id:/shares`
- [ ] Get share `GET /forms/:form-id:/shares/:share-id:` (currently not used)
- [x] Update share `PATCH /forms/:form-id:/shares/:share-id:`
- [x] Delete share `DELETE /forms/:form-id:/shares/:id:`

### Submissions
- [x] Get submissions `GET /forms/:form-id:/submissions`
- [x] Download submissions `GET /forms/:form-id:/submissions?fileFormat=:file-format:`
- [x] New submission `POST /forms/:form-id:/submissions`
- [x] Delete submissions `DELETE /forms/:form-id:/submissions`
- [ ] Get submission `GET /forms/:form-id:/submissions/:submission-id:` (currently not used)
- [ ] Update submission `PATCH /forms/:form-id:/submissions/:submission-id:` (currently not used)
- [x] Delete submission `DELETE /forms/:form-id:/submissions/:submission-id:`
- [x] Export submissions to cloud `POST /forms/:form-id:/submissions/export`
- [x] Upload files `POST /forms/:form-id:/submissions/files/:question-id:`

### Documentation
- [x] Adjust documentation and mark old API v2 as deprecated