### PR TITLE
Fix: Handle invalid form hashes correctly

### DIFF
--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -70,9 +70,17 @@ class PageController extends Controller {
 		$this->insertHeaderOnIos();
 		$this->initialState->provideInitialState('maxStringLengths', Constants::MAX_STRING_LENGTHS);
 		$this->initialState->provideInitialState('appConfig', $this->configService->getAppConfig());
+
 		if (isset($hash)) {
-			$this->initialState->provideInitialState('formId', $this->formMapper->findByHash($hash)->id);
+			try {
+				$form = $this->formMapper->findByHash($hash);
+				$this->initialState->provideInitialState('formId', $form->id);
+			} catch (DoesNotExistException $e) {
+				// Provide null to indicate no form was found
+				$this->initialState->provideInitialState('formId', 'invalid');
+			}
 		}
+
 		return new TemplateResponse($this->appName, self::TEMPLATE_MAIN, [
 			'id-app-content' => '#app-content-vue',
 			'id-app-navigation' => '#app-navigation-vue',

--- a/src/Forms.vue
+++ b/src/Forms.vue
@@ -251,6 +251,11 @@ export default {
 
 		// If the user is allowed to access this route
 		routeAllowed() {
+			// Check formId from initial state on app initialization
+			if (this.loading && loadState(appName, 'formId') === 'invalid') {
+				return false
+			}
+
 			// Not allowed, if no hash
 			if (!this.routeHash) {
 				return false
@@ -420,7 +425,9 @@ export default {
 					showError(t('forms', 'Form not found'))
 
 					if ([403, 404].includes(error.response?.status)) {
-						this.$router.push({ name: 'root' })
+						if (this.$route.name !== 'root') {
+							this.$router.push({ name: 'root' })
+						}
 					}
 				}
 			}
@@ -428,9 +435,6 @@ export default {
 			this.loading = false
 		},
 
-		/**
-		 *
-		 */
 		async onNewForm() {
 			try {
 				// Request a new empty form
@@ -487,7 +491,7 @@ export default {
 			this.forms.splice(formIndex, 1)
 
 			// Redirect if current form has been deleted
-			if (deletedHash === this.routeHash) {
+			if (deletedHash === this.routeHash && this.$route.name !== 'root') {
 				this.$router.push({ name: 'root' })
 			}
 		},


### PR DESCRIPTION
This fixes #2651 by correctly catching the NotFoundException in the backend and passing a corresponding value to the inital state of the app.

The `formId` is then checked against the defined value and routeAllowed returns `false` which then shows the correct error message that the form could not be found.