### PR TITLE
fix: Fix spreadsheet unlinking

### DIFF
--- a/src/views/Results.vue
+++ b/src/views/Results.vue
@@ -437,9 +437,9 @@ export default {
 
 	methods: {
 		async onUnlinkFile() {
-			await axios.update(
-				generateOcsUrl('apps/forms/api/v3/forms/{id}', {
-					id: this.form.id,
+			await axios.patch(
+				generateOcsUrl('apps/forms/api/v3/forms/{formId}', {
+					formId: this.form.id,
 				}),
 				{
 					keyValuePairs: {


### PR DESCRIPTION
Closes #2528.

I can't compile and test it due to an error:

```
devcontainer@e0e910ca5f18:/var/www/html/apps/forms$ npm run dev

> forms@5.0.0-alpha.1 dev
> vite --mode development build

Building forms for development
error during build:
TypeError: crypto$2.getRandomValues is not a function
    at resolveConfig (file:///var/www/html/apps/forms/node_modules/vite/dist/node/chunks/dep-CHZK6zbr.js:66562:16)
    at async build (file:///var/www/html/apps/forms/node_modules/vite/dist/node/chunks/dep-CHZK6zbr.js:65395:18)
    at async CAC.<anonymous> (file:///var/www/html/apps/forms/node_modules/vite/dist/node/cli.js:829:5)
```

Any suggestions how to deal with it?