### PR TITLE
feat: add question name to form answer output

### DIFF
--- a/docs/DataStructure.md
+++ b/docs/DataStructure.md
@@ -164,19 +164,21 @@ A submission-object describes a single submission by a user to a form.
 
 The actual answers of users on submission.
 
-| Property     | Type    | Restrictions  | Description                                     |
-| ------------ | ------- | ------------- | ----------------------------------------------- |
-| id           | Integer | unique        | An instance-wide unique id of the submission    |
-| submissionId | Integer |               | The id of the submission, the answer belongs to |
-| questionId   | Integer |               | The id of the question, the answer belongs to   |
-| text         | String  | max. 4096 ch. | The actual answer text, the user submitted      |
+| Property     | Type    | Restrictions  | Description                                          |
+| ------------ | ------- | ------------- | ---------------------------------------------------- |
+| id           | Integer | unique        | An instance-wide unique id of the submission         |
+| submissionId | Integer |               | The id of the submission, the answer belongs to      |
+| questionId   | Integer |               | The id of the question, the answer belongs to        |
+| questionName | String  |               | The technical name that was assigned to the question |
+| text         | String  | max. 4096 ch. | The actual answer text, the user submitted           |
 
-```
+```json
 {
-  "id": 5,
-  "submissionId": 5,
-  "questionId": 1,
-  "text": "Option 2"
+	"id": 5,
+	"submissionId": 5,
+	"questionId": 1,
+	"questionName": "preference",
+	"text": "Option 2"
 }
 ```
 

--- a/lib/ResponseDefinitions.php
+++ b/lib/ResponseDefinitions.php
@@ -63,6 +63,7 @@ namespace OCA\Forms;
  *   submissionId: int,
  *   fileId: ?int,
  *   questionId: int,
+ *   questionName?: string,
  *   text: string
  * }
  *

--- a/openapi.json
+++ b/openapi.json
@@ -58,6 +58,9 @@
                         "type": "integer",
                         "format": "int64"
                     },
+                    "questionName": {
+                        "type": "string"
+                    },
                     "text": {
                         "type": "string"
                     }

--- a/tests/Integration/Api/ApiV3Test.php
+++ b/tests/Integration/Api/ApiV3Test.php
@@ -1117,6 +1117,7 @@ class ApiV3Test extends IntegrationBase {
 									// 'questionId' => Checked dynamically
 									'text' => 'Option 1',
 									'fileId' => null,
+									'questionName' => 'city',
 								]
 							]
 						],
@@ -1137,6 +1138,7 @@ class ApiV3Test extends IntegrationBase {
 									// 'questionId' => Checked dynamically
 									'text' => 'Option 2',
 									'fileId' => null,
+									'questionName' => 'city'
 								]
 							]
 						],
@@ -1384,10 +1386,12 @@ CSV
 					'questionId' => $this->testForms[0]['questions'][1]['id'],
 					'text' => 'Option 1',
 					'fileId' => null,
+					'questionName' => 'city',
 				],
 				[
 					'questionId' => $this->testForms[0]['questions'][2]['id'],
 					'text' => 'test.txt',
+					'questionName' => 'file',
 				],
 			]
 		], $data['submissions'][0]);

--- a/tests/Unit/Controller/ApiControllerTest.php
+++ b/tests/Unit/Controller/ApiControllerTest.php
@@ -223,7 +223,7 @@ class ApiControllerTest extends TestCase {
 				'submissions' => [
 					['userId' => 'anon-user-1']
 				],
-				'questions' => [['name' => 'questions']],
+				'questions' => [['id' => 1, 'name' => 'questions']],
 				'expected' => [
 					'submissions' => [
 						[
@@ -233,6 +233,7 @@ class ApiControllerTest extends TestCase {
 					],
 					'questions' => [
 						[
+							'id' => 1,
 							'name' => 'questions',
 							'extraSettings' => new \stdClass(),
 						],
@@ -244,7 +245,7 @@ class ApiControllerTest extends TestCase {
 				'submissions' => [
 					['userId' => 'jdoe']
 				],
-				'questions' => [['name' => 'questions']],
+				'questions' => [['id' => 1, 'name' => 'questions']],
 				'expected' => [
 					'submissions' => [
 						[
@@ -254,6 +255,7 @@ class ApiControllerTest extends TestCase {
 					],
 					'questions' => [
 						[
+							'id' => 1,
 							'name' => 'questions',
 							'extraSettings' => new \stdClass(),
 						],


### PR DESCRIPTION
* Resolves https://github.com/nextcloud/forms/issues/2700

This allows to identify question from within the UI, as the user can see the name assigned to a question to identify it when using the submissions in external places like workflows.