### PR TITLE
fix(export): remove new lines from form title in the exported filename

### DIFF
--- a/lib/Service/FormsService.php
+++ b/lib/Service/FormsService.php
@@ -56,7 +56,7 @@ use OCP\Share\IShare;
  */
 class FormsService {
 	private ?IUser $currentUser;
-	
+
 	public function __construct(
 		IUserSession $userSession,
 		private ActivityManager $activityManager,
@@ -780,6 +780,6 @@ class FormsService {
 	}
 
 	private static function normalizeFileName(string $fileName): string {
-		return str_replace(mb_str_split(\OCP\Constants::FILENAME_INVALID_CHARS), '-', $fileName);
+		return str_replace([...mb_str_split(\OCP\Constants::FILENAME_INVALID_CHARS), "\n"], '-', $fileName);
 	}
 }

--- a/tests/Unit/Service/FormsServiceTest.php
+++ b/tests/Unit/Service/FormsServiceTest.php
@@ -1445,6 +1445,13 @@ class FormsServiceTest extends TestCase {
 		$this->formsService->getFileName($form, 'dummy');
 	}
 
+	public function testGetFileNameReplacesNewLines() {
+		$form = new Form();
+		$form->setTitle("Form \n new line");
+
+		$this->assertSame('Form - new line (responses).xlsx', $this->formsService->getFileName($form, 'xlsx'));
+	}
+
 	public function testGetFileName() {
 		$form = new Form();
 		$form->setTitle('Form 1');


### PR DESCRIPTION
See https://github.com/nextcloud/forms/pull/1758#issuecomment-1931252574

Even though new lines are valid POSIX, let's avoid them (because it seems Nextcloud Files really doesn't like them in filenames).