### PR TITLE
feat: allow cloning archived forms

### DIFF
--- a/lib/Controller/ApiController.php
+++ b/lib/Controller/ApiController.php
@@ -180,6 +180,7 @@ class ApiController extends OCSController {
 			unset($formData['id']);
 			unset($formData['created']);
 			unset($formData['lastUpdated']);
+			unset($formData['state']);
 			$formData['hash'] = $this->formsService->generateFormHash();
 			// TRANSLATORS Appendix to the form Title of a duplicated/copied form.
 			$formData['title'] .= ' - ' . $this->l10n->t('Copy');

--- a/src/Forms.vue
+++ b/src/Forms.vue
@@ -131,7 +131,10 @@
 		</template>
 
 		<!-- Archived forms modal -->
-		<ArchivedFormsModal :open.sync="showArchivedForms" :forms="archivedForms" />
+		<ArchivedFormsModal
+			:open.sync="showArchivedForms"
+			:forms="archivedForms"
+			@clone="onCloneForm" />
 	</NcContent>
 </template>
 

--- a/src/components/AppNavigationForm.vue
+++ b/src/components/AppNavigationForm.vue
@@ -57,7 +57,7 @@
 				{{ t('forms', 'Results') }}
 			</NcActionRouter>
 			<NcActionButton
-				v-if="canEdit && !isArchived"
+				v-if="canEdit"
 				:close-after-click="true"
 				@click="onCloneForm">
 				<template #icon>
@@ -278,6 +278,7 @@ export default {
 		onShareForm() {
 			this.$emit('open-sharing', this.form.hash)
 		},
+
 		onCloneForm() {
 			this.$emit('clone', this.form.id)
 		},

--- a/src/components/ArchivedFormsModal.vue
+++ b/src/components/ArchivedFormsModal.vue
@@ -17,6 +17,7 @@
 				:form="form"
 				:read-only="false"
 				force-display-actions
+				@clone="onCloneForm(form.id)"
 				@delete="onDelete(form)"
 				@mobile-close-navigation="$emit('update:open', false)" />
 		</ul>
@@ -68,6 +69,11 @@ export default defineComponent({
 
 	methods: {
 		t,
+
+		onCloneForm(formId) {
+			this.$emit('clone', formId)
+			this.$emit('update:open', false)
+		},
 
 		onDelete(form) {
 			this.shownForms = this.shownForms.filter(({ id }) => id !== form.id)


### PR DESCRIPTION
This closes #2019 by showing the button and handling the events in the frontend and by adjusting the backend to unset the state of the cloned form. It also adds a change to unset the expires timestamp when a form gets cloned.