### PR TITLE
fix: add `target="_blank"` to links in description

### DIFF
--- a/src/mixins/ViewsMixin.js
+++ b/src/mixins/ViewsMixin.js
@@ -83,6 +83,27 @@ export default {
 		},
 
 		formDescription() {
+			// Remember the old renderer if overridden, or proxy to the default renderer.
+			const defaultRender =
+				this.markdownit.renderer.rules.link_open ||
+				function (tokens, idx, options, env, self) {
+					return self.renderToken(tokens, idx, options)
+				}
+
+			this.markdownit.renderer.rules.link_open = function (
+				tokens,
+				idx,
+				options,
+				env,
+				self,
+			) {
+				// Add a new `target` attribute, or replace the value of the existing one.
+				tokens[idx].attrSet('target', '_blank')
+
+				// Pass the token to the default renderer.
+				return defaultRender(tokens, idx, options, env, self)
+			}
+
 			return (
 				this.markdownit.render(this.form.description) ||
 				this.form.description


### PR DESCRIPTION
This closes #1680 by adding a default target `_blank` to the markdown link renderer.

Code is from example here: https://github.com/markdown-it/markdown-it/blob/master/docs/architecture.md#renderer

Signed-off-by: Christian Hartmann <chris-hartmann@gmx.de>