### PR TITLE
Add padding and max width so they don't stick to right screen border

### DIFF
--- a/src/components/Questions/QuestionDate.vue
+++ b/src/components/Questions/QuestionDate.vue
@@ -129,7 +129,8 @@ export default {
 
 <style lang="scss" scoped>
 .mx-datepicker {
-	width: 300px;
+	width: 100%;
+	max-width: 300px;
 
 	&.disabled {
 		inset-inline-start: -12px;

--- a/src/components/Questions/QuestionFile.vue
+++ b/src/components/Questions/QuestionFile.vue
@@ -435,7 +435,8 @@ export default {
 		padding-inline: calc(3 * var(--default-grid-baseline)) var(--focus-offset);
 		padding-block: var(--focus-offset);
 		height: var(--default-clickable-area);
-		width: 300px;
+		width: 100%;
+		max-width: 300px;
 
 		label {
 			color: var(--color-text-maxcontrast);

--- a/src/views/Submit.vue
+++ b/src/views/Submit.vue
@@ -808,7 +808,7 @@ export default {
 	form {
 		.question {
 			// Less padding needed as submit view does not have drag handles
-			padding-inline-start: var(--default-clickable-area);
+			padding-inline: var(--default-clickable-area);
 		}
 
 		.form-buttons {


### PR DESCRIPTION
This also aligns them

Before: (notice how the border isn't clearly visible because it sticks to the right screen border)
![Screenshot 2024-11-06 at 17-00-31 TEST - Formulare - Storage Share](https://github.com/user-attachments/assets/b09713f9-e9da-4162-972c-80502c774072)
![Screenshot 2024-11-06 at 17-00-18 TEST - Formulare - Storage Share](https://github.com/user-attachments/assets/96a9d076-638a-4895-a065-8b09305a7f5d)

After:
![Screenshot 2024-11-06 at 16-53-17 TEST - Formulare - Storage Share](https://github.com/user-attachments/assets/5faabdc8-fc14-4ffb-bf91-da5b024de592)
![Screenshot 2024-11-06 at 16-59-57 TEST - Formulare - Storage Share](https://github.com/user-attachments/assets/26ed5f09-55d1-4ccc-ae27-d587fc92e0e2)

The german translation text doesn’t fit completely into the text box when the screen is very small. It will fit however into the `max-width` of 300px.