### PR TITLE
Fix(migration): Rename primary key of uploaded_files table

### DIFF
--- a/lib/Migration/Version040300Date20240523123456.php
+++ b/lib/Migration/Version040300Date20240523123456.php
@@ -59,7 +59,7 @@ class Version040300Date20240523123456 extends SimpleMigrationStep {
 				'notnull' => false,
 				'comment' => 'unix-timestamp',
 			]);
-			$table->setPrimaryKey(['id'], 'id');
+			$table->setPrimaryKey(['id'], 'forms_upload_files_id');
 		}
 
 		return $schema;

--- a/lib/Migration/Version050004Date20250319180638.php
+++ b/lib/Migration/Version050004Date20250319180638.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Forms\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+/**
+ * FIXME Auto-generated migration step: Please modify to your needs!
+ */
+class Version050004Date20250319180638 extends SimpleMigrationStep {
+
+	/**
+	 * @param IOutput $output
+	 * @param Closure(): ISchemaWrapper $schemaClosure
+	 * @param array $options
+	 * @return null|ISchemaWrapper
+	 */
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
+		/** @var ISchemaWrapper $schema */
+		$schema = $schemaClosure();
+
+		if ($schema->hasTable('forms_v2_uploaded_files')) {
+			$table = $schema->getTable('forms_v2_uploaded_files');
+			$table->dropPrimaryKey();
+			$table->setPrimaryKey(['id'], 'forms_upload_files_id');
+		}
+
+		return $schema;
+	}
+}


### PR DESCRIPTION
This fixes #2648. It changes the primary key name parameter in the original migration and adds a new migration for existing installations that drops the old primary key and creates a new one with the new name.

Signed-off-by: Christian Hartmann <chris-hartmann@gmx.de>