### PR TITLE
fix: Fix form view without permissions

### DIFF
--- a/src/Forms.vue
+++ b/src/Forms.vue
@@ -430,6 +430,10 @@ export default {
 				} catch (error) {
 					logger.error(`Form ${hash} not found`, { error })
 					showError(t('forms', 'Form not found'))
+
+					if ([403, 404].includes(error.response?.status)) {
+						this.$router.push({ name: 'root' })
+					}
 				}
 			}
 


### PR DESCRIPTION
Reproducer:
1. Create form (without sharing)
2. Copy internal link
3. Open internal link by another user

Expected result:
- Error is shown once

Actual result:
- There are a lot of http requests and multiple errors
  <details><summary>:mag: Preview </summary>
  <p>

  ![image](https://github.com/user-attachments/assets/90247aa0-56ce-4e7c-ad58-8b17389f254a)

  </p>
  </details>

So, now after receiving http 403/404 error we are showing an error and got redirected to main page
  <details><summary>:mag: Preview </summary>
  <p>

![image](https://github.com/user-attachments/assets/a370f61d-c513-40d3-aa81-c7476619bacc)

  </p>
  </details>
