### PR TITLE
test(ci): only install headless shell chromium for playwright

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -44,7 +44,7 @@ jobs:
           TESTING=true npm run build --if-present
 
       - name: Install Playwright Browsers
-        run: npx playwright install --with-deps
+        run: npx playwright install chromium --only-shell
 
       - name: Run Playwright tests
         run: npx playwright test


### PR DESCRIPTION
Speeds up the installation of the browsers drastically:
| scenario | 1st run | 2nd run | 3rd run | avg |
| ---- | ---- | ---- | ---- | ---- |
|all browsers | 53 sec| 74 sec| 59 sec| ~ 62 sec|
|only chromium  --with-deps| 42 sec| 29 sec| 31 sec|  ~ 34 sec|
|chromium  --with-deps --only-shell| 22 sec| 18 sec | | ~ 20 sec|
|chromium --only-shell| 4 sec| 5 sec| |~ 4.5 sec|