### PR TITLE
fix: remove group restriction on server level

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -39,6 +39,10 @@
 	<author>Tim Sattizahn</author>
 	<author>Vinzenz Rosenkranz</author>
 
+	<types>
+		<prevent_group_restriction />
+	</types>
+
 	<documentation>
 		<admin>https://github.com/nextcloud/forms/blob/main/README.md</admin>
 	</documentation>


### PR DESCRIPTION
This fixes #2602 by removing the group restriction for using the app. Form creation can still be limited to groups by an admin in the Forms settings.

Signed-off-by: Christian Hartmann <chris-hartmann@gmx.de>