### PR TITLE
fix: Correct validationTypeMenuId to use local index instead of $attrs

### DIFF
--- a/src/components/Questions/QuestionShort.vue
+++ b/src/components/Questions/QuestionShort.vue
@@ -131,7 +131,7 @@ export default {
 		 * Id of the validation type menu
 		 */
 		validationTypeMenuId() {
-			return 'q' + this.$attrs.index + '__validation_menu'
+			return 'q' + this.index + '__validation_menu'
 		},
 		/**
 		 * The regular expression


### PR DESCRIPTION
The validationTypeMenuId couldn't be calculated correctly, because `index` is undefined in `this.$attrs`.

Signed-off-by: Christian Hartmann <chris-hartmann@gmx.de>