### PR TITLE
feat: Allow listening to form submissions via events and webhooks

### DIFF
--- a/lib/Controller/ApiController.php
+++ b/lib/Controller/ApiController.php
@@ -1092,7 +1092,7 @@ class ApiController extends OCSController {
 		$this->formsService->setLastUpdatedTimestamp($formId);
 
 		//Create Activity
-		$this->formsService->notifyNewSubmission($form, $submission->getUserId());
+		$this->formsService->notifyNewSubmission($form, $submission);
 
 		if ($form->getFileId() !== null) {
 			try {
@@ -2362,7 +2362,7 @@ class ApiController extends OCSController {
 		$this->formsService->setLastUpdatedTimestamp($formId);
 
 		//Create Activity
-		$this->formsService->notifyNewSubmission($form, $submission->getUserId());
+		$this->formsService->notifyNewSubmission($form, $submission);
 
 		if ($form->getFileId() !== null) {
 			try {

--- a/lib/Events/AbstractFormEvent.php
+++ b/lib/Events/AbstractFormEvent.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace OCA\Forms\Events;
+
+use OCA\Forms\Db\Form;
+use OCP\EventDispatcher\Event;
+use OCP\EventDispatcher\IWebhookCompatibleEvent;
+
+if (interface_exists(\OCP\EventDispatcher\IWebhookCompatibleEvent::class)) {
+	abstract class AbstractFormEvent extends Event implements IWebhookCompatibleEvent {
+		public function __construct(
+			protected Form $form,
+		) {
+			parent::__construct();
+		}
+
+		public function getForm(): Form {
+			return $this->form;
+		}
+
+		/**
+		 * @inheritDoc
+		 */
+		public function getWebhookSerializable(): array {
+			return $this->form->read();
+		}
+	}
+
+} else {
+	// need this block as long as NC < 30 is supported
+	abstract class AbstractFormEvent extends Event {
+		public function __construct(
+			protected Form $form,
+		) {
+			parent::__construct();
+		}
+
+		public function getForm(): Form {
+			return $this->form;
+		}
+
+		public function getWebhookSerializable(): array {
+			return $this->form->read();
+		}
+	}
+}

--- a/lib/Events/FormSubmittedEvent.php
+++ b/lib/Events/FormSubmittedEvent.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace OCA\Forms\Events;
+
+use OCA\Forms\Db\Form;
+use OCA\Forms\Db\Submission;
+
+class FormSubmittedEvent extends AbstractFormEvent {
+	public function __construct(
+		Form $form,
+		private Submission $submission,
+	) {
+		parent::__construct($form);
+	}
+
+	public function getWebhookSerializable(): array {
+		return [
+			'form' => $this->form->read(),
+			'submission' => $this->submission->read(),
+		];
+	}
+}

--- a/tests/Unit/Controller/ApiControllerTest.php
+++ b/tests/Unit/Controller/ApiControllerTest.php
@@ -846,8 +846,7 @@ class ApiControllerTest extends TestCase {
 			->with(1);
 
 		$this->formsService->expects($this->once())
-			->method('notifyNewSubmission')
-			->with($form, 'currentUser');
+			->method('notifyNewSubmission');
 
 		$this->formsService->expects($this->once())
 			->method('getFilePath')


### PR DESCRIPTION
requires Nextcloud 30

This will allow users of the upcoming windmill workflow automation app to trigger automations based on form submissions.