### PR TITLE
Fix(routes): Add hash requirements for frontpage routes

### DIFF
--- a/lib/Constants.php
+++ b/lib/Constants.php
@@ -11,20 +11,6 @@ use OCP\Share\IShare;
 
 class Constants {
 	/**
-	 * Constants for API Controllers
-	 */
-	public const API_BASE = '/api/{apiVersion}/';
-	public const API_V3_REQUIREMENTS = [
-		'apiVersion' => 'v3',
-		'formId' => '\d+',
-		'questionId' => '\d+',
-		'optionId' => '\d+',
-		'shareId' => '\d+',
-		'submissionId' => '\d+',
-		'path' => '.+'
-	];
-	
-	/**
 	 * Used AppConfig Keys
 	 */
 	public const CONFIG_KEY_ALLOWPERMITALL = 'allowPermitAll';

--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -84,7 +84,7 @@ class PageController extends Controller {
 	 */
 	#[NoAdminRequired()]
 	#[NoCSRFRequired()]
-	#[FrontpageRoute(verb: 'GET', url: '/{hash}/{view}')]
+	#[FrontpageRoute(verb: 'GET', url: '/{hash}/{view}', requirements: ['hash' => '[a-zA-Z0-9]{16,}'])]
 	public function views(string $hash): TemplateResponse {
 		return $this->index($hash);
 	}
@@ -96,7 +96,7 @@ class PageController extends Controller {
 	#[NoAdminRequired()]
 	#[NoCSRFRequired()]
 	#[PublicPage()]
-	#[FrontpageRoute(verb: 'GET', url: '/{hash}')]
+	#[FrontpageRoute(verb: 'GET', url: '/{hash}', requirements: ['hash' => '[a-zA-Z0-9]{16,}'])]
 	public function internalLinkView(string $hash): Response {
 		$internalView = $this->urlGenerator->linkToRoute('forms.page.views', ['hash' => $hash, 'view' => 'submit']);
 
@@ -116,7 +116,7 @@ class PageController extends Controller {
 	#[NoAdminRequired()]
 	#[NoCSRFRequired()]
 	#[PublicPage()]
-	#[FrontpageRoute(verb: 'GET', url: '/s/{hash}')]
+	#[FrontpageRoute(verb: 'GET', url: '/s/{hash}', requirements: ['hash' => '[a-zA-Z0-9]{24,}'])]
 	public function publicLinkView(string $hash): Response {
 		try {
 			$share = $this->shareMapper->findPublicShareByHash($hash);


### PR DESCRIPTION
This fixes #2554 by adding requirements for the `hash` in the routes of the PageController. It also removes some unused constants from previous requirements handling

Signed-off-by: Christian Hartmann <chris-hartmann@gmx.de>