### PR TITLE
feat: replace drag icon for questions

### DIFF
--- a/src/components/Icons/IconDragIndicator.vue
+++ b/src/components/Icons/IconDragIndicator.vue
@@ -1,0 +1,45 @@
+<!--
+  - SPDX-FileCopyrightText: 2025 Christian Hartmann <chris-hartmann@gmx.de>
+  - SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
+<template>
+	<span
+		:aria-hidden="!title"
+		:aria-label="title"
+		class="material-design-icon drag-indicator-icon"
+		role="img"
+		v-bind="$attrs"
+		@click="$emit('click', $event)">
+		<svg
+			:fill="fillColor"
+			class="material-design-icon__svg"
+			:height="size"
+			:width="size"
+			viewBox="0 -960 960 960">
+			<path
+				d="M360-160q-33 0-56.5-23.5T280-240q0-33 23.5-56.5T360-320q33 0 56.5 23.5T440-240q0 33-23.5 56.5T360-160Zm240 0q-33 0-56.5-23.5T520-240q0-33 23.5-56.5T600-320q33 0 56.5 23.5T680-240q0 33-23.5 56.5T600-160ZM360-400q-33 0-56.5-23.5T280-480q0-33 23.5-56.5T360-560q33 0 56.5 23.5T440-480q0 33-23.5 56.5T360-400Zm240 0q-33 0-56.5-23.5T520-480q0-33 23.5-56.5T600-560q33 0 56.5 23.5T680-480q0 33-23.5 56.5T600-400ZM360-640q-33 0-56.5-23.5T280-720q0-33 23.5-56.5T360-800q33 0 56.5 23.5T440-720q0 33-23.5 56.5T360-640Zm240 0q-33 0-56.5-23.5T520-720q0-33 23.5-56.5T600-800q33 0 56.5 23.5T680-720q0 33-23.5 56.5T600-640Z" />
+			<title v-if="title">{{ title }}</title>
+		</svg>
+	</span>
+</template>
+
+<script>
+export default {
+	name: 'IconDragIndicator',
+	props: {
+		title: {
+			type: String,
+			default: '',
+		},
+		fillColor: {
+			type: String,
+			default: 'currentColor',
+		},
+		size: {
+			type: Number,
+			default: 20,
+		},
+	},
+}
+</script>

--- a/src/components/Questions/Question.vue
+++ b/src/components/Questions/Question.vue
@@ -29,7 +29,7 @@
 					<IconArrowUp :size="20" />
 				</template>
 			</NcButton>
-			<IconDragHorizontalVariant :size="20" />
+			<IconDragIndicator :size="20" />
 			<NcButton
 				ref="buttonDown"
 				:aria-label="t('forms', 'Move question down')"
@@ -166,8 +166,8 @@ import IconArrowUp from 'vue-material-design-icons/ArrowUp.vue'
 import IconAsterisk from 'vue-material-design-icons/Asterisk.vue'
 import IconContentCopy from 'vue-material-design-icons/ContentCopy.vue'
 import IconDelete from 'vue-material-design-icons/Delete.vue'
-import IconDragHorizontalVariant from 'vue-material-design-icons/DragHorizontalVariant.vue'
 import IconDotsHorizontal from 'vue-material-design-icons/DotsHorizontal.vue'
+import IconDragIndicator from '../Icons/IconDragIndicator.vue'
 import IconIdentifier from 'vue-material-design-icons/Identifier.vue'
 import IconOverlay from '../Icons/IconOverlay.vue'
 
@@ -181,8 +181,8 @@ export default {
 		IconAsterisk,
 		IconContentCopy,
 		IconDelete,
-		IconDragHorizontalVariant,
 		IconDotsHorizontal,
+		IconDragIndicator,
 		IconIdentifier,
 		IconOverlay,
 		NcActions,


### PR DESCRIPTION
This closes #2576 by adding IconDragIndicator and replacing IconDragHorizontalVariant with it.

| old icon | new icon |
|---|---|
| ![grafik](https://github.com/user-attachments/assets/38bec21c-1084-498a-a57c-08594e641e1d) | ![grafik](https://github.com/user-attachments/assets/8df25562-b649-43d0-9c20-4fe7f72a2088) |