### PR TITLE
fix: Preserve intermediate changes when updating answer text

### DIFF
--- a/src/components/Questions/AnswerInput.vue
+++ b/src/components/Questions/AnswerInput.vue
@@ -212,6 +212,10 @@ export default {
 					this.$emit('create-answer', this.index, newAnswer)
 				} else {
 					await this.updateAnswer(answer)
+
+					// Forward changes, but use current answer.text to avoid erasing
+					// any in-between changes while updating the answer
+					answer.text = this.$refs.input.value
 					this.$emit('update:answer', this.index, answer)
 				}
 			}


### PR DESCRIPTION
This fixes #2713 by emitting the changes to the AnswerInput text between starting the updateAnswer call and its end.

Signed-off-by: Christian Hartmann <chris-hartmann@gmx.de>