### PR TITLE
fix: Update QRDialog title to include escape and sanitize options

### DIFF
--- a/src/components/SidebarTabs/SharingSidebarTab.vue
+++ b/src/components/SidebarTabs/SharingSidebarTab.vue
@@ -93,7 +93,14 @@
 		</TransitionGroup>
 
 		<QRDialog
-			:title="t('forms', 'Share {formTitle}', { formTitle: form.title })"
+			:title="
+				t(
+					'forms',
+					'Share {formTitle}',
+					{ formTitle: form.title },
+					{ escape: false, sanitize: false },
+				)
+			"
 			:text="qrDialogText"
 			@closed="qrDialogText = ''" />
 


### PR DESCRIPTION
This fixes #2619 by adding the options `escape: false` and `sanitize: false` to the translation functions. The returned string will be escaped and sanitized in the Vue component so this shouldn't be a security problem.

Signed-off-by: Christian Hartmann <chris-hartmann@gmx.de>