### PR TITLE
fix: parameter confusion in `update:answer` events for multiple questions

### DIFF
--- a/src/components/Questions/QuestionDropdown.vue
+++ b/src/components/Questions/QuestionDropdown.vue
@@ -71,7 +71,7 @@
 						:max-index="options.length - 1"
 						:max-option-length="maxStringLengths.optionText"
 						@create-answer="onCreateAnswer"
-						@update:answer="updateAnswer(index, answer)"
+						@update:answer="updateAnswer"
 						@delete="deleteOption"
 						@focus-next="focusNextInput"
 						@move-up="onOptionMoveUp(index)"

--- a/src/components/Questions/QuestionMultiple.vue
+++ b/src/components/Questions/QuestionMultiple.vue
@@ -145,7 +145,7 @@
 						:max-index="options.length - 1"
 						:max-option-length="maxStringLengths.optionText"
 						@create-answer="onCreateAnswer"
-						@update:answer="updateAnswer(index, answer)"
+						@update:answer="updateAnswer"
 						@delete="deleteOption"
 						@focus-next="focusNextInput"
 						@move-up="onOptionMoveUp(index)"

--- a/src/mixins/QuestionMultipleMixin.ts
+++ b/src/mixins/QuestionMultipleMixin.ts
@@ -148,7 +148,7 @@ export default defineComponent({
 		 * @param {string|number} index the current index to update
 		 * @param {object} answer the new answer value
 		 */
-		updateAnswer(index: number, answer: FormsOption & { local?: boolean }) {
+		updateAnswer(index: number, answer: FormsOption) {
 			const options = [...this.sortedOptions]
 			const [oldValue] = options.splice(index, 1, answer)
 


### PR DESCRIPTION
This fixes #2621. The parameters for updating the answers were taken from the current component instead of passing them correctly from the AnswerInput.

Signed-off-by: Christian Hartmann <chris-hartmann@gmx.de>