### PR TITLE
enh: make show to all users an admin setting

### DIFF
--- a/lib/Constants.php
+++ b/lib/Constants.php
@@ -31,11 +31,13 @@ class Constants {
 	 */
 	public const CONFIG_KEY_ALLOWPERMITALL = 'allowPermitAll';
 	public const CONFIG_KEY_ALLOWPUBLICLINK = 'allowPublicLink';
+	public const CONFIG_KEY_ALLOWSHOWTOALL = 'allowShowToAll';
 	public const CONFIG_KEY_CREATIONALLOWEDGROUPS = 'creationAllowedGroups';
 	public const CONFIG_KEY_RESTRICTCREATION = 'restrictCreation';
 	public const CONFIG_KEYS = [
 		self::CONFIG_KEY_ALLOWPERMITALL,
 		self::CONFIG_KEY_ALLOWPUBLICLINK,
+		self::CONFIG_KEY_ALLOWSHOWTOALL,
 		self::CONFIG_KEY_CREATIONALLOWEDGROUPS,
 		self::CONFIG_KEY_RESTRICTCREATION
 	];

--- a/lib/Service/ConfigService.php
+++ b/lib/Service/ConfigService.php
@@ -57,6 +57,9 @@ class ConfigService {
 	public function getAllowPublicLink(): bool {
 		return json_decode($this->config->getAppValue($this->appName, Constants::CONFIG_KEY_ALLOWPUBLICLINK, 'true'));
 	}
+	public function getAllowShowToAll() : bool {
+		return json_decode($this->config->getAppValue($this->appName, Constants::CONFIG_KEY_ALLOWSHOWTOALL, 'true'));
+	}
 	private function getUnformattedCreationAllowedGroups(): array {
 		return json_decode($this->config->getAppValue($this->appName, Constants::CONFIG_KEY_CREATIONALLOWEDGROUPS, '[]'));
 	}
@@ -74,6 +77,7 @@ class ConfigService {
 		return [
 			Constants::CONFIG_KEY_ALLOWPERMITALL => $this->getAllowPermitAll(),
 			Constants::CONFIG_KEY_ALLOWPUBLICLINK => $this->getAllowPublicLink(),
+			Constants::CONFIG_KEY_ALLOWSHOWTOALL => $this->getAllowShowToAll(),
 			Constants::CONFIG_KEY_CREATIONALLOWEDGROUPS => $this->getCreationAllowedGroups(),
 			Constants::CONFIG_KEY_RESTRICTCREATION => $this->getRestrictCreation(),
 

--- a/lib/Service/FormsService.php
+++ b/lib/Service/FormsService.php
@@ -465,6 +465,14 @@ class FormsService {
 			return false;
 		}
 
+		// Shown if permitall and showntoall are both set.
+		if ($form->getAccess()['permitAllUsers'] &&
+			$form->getAccess()['showToAllUsers'] &&
+			$this->configService->getAllowPermitAll() &&
+			$this->configService->getAllowShowToAll()) {
+
+			return true;
+		}
 		return true;
 	}
 

--- a/src/FormsSettings.vue
+++ b/src/FormsSettings.vue
@@ -56,6 +56,18 @@
 				@update:checked="onAllowPermitAllChange">
 				{{ t('forms', 'Allow sharing to all logged in accounts') }}
 			</NcCheckboxRadioSwitch>
+			<NcCheckboxRadioSwitch
+				ref="switchAllowShowToAll"
+				:checked.sync="appConfig.allowShowToAll"
+				type="switch"
+				@update:checked="onAllowShowToAllChange">
+				{{
+					t(
+						'forms',
+						'Allow showing form to all logged in accounts on sidebar',
+					)
+				}}
+			</NcCheckboxRadioSwitch>
 		</NcSettingsSection>
 	</div>
 </template>
@@ -122,6 +134,12 @@ export default {
 			const el = this.$refs.switchAllowPermitAll
 			el.loading = true
 			await this.saveAppConfig('allowPermitAll', newVal)
+			el.loading = false
+		},
+		async onAllowShowToAllChange(newVal) {
+			const el = this.$refs.switchAllowShowToAll
+			el.loading = true
+			await this.saveAppConfig('allowShowToAll', newVal)
 			el.loading = false
 		},
 

--- a/src/components/SidebarTabs/SharingSidebarTab.vue
+++ b/src/components/SidebarTabs/SharingSidebarTab.vue
@@ -190,7 +190,7 @@
 					@update:checked="onPermitAllUsersChange" />
 			</div>
 			<div
-				v-if="form.access.permitAllUsers"
+				v-if="appConfig.allowShowToAll && form.access.permitAllUsers"
 				class="share-div share-div--indent">
 				<div class="share-div__avatar">
 					<FormsIcon :size="16" />

--- a/tests/Unit/Controller/ConfigControllerTest.php
+++ b/tests/Unit/Controller/ConfigControllerTest.php
@@ -91,6 +91,11 @@ class ConfigControllerTest extends TestCase {
 				'configValue' => true,
 				'strConfig' => 'true'
 			],
+			'booleanConfig' => [
+				'configKey' => 'allowShowToAll',
+				'configValue' => true,
+				'strConfig' => 'true'
+			],
 			'arrayConfig' => [
 				'configKey' => 'allowPermitAll',
 				'configValue' => [

--- a/tests/Unit/Service/ConfigServiceTest.php
+++ b/tests/Unit/Service/ConfigServiceTest.php
@@ -85,6 +85,7 @@ class ConfigServiceTest extends TestCase {
 				'strConfig' => [
 					'allowPermitAll' => 'false',
 					'allowPublicLink' => 'false',
+					'allowShowToAll' => 'false',
 					'creationAllowedGroups' => '["group1", "group2", "nonExisting"]',
 					'restrictCreation' => 'true',
 				],
@@ -95,6 +96,7 @@ class ConfigServiceTest extends TestCase {
 				'expected' => [
 					'allowPermitAll' => false,
 					'allowPublicLink' => false,
+					'allowShowToAll' => false,
 					'creationAllowedGroups' => [
 						[
 							'groupId' => 'group1',
@@ -157,9 +159,9 @@ class ConfigServiceTest extends TestCase {
 				'expected' => [
 					'allowPermitAll' => true,
 					'allowPublicLink' => true,
+					'allowShowToAll' => true,
 					'creationAllowedGroups' => [],
 					'restrictCreation' => false,
-
 					'canCreateForms' => true
 				]
 			]


### PR DESCRIPTION
- Permit to all can be controlled by an admin setting
- Makes sense to me to control also "show to all" using an admin setting

Replaces original PR #1906 by @akhil1508 where we didn't get any response anymore