### PR TITLE
Optimization method FormsService::canSubmit

### DIFF
--- a/lib/Controller/ApiController.php
+++ b/lib/Controller/ApiController.php
@@ -1161,7 +1161,7 @@ class ApiController extends OCSController {
 
 		// Ensure the form is unique if needed.
 		// If we can not submit anymore then the submission must be unique
-		if (!$this->formsService->canSubmit($form) && !$this->submissionService->isUniqueSubmission($submission)) {
+		if (!$this->formsService->canSubmit($form) && $this->submissionMapper->hasMultipleFormSubmissionsByUser($form, $submission->getUserId())) {
 			$this->submissionMapper->delete($submission);
 			throw new OCSForbiddenException('Already submitted');
 		}

--- a/lib/Migration/Version040300Date20240708163401.php
+++ b/lib/Migration/Version040300Date20240708163401.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright Copyright (c) 2024 Andrii Ilkiv <ailkiv@users.noreply.github.com>
+ *
+ * @author Andrii Ilkiv <ailkiv@users.noreply.github.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Forms\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+class Version040300Date20240708163401 extends SimpleMigrationStep {
+	/**
+	 * @param IOutput $output
+	 * @param Closure $schemaClosure The `\Closure` returns a `ISchemaWrapper`
+	 * @param array $options
+	 * @return null|ISchemaWrapper
+	 */
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
+		/** @var ISchemaWrapper $schema */
+		$schema = $schemaClosure();
+
+		$table = $schema->getTable('forms_v2_submissions');
+		if (!$table->hasIndex('forms_submissions_form_user')) {
+			$table->addIndex(['form_id', 'user_id'], 'forms_submissions_form_user');
+		}
+
+		return $schema;
+	}
+}

--- a/lib/Service/FormsService.php
+++ b/lib/Service/FormsService.php
@@ -335,13 +335,11 @@ class FormsService {
 		}
 
 		// Refuse access, if SubmitMultiple is not set and user already has taken part.
-		if (!$form->getSubmitMultiple()) {
-			$participants = $this->submissionMapper->findParticipantsByForm($form->getId());
-			foreach ($participants as $participant) {
-				if ($participant === $this->currentUser->getUID()) {
-					return false;
-				}
-			}
+		if (
+			!$form->getSubmitMultiple() &&
+			$this->submissionMapper->hasFormSubmissionsByUser($form, $this->currentUser->getUID())
+		) {
+			return false;
 		}
 
 		return true;

--- a/lib/Service/SubmissionService.php
+++ b/lib/Service/SubmissionService.php
@@ -166,13 +166,6 @@ class SubmissionService {
 	}
 
 	/**
-	 * Validate the new submission is unique
-	 */
-	public function isUniqueSubmission(Submission $newSubmission): bool {
-		return $this->submissionMapper->countSubmissions($newSubmission->getFormId(), $newSubmission->getUserId()) === 1;
-	}
-
-	/**
 	 * Export Submissions to Cloud-Filesystem
 	 *
 	 * @param Form $form the form

--- a/tests/Unit/Db/SubmissionMapperTest.php
+++ b/tests/Unit/Db/SubmissionMapperTest.php
@@ -1,0 +1,139 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * @copyright Copyright (c) 2024 Abdrii Ilkiv <ailkiv@users.noreply.github.com>
+ *
+ * @author Abdrii Ilkiv <ailkiv@users.noreply.github.com>
+ *
+ * @license AGPL-3.0-or-later
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+namespace OCA\Forms\Tests\Unit\Db;
+
+use OCA\Forms\Db\Form;
+use OCA\Forms\Db\SubmissionMapper;
+
+use Test\TestCase;
+
+class SubmissionMapperTest extends TestCase {
+	
+	private SubmissionMapper $mockSubmissionMapper;
+
+
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->mockSubmissionMapper = $this->getMockBuilder(SubmissionMapper::class)
+					 ->disableOriginalConstructor()
+					 ->setMethods(['countSubmissionsWithFilters'])
+					 ->getMock();
+	}
+
+	/**
+	 * @dataProvider dataHasMultipleFormSubmissionsByUser
+	 */
+	public function testHasMultipleFormSubmissionsByUser(int $numberOfSubmissions, bool $expected) {
+		$this->mockSubmissionMapper->expects($this->once())
+			 ->method('countSubmissionsWithFilters')
+			 ->will($this->returnValue($numberOfSubmissions));
+
+		$form = new Form();
+		$form->setId(1);
+		
+		$this->assertEquals($expected, $this->mockSubmissionMapper->hasMultipleFormSubmissionsByUser($form, 'user1'));
+	}
+
+	public function dataHasMultipleFormSubmissionsByUser() {
+		return [
+			[
+				'numberOfSubmissions' => 0,
+				'expected' => false,
+			],
+			[
+				'numberOfSubmissions' => 1,
+				'expected' => false,
+			],
+			[
+				'numberOfSubmissions' => 2,
+				'expected' => true,
+			],
+			[
+				'numberOfSubmissions' => 3,
+				'expected' => true,
+			],
+		];
+	}
+
+	/**
+	 * @dataProvider dataHasFormSubmissionsByUser
+	 */
+	public function testHasFormSubmissionsByUser(int $numberOfSubmissions, bool $expected) {
+		$this->mockSubmissionMapper->expects($this->once())
+			 ->method('countSubmissionsWithFilters')
+			 ->will($this->returnValue($numberOfSubmissions));
+
+		$form = new Form();
+		$form->setId(1);
+		
+		$this->assertEquals($expected, $this->mockSubmissionMapper->hasFormSubmissionsByUser($form, 'user1'));
+	}
+
+	public function dataHasFormSubmissionsByUser() {
+		return [
+			[
+				'numberOfSubmissions' => 0,
+				'expected' => false,
+			],
+			[
+				'numberOfSubmissions' => 1,
+				'expected' => true,
+			],
+			[
+				'numberOfSubmissions' => 2,
+				'expected' => true,
+			],
+		];
+	}
+
+	/**
+	 * @dataProvider dataCountSubmissions
+	 */
+	public function testCountSubmissions(int $numberOfSubmissions, int $expected) {
+		$this->mockSubmissionMapper->expects($this->once())
+			 ->method('countSubmissionsWithFilters')
+			 ->will($this->returnValue($numberOfSubmissions));
+
+		$this->assertEquals($expected, $this->mockSubmissionMapper->countSubmissions(1));
+	}
+
+	public function dataCountSubmissions() {
+		return [
+			[
+				'numberOfSubmissions' => 0,
+				'expected' => 0,
+			],
+			[
+				'numberOfSubmissions' => 1,
+				'expected' => 1,
+			],
+			[
+				'numberOfSubmissions' => 20,
+				'expected' => 20,
+			],
+		];
+	}
+}

--- a/tests/Unit/Service/FormsServiceTest.php
+++ b/tests/Unit/Service/FormsServiceTest.php
@@ -802,25 +802,25 @@ class FormsServiceTest extends TestCase {
 			'allowFormOwner' => [
 				'ownerId' => 'currentUser',
 				'submitMultiple' => false,
-				'participantsArray' => ['currentUser'],
+				'hasFormSubmissionsByUser' => true,
 				'expected' => true
 			],
 			'submitMultipleGood' => [
 				'ownerId' => 'someUser',
 				'submitMultiple' => false,
-				'participantsArray' => ['notCurrentUser'],
+				'hasFormSubmissionsByUser' => false,
 				'expected' => true
 			],
 			'submitMultipleNotGood' => [
 				'ownerId' => 'someUser',
 				'submitMultiple' => false,
-				'participantsArray' => ['notCurrentUser', 'currentUser'],
+				'hasFormSubmissionsByUser' => true,
 				'expected' => false
 			],
 			'submitMultiple' => [
 				'ownerId' => 'someUser',
 				'submitMultiple' => true,
-				'participantsArray' => ['currentUser'],
+				'hasFormSubmissionsByUser' => true,
 				'expected' => true
 			]
 		];
@@ -830,10 +830,10 @@ class FormsServiceTest extends TestCase {
 	 *
 	 * @param string $ownerId
 	 * @param bool $submitMultiple
-	 * @param array $participantsArray
+	 * @param bool $hasFormSubmissionsByUser
 	 * @param bool $expected
 	 */
-	public function testCanSubmit(string $ownerId, bool $submitMultiple, array $participantsArray, bool $expected) {
+	public function testCanSubmit(string $ownerId, bool $submitMultiple, bool $hasFormSubmissionsByUser, bool $expected) {
 		$form = new Form();
 		$form->setId(42);
 		$form->setAccess([
@@ -844,9 +844,9 @@ class FormsServiceTest extends TestCase {
 		$form->setSubmitMultiple($submitMultiple);
 
 		$this->submissionMapper->expects($this->any())
-			->method('findParticipantsByForm')
-			->with(42)
-			->willReturn($participantsArray);
+			->method('hasFormSubmissionsByUser')
+			->with($form, 'currentUser')
+			->willReturn($hasFormSubmissionsByUser);
 
 		$this->assertEquals($expected, $this->formsService->canSubmit($form));
 	}

--- a/tests/Unit/Service/SubmissionServiceTest.php
+++ b/tests/Unit/Service/SubmissionServiceTest.php
@@ -153,41 +153,6 @@ class SubmissionServiceTest extends TestCase {
 		);
 	}
 
-	/**
-	 * @dataProvider dataIsUniqueSubmission
-	 */
-	public function testIsUniqueSubmission(array $submissionData, int $numberOfSubmissions, bool $expected) {
-		$this->submissionMapper->method('countSubmissions')
-			->with($submissionData['formId'], $submissionData['userId'])
-			->willReturn($numberOfSubmissions);
-
-		$submission = Submission::fromParams($submissionData);
-		$this->assertEquals($expected, $this->submissionService->isUniqueSubmission($submission));
-	}
-
-	public function dataIsUniqueSubmission() {
-		return [
-			[
-				'submissionData' => [
-					'id' => 1,
-					'userId' => 'user',
-					'formId' => 1,
-				],
-				'numberOfSubmissions' => 1,
-				'expected' => true,
-			],
-			[
-				'submissionData' => [
-					'id' => 3,
-					'userId' => 'user',
-					'formId' => 1,
-				],
-				'numberOfSubmissions' => 2,
-				'expected' => false,
-			],
-		];
-	}
-
 	public function testGetSubmissions() {
 		$submission_1 = new Submission();
 		$submission_1->setId(42);


### PR DESCRIPTION
Currently, to check if a user has filled out the form, all entities are retrieved, and then two loops are performed at the PHP. My version does the same thing but with a single simple query.