### PR TITLE
chore: Simplify props usage by removing unnecessary bindings in various components

### DIFF
--- a/src/Forms.vue
+++ b/src/Forms.vue
@@ -49,7 +49,7 @@
 						v-for="form in sharedForms"
 						:key="form.id"
 						:form="form"
-						:read-only="true"
+						read-only
 						@open-sharing="openSharing"
 						@mobile-close-navigation="mobileCloseNavigation" />
 				</ul>
@@ -60,7 +60,7 @@
 					<NcButton
 						alignment="start"
 						class="forms__archived-forms-toggle"
-						type="tertiary"
+						variant="tertiary"
 						wide
 						@click="showArchivedForms = true">
 						<template #icon>
@@ -91,7 +91,7 @@
 					<FormsIcon :size="64" />
 				</template>
 				<template v-if="canCreateForms" #action>
-					<NcButton type="primary" @click="onNewForm">
+					<NcButton variant="primary" @click="onNewForm">
 						{{ t('forms', 'Create a form') }}
 					</NcButton>
 				</template>
@@ -109,7 +109,7 @@
 					<FormsIcon :size="64" />
 				</template>
 				<template v-if="canCreateForms" #action>
-					<NcButton type="primary" @click="onNewForm">
+					<NcButton variant="primary" @click="onNewForm">
 						{{ t('forms', 'Create new form') }}
 					</NcButton>
 				</template>

--- a/src/FormsSettings.vue
+++ b/src/FormsSettings.vue
@@ -17,7 +17,7 @@
 			<NcSelect
 				v-model="appConfig.creationAllowedGroups"
 				:disabled="!appConfig.restrictCreation"
-				:multiple="true"
+				multiple
 				:options="availableGroups"
 				:placeholder="t('forms', 'Select groups')"
 				class="forms-settings__creation__multiselect"

--- a/src/FormsSubmit.vue
+++ b/src/FormsSubmit.vue
@@ -7,7 +7,7 @@
 	<NcContent app-name="forms" :class="{ 'app-forms-embedded': isEmbedded }">
 		<Submit
 			:form="form"
-			:public-view="true"
+			public-view
 			:share-hash="shareHash"
 			:is-logged-in="isLoggedIn" />
 	</NcContent>

--- a/src/components/AppNavigationForm.vue
+++ b/src/components/AppNavigationForm.vue
@@ -9,7 +9,7 @@
 		:active="isActive"
 		:actions-aria-label="t('forms', 'Form actions')"
 		:counter-number="form.submissionCount"
-		:compact="true"
+		compact
 		:force-display-actions="forceDisplayActions"
 		:name="formTitle"
 		:to="{
@@ -28,8 +28,8 @@
 		<template v-if="!loading && !readOnly" #actions>
 			<NcActionRouter
 				v-if="!isArchived"
-				:close-after-click="true"
-				:exact="true"
+				close-after-click
+				exact
 				:to="{ name: 'edit', params: { hash: form.hash } }"
 				@click="mobileCloseNavigation">
 				<template #icon>
@@ -39,7 +39,7 @@
 			</NcActionRouter>
 			<NcActionButton
 				v-if="!isArchived"
-				:close-after-click="true"
+				close-after-click
 				@click="onShareForm">
 				<template #icon>
 					<IconShareVariant :size="20" />
@@ -47,8 +47,8 @@
 				{{ t('forms', 'Share form') }}
 			</NcActionButton>
 			<NcActionRouter
-				:close-after-click="true"
-				:exact="true"
+				close-after-click
+				exact
 				:to="{ name: 'results', params: { hash: form.hash } }"
 				@click="mobileCloseNavigation">
 				<template #icon>
@@ -56,10 +56,7 @@
 				</template>
 				{{ t('forms', 'Results') }}
 			</NcActionRouter>
-			<NcActionButton
-				v-if="canEdit"
-				:close-after-click="true"
-				@click="onCloneForm">
+			<NcActionButton v-if="canEdit" close-after-click @click="onCloneForm">
 				<template #icon>
 					<IconContentCopy :size="20" />
 				</template>
@@ -68,7 +65,7 @@
 			<NcActionSeparator v-if="canEdit" />
 			<NcActionButton
 				v-if="canEdit"
-				:close-after-click="true"
+				close-after-click
 				@click="onToggleArchive">
 				<template #icon>
 					<IconArchiveOff v-if="isArchived" :size="20" />
@@ -82,7 +79,7 @@
 			</NcActionButton>
 			<NcActionButton
 				v-if="canEdit"
-				:close-after-click="true"
+				close-after-click
 				@click="showDeleteDialog = true">
 				<template #icon>
 					<IconDelete :size="20" />

--- a/src/components/Questions/AnswerInput.vue
+++ b/src/components/Questions/AnswerInput.vue
@@ -57,7 +57,7 @@
 			</NcActions>
 			<NcButton
 				:aria-label="t('forms', 'Delete answer')"
-				type="tertiary"
+				variant="tertiary"
 				@click="deleteEntry">
 				<template #icon>
 					<IconDelete :size="20" />

--- a/src/components/Questions/Question.vue
+++ b/src/components/Questions/Question.vue
@@ -23,7 +23,7 @@
 				:aria-label="t('forms', 'Move question up')"
 				:disabled="!canMoveUp"
 				class="question__drag-handle-button"
-				type="tertiary-no-background"
+				variant="tertiary-no-background"
 				@click.stop="onMoveUp">
 				<template #icon>
 					<IconArrowUp :size="20" />
@@ -35,7 +35,7 @@
 				:aria-label="t('forms', 'Move question down')"
 				:disabled="!canMoveDown"
 				class="question__drag-handle-button"
-				type="tertiary-no-background"
+				variant="tertiary-no-background"
 				@click.stop="onMoveDown">
 				<template #icon>
 					<IconArrowDown :size="20" />
@@ -79,7 +79,7 @@
 				<NcActions
 					v-if="!readOnly"
 					:id="actionsId"
-					:force-menu="true"
+					force-menu
 					placement="bottom-end"
 					class="question__header__title__menu">
 					<template v-if="isRequired" #icon>
@@ -108,7 +108,7 @@
 						</template>
 						{{ t('forms', 'Technical name') }}
 					</NcActionInput>
-					<NcActionButton :close-after-click="true" @click="onClone">
+					<NcActionButton close-after-click @click="onClone">
 						<template #icon>
 							<IconContentCopy :size="20" />
 						</template>

--- a/src/components/Questions/QuestionFile.vue
+++ b/src/components/Questions/QuestionFile.vue
@@ -123,7 +123,7 @@
 							:disabled="
 								!readOnly || values.length >= maxAllowedFilesCount
 							"
-							type="tertiary-no-background"
+							variant="tertiary-no-background"
 							@click="toggleFileInput">
 							<template #icon>
 								<IconUploadMultiple

--- a/src/components/Results/Submission.vue
+++ b/src/components/Results/Submission.vue
@@ -9,7 +9,7 @@
 			<h3 dir="auto">
 				{{ submission.userDisplayName }}
 			</h3>
-			<NcActions class="submission-menu" :force-menu="true">
+			<NcActions class="submission-menu" force-menu>
 				<NcActionButton v-if="canDeleteSubmission" @click="onDelete">
 					<template #icon>
 						<IconDelete :size="20" />

--- a/src/components/SidebarTabs/SharingSearchDiv.vue
+++ b/src/components/SidebarTabs/SharingSearchDiv.vue
@@ -12,7 +12,7 @@
 			:get-option-key="(option) => option.key"
 			:options="options"
 			:placeholder="t('forms', 'Search for user, group or team …')"
-			:user-select="true"
+			user-select
 			:filter-by="() => true"
 			label="displayName"
 			@search="asyncSearch"

--- a/src/components/SidebarTabs/SharingShareDiv.vue
+++ b/src/components/SidebarTabs/SharingShareDiv.vue
@@ -7,7 +7,7 @@
 	<li class="share-div">
 		<NcAvatar
 			:user="share.shareWith"
-			:disable-menu="true"
+			disable-menu
 			:display-name="displayName"
 			:is-no-user="isNoUser" />
 		<div class="share-div__desc">

--- a/src/components/SidebarTabs/SharingSidebarTab.vue
+++ b/src/components/SidebarTabs/SharingSidebarTab.vue
@@ -81,7 +81,7 @@
 					</NcActionButton>
 					<NcActionButton
 						v-if="appConfig.allowPublicLink"
-						:close-after-click="true"
+						close-after-click
 						@click="addPublicLink">
 						<template #icon>
 							<IconPlus :size="20" />

--- a/src/components/SidebarTabs/TransferOwnership.vue
+++ b/src/components/SidebarTabs/TransferOwnership.vue
@@ -8,8 +8,8 @@
 		<NcButton
 			class="transfer-button"
 			alignment="start"
-			type="tertiary"
-			:wide="true"
+			variant="tertiary"
+			wide
 			@click="openModal">
 			<span class="transfer-button__text">{{
 				t('forms', 'Transfer ownership')
@@ -20,7 +20,7 @@
 			:open.sync="showModal"
 			content-classes="modal-content"
 			:name="t('forms', 'Transfer ownership')"
-			:out-transition="true"
+			out-transition
 			@close="closeModal">
 			<template #default>
 				<!-- eslint-disable vue/no-v-html -->
@@ -41,13 +41,13 @@
 					v-model="selected"
 					class="modal-content__select"
 					:reset-focus-on-options-change="false"
-					:clear-search-on-select="true"
-					:close-on-select="true"
+					clear-search-on-select
+					close-on-select
 					:loading="loading"
 					:get-option-key="(option) => option.key"
 					:options="options"
 					:placeholder="t('forms', 'Search for a user')"
-					:user-select="true"
+					user-select
 					label="displayName"
 					@search="(query) => asyncSearch(query, true)">
 					<template #no-options>
@@ -85,7 +85,7 @@
 			<template #actions>
 				<NcButton
 					:disabled="!canTransfer"
-					type="error"
+					variant="error"
 					@click="onOwnershipTransfer">
 					{{ t('forms', 'I understand, transfer this form') }}
 				</NcButton>

--- a/src/components/TopBar.vue
+++ b/src/components/TopBar.vue
@@ -18,7 +18,7 @@
 		<NcButton
 			v-if="canShare && !sidebarOpened"
 			:aria-label="isMobile ? t('forms', 'Share form') : null"
-			type="tertiary"
+			variant="tertiary"
 			@click="onShareForm">
 			<template #icon>
 				<IconShareVariant :size="20" />

--- a/src/views/Create.vue
+++ b/src/views/Create.vue
@@ -54,7 +54,7 @@
 						dir="auto"
 						:maxlength="maxStringLengths.formTitle"
 						:placeholder="t('forms', 'Form title')"
-						:required="true"
+						required
 						autofocus
 						@input="onTitleChange" />
 				</h2>
@@ -127,7 +127,7 @@
 						:open.sync="questionMenuOpened"
 						:menu-name="t('forms', 'Add a question')"
 						:aria-label="t('forms', 'Add a question')"
-						:primary="true">
+						primary>
 						<template #icon>
 							<NcLoadingIcon v-if="isLoadingQuestions" :size="20" />
 							<IconPlus v-else :size="20" />
@@ -135,7 +135,7 @@
 						<NcActionButton
 							v-for="(answer, type) in answerTypesFilter"
 							:key="answer.label"
-							:close-after-click="true"
+							close-after-click
 							:disabled="isLoadingQuestions"
 							class="question-menu__question"
 							@click="addQuestion(type)">

--- a/src/views/Results.vue
+++ b/src/views/Results.vue
@@ -16,7 +16,7 @@
 			"
 			:buttons="linkedFileNotAvailableButtons"
 			size="normal"
-			:can-close="false" />
+			no-close />
 
 		<TopBar
 			:archived="isFormArchived"
@@ -111,7 +111,7 @@
 							<NcActionButton
 								v-if="!noSubmissions"
 								:close-after-click="false"
-								:is-menu="true"
+								is-menu
 								@click="isDownloadActionOpened = true">
 								<template #icon>
 									<IconDownload :size="20" />
@@ -180,7 +180,7 @@
 				</template>
 				<template #action>
 					<div class="response-actions">
-						<NcButton type="primary" @click="onShareForm">
+						<NcButton variant="primary" @click="onShareForm">
 							<template #icon>
 								<IconShareVariant :size="20" decorative />
 							</template>

--- a/src/views/Submit.vue
+++ b/src/views/Submit.vue
@@ -104,7 +104,7 @@
 						v-for="(question, index) in validQuestions"
 						ref="questions"
 						:key="question.id"
-						:read-only="true"
+						read-only
 						:answer-type="answerTypes[question.type]"
 						:index="index + 1"
 						:max-string-lengths="maxStringLengths"
@@ -119,8 +119,8 @@
 						alignment="center-reverse"
 						class="submit-button"
 						:disabled="!hasAnswers"
-						native-type="reset"
-						type="tertiary-no-background"
+						type="reset"
+						variant="tertiary-no-background"
 						@click.prevent="showClearFormDialog = true">
 						<template #icon>
 							<NcIconSvgWrapper :svg="IconRefreshSvg" />
@@ -131,8 +131,8 @@
 						alignment="center-reverse"
 						class="submit-button"
 						:disabled="loading"
-						native-type="submit"
-						type="primary">
+						type="submit"
+						variant="primary">
 						<template #icon>
 							<NcIconSvgWrapper :svg="IconSendSvg" />
 						</template>
@@ -160,7 +160,7 @@
 					)
 				"
 				:buttons="confirmLeaveFormButtons"
-				:can-close="false"
+				no-close
 				:close-on-click-outside="false" />
 			<!-- Confirmation dialog for clear form -->
 			<NcDialog
@@ -168,7 +168,7 @@
 				:name="t('forms', 'Clear form')"
 				:message="t('forms', 'Do you want to clear all answers?')"
 				:buttons="confirmClearFormButtons"
-				:can-close="false"
+				no-close
 				:close-on-click-outside="false" />
 			<!-- Confirmation dialog if form was changed -->
 			<NcDialog
@@ -181,7 +181,7 @@
 					)
 				"
 				:buttons="confirmClearFormButtons"
-				:can-close="false"
+				no-close
 				:close-on-click-outside="false" />
 		</template>
 	</NcAppContent>


### PR DESCRIPTION
With the update to 8.24 of the nexctlcoud-vue lib some more props were changed to have a default `false` value instead of the old props with a default of `true`. This PR adopts the new props and also cleans up some more boolean props.

Signed-off-by: Christian Hartmann <chris-hartmann@gmx.de>