### PR TITLE
Fix misaligned form elements

### DIFF
--- a/src/components/Icons/IconOverlay.vue
+++ b/src/components/Icons/IconOverlay.vue
@@ -21,8 +21,8 @@
 
 .icon-overlay {
 	position: absolute;
-	inset-inline-start: 2px;
-	inset-block-start: 2px;
+	inset-inline-start: 0;
+	inset-block-start: -2px;
 
 	transform: scale(0.7);
 }

--- a/src/components/Questions/AnswerInput.vue
+++ b/src/components/Questions/AnswerInput.vue
@@ -251,7 +251,7 @@ export default {
 	}
 
 	.question__input {
-		width: 100%;
+		width: calc(100% - var(--default-clickable-area));
 		position: relative;
 		inset-inline-start: -12px;
 		margin-inline-end: -12px !important;

--- a/src/components/Questions/Question.vue
+++ b/src/components/Questions/Question.vue
@@ -375,7 +375,7 @@ export default {
 	&__drag-handle {
 		position: absolute;
 		display: flex;
-		inset-inline-start: 0;
+		inset-inline-start: var(--default-grid-baseline);
 		flex-direction: column;
 		justify-content: center;
 		gap: 12px;

--- a/src/components/Questions/Question.vue
+++ b/src/components/Questions/Question.vue
@@ -451,8 +451,13 @@ export default {
 
 			&__warning {
 				margin-block: auto;
-				margin-inline: 4px 12px;
+				margin-inline: 8px;
 				color: var(--color-error);
+			}
+
+			&__menu {
+				margin-block: auto;
+				margin-inline-end: 12px;
 			}
 		}
 
@@ -477,7 +482,7 @@ export default {
 				z-index: inherit;
 				overflow-wrap: break-word;
 				// match with other inputs
-				width: calc(100% - 32px);
+				width: calc(100% - var(--default-clickable-area));
 			}
 			&__output {
 				//compensate border

--- a/src/components/Questions/QuestionDropdown.vue
+++ b/src/components/Questions/QuestionDropdown.vue
@@ -340,7 +340,7 @@ export default {
 	min-height: var(--default-clickable-area);
 
 	.question__input {
-		width: 100%;
+		width: calc(100% - var(--default-clickable-area));
 		position: relative;
 		inset-inline-start: -12px;
 		margin-inline-end: 32px !important;

--- a/src/components/Questions/QuestionLong.vue
+++ b/src/components/Questions/QuestionLong.vue
@@ -96,7 +96,7 @@ export default {
 		// Just overrides Server CSS-Styling for disabled inputs. -> Not Good??
 		background-color: var(--color-main-background);
 		color: var(--color-main-text);
-		width: calc(100% - 32px) !important;
+		width: calc(100% - var(--default-clickable-area)) !important;
 		margin-inline-start: -12px;
 	}
 }

--- a/src/components/Questions/QuestionMultiple.vue
+++ b/src/components/Questions/QuestionMultiple.vue
@@ -661,7 +661,7 @@ export default {
 	}
 
 	.question__input {
-		width: 100%;
+		width: calc(100% - var(--default-clickable-area));
 		position: relative;
 		inset-inline-start: -34px;
 		inset-block-start: 1px;

--- a/src/components/Questions/QuestionShort.vue
+++ b/src/components/Questions/QuestionShort.vue
@@ -41,7 +41,7 @@
 				:container="`#${validationTypeMenuId}`"
 				:open.sync="isValidationTypeMenuOpen"
 				class="validation-type-menu__toggle"
-				type="tertiary-no-background">
+				type="tertiary">
 				<template #icon>
 					<component :is="validationObject.icon" :size="20" />
 				</template>
@@ -240,15 +240,15 @@ export default {
 	min-height: var(--default-clickable-area);
 
 	&:disabled {
-		width: calc(100% - 32px) !important;
+		width: calc(100% - var(--default-clickable-area)) !important;
 		margin-inline-start: -12px;
 	}
 }
 
 .validation-type-menu__toggle {
 	position: relative;
-	left: calc(100% - var(--default-clickable-area));
-	top: -47px; // input height + margin
+	inset-inline-start: -4px;
+	inset-block-start: 4px;
 }
 
 :deep(input:invalid) {

--- a/src/components/Questions/QuestionShort.vue
+++ b/src/components/Questions/QuestionShort.vue
@@ -41,7 +41,7 @@
 				:container="`#${validationTypeMenuId}`"
 				:open.sync="isValidationTypeMenuOpen"
 				class="validation-type-menu__toggle"
-				type="tertiary">
+				type="tertiary-no-background">
 				<template #icon>
 					<component :is="validationObject.icon" :size="20" />
 				</template>
@@ -247,7 +247,7 @@ export default {
 
 .validation-type-menu__toggle {
 	position: relative;
-	inset-inline-start: -4px;
+	inset-inline-end: calc(4px + var(--default-clickable-area));
 	inset-block-start: 4px;
 }
 

--- a/src/views/Create.vue
+++ b/src/views/Create.vue
@@ -576,7 +576,7 @@ export default {
 			margin-block: 22px 14px;
 			margin-inline: 0;
 			width: calc(
-				100% - 56px
+				100% - 58px
 			); // margin of header, needed if screen is < 806px (max-width + margin-left)
 			overflow: hidden;
 			text-overflow: ellipsis;
@@ -593,7 +593,7 @@ export default {
 			min-height: unset;
 			padding-block: 0px 20px;
 			padding-inline: 12px;
-			width: calc(100% - 56px);
+			width: calc(100% - 58px);
 		}
 
 		.form-desc {

--- a/src/views/Results.vue
+++ b/src/views/Results.vue
@@ -804,7 +804,7 @@ export default {
 		display: flex;
 		flex-direction: column;
 		margin-block-end: 24px;
-		margin-inline-start: 56px;
+		margin-inline-start: 40px;
 
 		h2 {
 			margin-block-end: 0; // because the input field has enough padding
@@ -827,11 +827,12 @@ export default {
 		display: flex;
 		flex-wrap: wrap;
 		align-items: center;
-		margin-top: 8px;
-		padding-left: calc(14px - var(--border-radius-pill));
+		margin-block-start: 8px;
+		margin-inline-start: 8px;
+		padding-inline-start: calc(14px - var(--border-radius-pill));
 
 		&__toggle {
-			margin-right: 1em;
+			margin-inline-end: 1em;
 		}
 	}
 }

--- a/src/views/Submit.vue
+++ b/src/views/Submit.vue
@@ -767,17 +767,17 @@ export default {
 	// Title & description header
 	header {
 		margin-block-end: 24px;
-		margin-inline-start: 56px;
+		margin-inline-start: var(--default-clickable-area);
 
 		.form-title,
 		.form-desc,
 		.info-message {
 			width: calc(
-				100% - 56px
+				100% - 58px
 			); // margin of header, needed if screen is < 806px (max-width + margin-left)
 			font-size: 100%;
-			padding-block: 0px;
-			padding-inline: 16px;
+			padding-block: 0;
+			padding-inline: 18px;
 			border: none;
 		}
 		.form-title {


### PR DESCRIPTION
Closes #2403

I’m very sorry for the delay. This was a tough one to get right, this should probably not get backported to v29, as it might break there.

| Before | After |
| ------- | ----- |
| ![Screenshot 2025-02-18 at 05-14-03 Test - Formulare - Nextcloud](https://github.com/user-attachments/assets/67c7f9b8-5688-49cc-a5a6-58ca06e08e0d) | ![Screenshot 2025-02-18 at 04-51-02 Test - Formulare - Nextcloud](https://github.com/user-attachments/assets/af3a9be2-e17e-4932-ad11-d7d29f09504c) |
| ![Screenshot 2025-02-18 at 05-14-24 Test - Formulare - Nextcloud](https://github.com/user-attachments/assets/5f456bae-ed92-419e-b331-bd082c70ada6) | ![Screenshot 2025-02-18 at 04-50-50 Test - Formulare - Nextcloud](https://github.com/user-attachments/assets/d1b73d2d-a0d6-4215-9136-25214ff075b0) |

Notice the error fitting with some room to breath, and the validation menu next to the short answer „reappearing“

Very sorry again for the delay, I know you have a release date! I hope this is still early enough. :)