### PR TITLE
fix: show expiration message again in submit view

### DIFF
--- a/src/views/Submit.vue
+++ b/src/views/Submit.vue
@@ -55,7 +55,8 @@
 					class="form-desc"
 					dir="auto"
 					v-html="formDescription" />
-				<p v-if="isExpired" class="info-message">
+				<!-- Show expiration message-->
+				<p v-if="form.expires && form.showExpiration" class="info-message">
 					{{ expirationMessage }}
 				</p>
 				<!-- Generate form information message-->


### PR DESCRIPTION
This fixes a regression introduced by #1925 and shows the expiration in the submit view correctly again

Signed-off-by: GitHub <noreply@github.com>