### PR TITLE
fix: Update transfer ownership logic

### DIFF
--- a/src/components/SidebarTabs/TransferOwnership.vue
+++ b/src/components/SidebarTabs/TransferOwnership.vue
@@ -188,7 +188,9 @@ export default {
 							id: this.form.id,
 						}),
 						{
-							ownerId: this.selected.shareWith,
+							keyValuePairs: {
+								ownerId: this.selected.shareWith,
+							},
 						},
 					)
 					showSuccess(


### PR DESCRIPTION
This commit fixes #2370. Instead of directly assigning the ownerId, it now uses keyValuePairs to pass the ownerId as a key-value pair.

Signed-off-by: GitHub <noreply@github.com>