### PR TITLE
fix: prevent modifications to archived forms in ApiController and ShareApiController

### DIFF
--- a/lib/Controller/ApiController.php
+++ b/lib/Controller/ApiController.php
@@ -268,6 +268,17 @@ class ApiController extends OCSController {
 		]);
 
 		$form = $this->getFormIfAllowed($formId);
+		if (
+			$this->formsService->isFormArchived($form)
+			&& !(
+				sizeof($keyValuePairs) === 1
+				&& key_exists('state', $keyValuePairs)
+				&& $keyValuePairs['state'] === Constants::FORM_STATE_CLOSED
+			)
+		) {
+			$this->logger->debug('This form is archived and can not be modified except to change state to closed.');
+			throw new OCSForbiddenException('This form is archived and can not be modified except to change state to closed.');
+		}
 
 		// Don't allow empty array
 		if (sizeof($keyValuePairs) === 0) {

--- a/lib/Controller/ShareApiController.php
+++ b/lib/Controller/ShareApiController.php
@@ -123,6 +123,11 @@ class ShareApiController extends OCSController {
 			throw new OCSNotFoundException('Could not find form');
 		}
 
+		if ($this->formsService->isFormArchived($form)) {
+			$this->logger->debug('This form is archived and can not be modified');
+			throw new OCSForbiddenException('This form is archived and can not be modified');
+		}
+
 		// Check for permission to share form
 		if ($form->getOwnerId() !== $this->currentUser->getUID()) {
 			$this->logger->debug('This form is not owned by the current user');
@@ -243,6 +248,11 @@ class ShareApiController extends OCSController {
 			throw new OCSNotFoundException('Could not find share');
 		}
 
+		if ($this->formsService->isFormArchived($form)) {
+			$this->logger->debug('This form is archived and can not be modified');
+			throw new OCSForbiddenException('This form is archived and can not be modified');
+		}
+
 		if ($formId !== $formShare->getFormId()) {
 			$this->logger->debug('This share doesn\'t belong to the given Form');
 			throw new OCSBadRequestException('Share doesn\'t belong to given Form');
@@ -334,6 +344,11 @@ class ShareApiController extends OCSController {
 		} catch (IMapperException $e) {
 			$this->logger->debug('Could not find share', ['exception' => $e]);
 			throw new OCSNotFoundException('Could not find share');
+		}
+
+		if ($this->formsService->isFormArchived($form)) {
+			$this->logger->debug('This form is archived and can not be modified');
+			throw new OCSForbiddenException('This form is archived and can not be modified');
 		}
 
 		if ($formId !== $share->getFormId()) {


### PR DESCRIPTION
This fixes #2740 by adding checks if the form is archived and not currently in the process of "un-archiving"

Signed-off-by: Christian Hartmann <chris-hartmann@gmx.de>