### PR TITLE
chore: remove unused access variable in hasPublicLink method

### DIFF
--- a/lib/Service/FormsService.php
+++ b/lib/Service/FormsService.php
@@ -364,8 +364,6 @@ class FormsService {
 	 * @return boolean
 	 */
 	private function hasPublicLink(Form $form): bool {
-		$access = $form->getAccess();
-
 		$shareEntities = $this->shareMapper->findByForm($form->getId());
 		foreach ($shareEntities as $shareEntity) {
 			if ($shareEntity->getShareType() === IShare::TYPE_LINK) {


### PR DESCRIPTION
This removes an unused variable