### PR TITLE
fix: Fix merging of options for cancelable request

### DIFF
--- a/src/utils/CancelableRequest.js
+++ b/src/utils/CancelableRequest.js
@@ -45,7 +45,7 @@ const CancelableRequest = function (request) {
 	const fetch = async function (url, options) {
 		return request(
 			url,
-			Object.assign({ cancelToken: source.token }, { options }),
+			Object.assign({ cancelToken: source.token }, { ...options }),
 		)
 	}
 	return {


### PR DESCRIPTION
I'm using this `CancelableRequest` for own needs but it has a bug with merging options. Here an reproducer:

```js
// Create new cancelable get request
const { request, cancel } = CancelableRequest(async function(url, requestOptions) {
	return axios.get(url, requestOptions)
})

const response = await request(generateOcsUrl('apps/forms/api/v2.4/form/{id}', { id }), {params: {tenant}})
```

the problem is that merging of options merges extra options under `options` key instead of it merging all keys and values.