### PR TITLE
fix: ignore composer.lock in prettier

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -16,3 +16,4 @@ l10n/
 # PHP
 lib/
 **/*.php
+composer.lock


### PR DESCRIPTION
Actually `composer.lock` is autogenerated file by Composer. There is no any sense to re-format it. This is not a code that we control.

At the same time we can add [composer-normalize](https://github.com/ergebnis/composer-normalize) plugin to unify `compser.json` if it needed