### PR TITLE
test: Add e2e tests for form description

### DIFF
--- a/playwright/e2e/form-description.spec.ts
+++ b/playwright/e2e/form-description.spec.ts
@@ -1,0 +1,100 @@
+/**
+ * SPDX-FileCopyrightText: 2024 Ferdinand Thiessen <opensource@fthiessen.de>
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { expect, mergeTests } from '@playwright/test'
+import { test as randomUserTest } from '../support/fixtures/random-user'
+import { test as appNavigationTest } from '../support/fixtures/navigation'
+import { test as topBarTest } from '../support/fixtures/topBar'
+import { test as formTest } from '../support/fixtures/form'
+import { FormsView } from '../support/sections/TopBarSection'
+
+const test = mergeTests(randomUserTest, appNavigationTest, formTest, topBarTest)
+
+test.beforeEach(async ({ page }) => {
+	await page.goto('apps/forms')
+	await page.waitForURL(/apps\/forms$/)
+})
+
+test.describe('Form description', () => {
+	test('Can edit the description', async ({
+		appNavigation,
+		form,
+		topBar,
+		page,
+	}) => {
+		await appNavigation.clickNewForm()
+		await form.fillTitle('Test form')
+
+		await form.fillDescription('Hello this is an example')
+
+		await topBar.toggleView(FormsView.View)
+
+		await expect(page.locator('.form-desc')).toContainText(
+			'Hello this is an example',
+		)
+	})
+
+	test('Can use Markdown in the description', async ({
+		appNavigation,
+		form,
+		topBar,
+		page,
+	}) => {
+		await appNavigation.clickNewForm()
+		await form.fillTitle('Test form')
+
+		await form.fillDescription('Hello **this** is an example')
+
+		await topBar.toggleView(FormsView.View)
+
+		await expect(page.locator('.form-desc')).toContainText(
+			'Hello this is an example',
+		)
+		await expect(page.locator('.form-desc').locator('strong')).toContainText(
+			'this',
+		)
+	})
+
+	test(
+		'Markdown links are opened in a new tab',
+		{
+			annotation: {
+				type: 'issue',
+				description: 'https://github.com/nextcloud/forms/issues/1680',
+			},
+		},
+		async ({ appNavigation, form, topBar, page }) => {
+			await appNavigation.clickNewForm()
+			await form.fillTitle('Test form')
+
+			await form.fillDescription('The link: [link-name](http://example.com)')
+
+			await topBar.toggleView(FormsView.View)
+
+			await expect(page.locator('.form-desc')).toContainText(
+				'The link: link-name',
+			)
+			const link = page.locator('.form-desc').getByRole('link')
+
+			await expect(link).toContainText('link-name')
+			await expect(link).toHaveAttribute('href', 'http://example.com')
+			await expect(link).toHaveAttribute('target', '_blank')
+
+			// check opening works
+			// lets mock the response to not need to query that server for real
+			page.context().route(/example\.com/, (route) =>
+				route.fulfill({
+					body: '<!doctype html><meta charset=utf-8><title>success</title>',
+					status: 200,
+					contentType: 'text/html; charset=utf-8',
+				}),
+			)
+			const pagePromise = page.context().waitForEvent('page', {})
+			await link.click()
+			const newPage = await pagePromise
+			await expect(newPage).toHaveTitle('success')
+		},
+	)
+})

--- a/playwright/support/fixtures/topBar.ts
+++ b/playwright/support/fixtures/topBar.ts
@@ -1,0 +1,18 @@
+/**
+ * SPDX-FileCopyrightText: 2024 Ferdinand Thiessen <opensource@fthiessen.de>
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { test as baseTest } from '@playwright/test'
+import { TopBarSection } from '../sections/TopBarSection'
+
+interface TopBarFixture {
+	topBar: TopBarSection
+}
+
+export const test = baseTest.extend<TopBarFixture>({
+	topBar: async ({ page }, use) => {
+		const form = new TopBarSection(page)
+		await use(form)
+	},
+})

--- a/playwright/support/sections/TopBarSection.ts
+++ b/playwright/support/sections/TopBarSection.ts
@@ -1,0 +1,38 @@
+/**
+ * SPDX-FileCopyrightText: 2024 Ferdinand Thiessen <opensource@fthiessen.de>
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import type { Locator, Page } from '@playwright/test'
+
+export enum FormsView {
+	View = 'View',
+	Edit = 'Edit',
+	Results = 'Results',
+}
+
+export class TopBarSection {
+	public readonly toolbar: Locator
+
+	// eslint-disable-next-line no-useless-constructor
+	constructor(public readonly page: Page) {
+		this.toolbar = this.page.getByRole('toolbar', { name: 'View mode' })
+	}
+
+	public async getActiveView(): Promise<Locator> {
+		return this.toolbar.getByRole('radio', { checked: true })
+	}
+
+	public async getAllViews(): Promise<Locator> {
+		return this.toolbar.getByRole('radio')
+	}
+
+	public async toggleView(view: FormsView): Promise<void> {
+		const radio = this.toolbar.getByRole('radio', { name: view })
+		if (await radio.isChecked()) {
+			return
+		}
+		await radio.check({ force: true }) // force is needed as the input element is hidden behind the icon
+		await this.page.waitForURL(/\/submit$/)
+	}
+}

--- a/src/components/TopBar.vue
+++ b/src/components/TopBar.vue
@@ -21,6 +21,7 @@
   -->
 <template>
 	<div
+		:aria-label="t('forms', 'View mode')"
 		class="top-bar"
 		:class="{
 			'top-bar--has-sidebar': sidebarOpened,
@@ -60,6 +61,7 @@
 
 <script>
 import { mdiEye, mdiPencil, mdiPoll } from '@mdi/js'
+import { t } from '@nextcloud/l10n'
 import { useIsMobile } from '@nextcloud/vue'
 
 import NcButton from '@nextcloud/vue/dist/Components/NcButton.js'
@@ -118,6 +120,8 @@ export default {
 
 	setup() {
 		return {
+			t,
+
 			isMobile: useIsMobile(),
 		}
 	},


### PR DESCRIPTION
Added general tests and a regression test for https://github.com/nextcloud/forms/pull/2280

BTW if you wonder what the `annotation` in the test case description is good for: It provides this nice link if you view the results and wonder why that test was added ^^

![image](https://github.com/user-attachments/assets/1fb8f580-b92f-4ed9-911d-43c804156bc0)
