### PR TITLE
fix(submit): `access` is unset for public forms so check for existance first

### DIFF
--- a/src/views/Submit.vue
+++ b/src/views/Submit.vue
@@ -65,7 +65,7 @@
 				<!-- TODO: remove with Forms 5.0
 				 Show info about legacyLink that will be removed -->
 				<NcNoteCard
-					v-if="form.access.legacyLink"
+					v-if="form.access?.legacyLink"
 					type="warning"
 					:heading="t('forms', 'Legacy link in use')">
 					{{


### PR DESCRIPTION
On public forms `form.access` is undefined to optional chain the access to `legacyLink`