### PR TITLE
fix: address vue warnings in console

### DIFF
--- a/src/components/PillMenu.vue
+++ b/src/components/PillMenu.vue
@@ -53,7 +53,7 @@ export default {
 		 */
 		disabled: {
 			type: Boolean,
-			required: true,
+			default: false,
 		},
 
 		/**

--- a/src/components/Questions/QuestionDropdown.vue
+++ b/src/components/Questions/QuestionDropdown.vue
@@ -34,8 +34,8 @@
 			:options="sortedOptions"
 			:searchable="false"
 			label="text"
+			:aria-label-combobox="selectOptionPlaceholder"
 			@input="onInput" />
-
 		<template v-else>
 			<div v-if="isLoading">
 				<NcLoadingIcon :size="64" />

--- a/src/components/SidebarTabs/SharingSearchDiv.vue
+++ b/src/components/SidebarTabs/SharingSearchDiv.vue
@@ -15,6 +15,7 @@
 			user-select
 			:filter-by="() => true"
 			label="displayName"
+			:aria-label-combobox="t('forms', 'Search for user, group or team …')"
 			@search="asyncSearch"
 			@input="addShare">
 			<template #no-options>


### PR DESCRIPTION
This fixes some Vue warnings in the browser console. One was about a missing required prop `disabled` for the PIllMenu. I changed the prop to have a default value of `false`.

The other two changes are related to a11y and missing ariaLabelComboboxes for NcSelect components in the sharing sidebar and the dropdown question type.

Signed-off-by: Christian Hartmann <chris-hartmann@gmx.de>