### PR TITLE
fix: disable edit switch when the form is archived

### DIFF
--- a/src/components/SidebarTabs/SettingsSidebarTab.vue
+++ b/src/components/SidebarTabs/SettingsSidebarTab.vue
@@ -23,6 +23,7 @@
 		</NcCheckboxRadioSwitch>
 		<NcCheckboxRadioSwitch
 			:model-value="form.allowEditSubmissions"
+			:disabled="formArchived"
 			type="switch"
 			@update:model-value="onAllowEditSubmissionsChange">
 			{{ t('forms', 'Allow editing own responses') }}


### PR DESCRIPTION
Signed-off-by: GitHub <noreply@github.com>