### PR TITLE
fix: Allow guests to open public pages again

### DIFF
--- a/lib/Activity/ActivityManager.php
+++ b/lib/Activity/ActivityManager.php
@@ -35,8 +35,8 @@ use OCP\Share\IShare;
 use Psr\Log\LoggerInterface;
 
 class ActivityManager {
-	private IUser $currentUser;
-	
+	private ?IUser $currentUser;
+
 	public function __construct(
 		protected string $appName,
 		private IManager $manager,

--- a/lib/Service/ConfigService.php
+++ b/lib/Service/ConfigService.php
@@ -36,8 +36,8 @@ use OCP\IUserSession;
 use Psr\Log\LoggerInterface;
 
 class ConfigService {
-	private IUser $currentUser;
-		
+	private ?IUser $currentUser;
+
 	public function __construct(
 		protected string $appName,
 		private IConfig $config,
@@ -110,6 +110,10 @@ class ConfigService {
 		// Restriction active or not
 		if (!$this->getRestrictCreation()) {
 			return true;
+		}
+
+		if ($this->currentUser === null) {
+			return false;
 		}
 
 		$userGroups = $this->groupManager->getUserGroupIds($this->currentUser);


### PR DESCRIPTION
### Steps

1. Create a public form
2. Open it as a guest
3. :boom: 

```
Cannot assign null to property OCA\Forms\Service\ConfigService::$currentUser of type OCP\IUser

// After fixing that
Cannot assign null to property OCA\Forms\Activity\ActivityManager::$currentUser of type OCP\IUser
```

Not sure if you want to apply some hardening to prevent methods from calling things on `currentUser` which can be null now, so please take over @susnux 