### PR TITLE
feat: add warning about removing legacy links

### DIFF
--- a/CHANGELOG.en.md
+++ b/CHANGELOG.en.md
@@ -1,0 +1,23 @@
+# Changelog
+
+## v4.3.0 - 2024-09-13
+
+-   **New question type: Files**
+
+    You can now ask for file uploads in your forms!
+
+-   **Share your forms via QR code**
+
+    Get a QR code representation of your public share link!
+
+-   **Set limits for your checkbox questions**
+
+    Ask for a minimum/maximum number of answers!
+
+-   **Add many options at once**
+
+    It's now way easier to add a lot of options to your checkbox/dropdown/radio questions!
+
+-   **Deprecation of legacy links**
+
+    Legacy share links will be removed in v5.0 of Forms. Forms with such links will show a warning in edit and submit view.

--- a/src/components/SidebarTabs/SharingSidebarTab.vue
+++ b/src/components/SidebarTabs/SharingSidebarTab.vue
@@ -130,7 +130,7 @@
 				v-tooltip="
 					t(
 						'forms',
-						'For compatibility with the old Sharing, the internal link is still usable as Share link. We recommend replacing the link with a new Share link.',
+						'For compatibility with the old Sharing, the internal link is still usable as Share link. Please replace the link with a new Share link. The internal sharing link will not work anymore starting with Forms 5.0',
 					)
 				"
 				class="share-div__legacy-warning">

--- a/src/views/Create.vue
+++ b/src/views/Create.vue
@@ -104,6 +104,19 @@
 				<p v-if="infoMessage" class="info-message">
 					{{ infoMessage }}
 				</p>
+				<!-- TODO: remove with Forms 5.0
+				 Show info about legacyLink that will be removed -->
+				<NcNoteCard
+					v-if="form.access.legacyLink"
+					type="warning"
+					:heading="t('forms', 'Legacy link in use')">
+					{{
+						t(
+							'forms',
+							'This form still uses a deprecated share link, that will be removed in Forms 5.0. Please use the new sharing mechanism.',
+						)
+					}}
+				</NcNoteCard>
 			</header>
 
 			<section>
@@ -186,6 +199,7 @@ import NcActions from '@nextcloud/vue/dist/Components/NcActions.js'
 import NcAppContent from '@nextcloud/vue/dist/Components/NcAppContent.js'
 import NcEmptyContent from '@nextcloud/vue/dist/Components/NcEmptyContent.js'
 import NcLoadingIcon from '@nextcloud/vue/dist/Components/NcLoadingIcon.js'
+import NcNoteCard from '@nextcloud/vue/dist/Components/NcNoteCard.js'
 import IconLock from 'vue-material-design-icons/Lock.vue'
 import IconPlus from 'vue-material-design-icons/Plus.vue'
 
@@ -214,6 +228,7 @@ export default {
 		NcAppContent,
 		NcEmptyContent,
 		NcLoadingIcon,
+		NcNoteCard,
 		Question,
 		QuestionLong,
 		QuestionShort,

--- a/src/views/Submit.vue
+++ b/src/views/Submit.vue
@@ -62,6 +62,19 @@
 				<p v-if="infoMessage" class="info-message">
 					{{ infoMessage }}
 				</p>
+				<!-- TODO: remove with Forms 5.0
+				 Show info about legacyLink that will be removed -->
+				<NcNoteCard
+					v-if="form.access.legacyLink"
+					type="warning"
+					:heading="t('forms', 'Legacy link in use')">
+					{{
+						t(
+							'forms',
+							'This form still uses a deprecated share link, that will be removed in Forms 5.0. Please use the new sharing mechanism.',
+						)
+					}}
+				</NcNoteCard>
 			</header>
 
 			<NcEmptyContent
@@ -179,6 +192,7 @@ import NcDialog from '@nextcloud/vue/dist/Components/NcDialog.js'
 import NcEmptyContent from '@nextcloud/vue/dist/Components/NcEmptyContent.js'
 import NcLoadingIcon from '@nextcloud/vue/dist/Components/NcLoadingIcon.js'
 import NcIconSvgWrapper from '@nextcloud/vue/dist/Components/NcIconSvgWrapper.js'
+import NcNoteCard from '@nextcloud/vue/dist/Components/NcNoteCard.js'
 
 import IconCancelSvg from '@mdi/svg/svg/cancel.svg?raw'
 import IconCheckSvg from '@mdi/svg/svg/check.svg?raw'
@@ -204,6 +218,7 @@ export default {
 		NcEmptyContent,
 		NcLoadingIcon,
 		NcIconSvgWrapper,
+		NcNoteCard,
 		Question,
 		QuestionLong,
 		QuestionShort,


### PR DESCRIPTION
This fixes #2071 by adding a warning NoteCard to submit/create view for forms with legacyLink enabled.

![grafik](https://github.com/user-attachments/assets/8c5594d5-4620-48bc-a0c4-c959bbf1a56a)

Signed-off-by: Christian Hartmann <chris-hartmann@gmx.de>