### PR TITLE
(fix) default timezone for export

### DIFF
--- a/lib/Service/SubmissionService.php
+++ b/lib/Service/SubmissionService.php
@@ -207,7 +207,7 @@ class SubmissionService {
 		$submissionEntities = array_reverse($submissionEntities);
 
 		$questions = $this->questionMapper->findByForm($form->getId());
-		$defaultTimeZone = date_default_timezone_get();
+		$defaultTimeZone = $this->config->getSystemValueString('default_timezone', 'UTC');
 
 		if (!$this->currentUser) {
 			$userTimezone = $this->config->getUserValue($form->getOwnerId(), 'core', 'timezone', $defaultTimeZone);

--- a/tests/Unit/Service/SubmissionServiceTest.php
+++ b/tests/Unit/Service/SubmissionServiceTest.php
@@ -579,7 +579,11 @@ file2.txt"
 				return $questionEntities;
 			}));
 
-		date_default_timezone_set('Europe/Berlin');
+		$this->config->expects($this->once())
+			->method('getSystemValueString')
+			->with('default_timezone', 'UTC')
+			->willReturn('Europe/Berlin');
+
 		$this->config->expects($this->once())
 			->method('getUserValue')
 			->with('currentUser', 'core', 'timezone', 'Europe/Berlin')


### PR DESCRIPTION
In the server/lib/base.php file of the Nextcloud server, UTC is always set as the default timezone:

https://github.com/nextcloud/server/blob/4a44d6a6774d79a8c91cab5f94acafa271b6d4d6/lib/base.php#L609

The main argument for this choice seems to be to simplify log reading, as discussed in this issue: https://github.com/nextcloud/server/issues/3553

However, this hardcoding of UTC affects all instances where date_default_timezone_get is used, resulting in UTC even when it would be more intuitive to use the server's timezone or the one set in config.php under default_timezone.

This pull request corrects the timestamp values in export files, aligning them with the expected timezone settings. The fix is informed by the solutions implemented in other parts of the system where similar timezone issues are handled, as seen in references like:

https://github.com/search?q=org%3Anextcloud+%22%3EgetDefaultTimeZone%28%22&type=code