### PR TITLE
test(playwright): use getContainer from @nextcloud/cypress/docker

### DIFF
--- a/playwright/support/setup.ts
+++ b/playwright/support/setup.ts
@@ -4,7 +4,7 @@
  */
 
 import { test as setup } from '@playwright/test'
-import { configureNextcloud, docker } from '@nextcloud/cypress/docker'
+import { configureNextcloud, getContainer } from '@nextcloud/cypress/docker'
 
 /**
  * We use this to ensure Nextcloud is configured correctly before running our tests
@@ -13,7 +13,5 @@ import { configureNextcloud, docker } from '@nextcloud/cypress/docker'
  * as that only checks for the URL to be accessible which happens already before everything is configured.
  */
 setup('Configure Nextcloud', async () => {
-	const containerName = 'nextcloud-cypress-tests_forms'
-	const container = docker.getContainer(containerName)
-	await configureNextcloud(['forms', 'viewer'], undefined, container)
+	await configureNextcloud(['forms', 'viewer'], undefined, getContainer())
 })

--- a/playwright/support/utils/session.ts
+++ b/playwright/support/utils/session.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import { docker } from '@nextcloud/cypress/docker'
+import { getContainer } from '@nextcloud/cypress/docker'
 import { expect, type APIRequestContext } from '@playwright/test'
 
 /**
@@ -22,8 +22,7 @@ export async function runShell(
 		env?: Record<string, string | number>
 	},
 ) {
-	const containerName = 'nextcloud-cypress-tests_forms'
-	const container = docker.getContainer(containerName)
+	const container = getContainer()
 
 	const exec = await container.exec({
 		Cmd: ['sh', '-c', command],


### PR DESCRIPTION
Avoid hardcoding `containerName` to make reuse in other apps easier.
