### PR TITLE
feat: don't show default submission header if custom message is set

### DIFF
--- a/src/views/Submit.vue
+++ b/src/views/Submit.vue
@@ -58,7 +58,11 @@
 			<NcEmptyContent
 				v-else-if="success || !form.canSubmit"
 				class="forms-emptycontent"
-				:name="t('forms', 'Thank you for completing the form!')"
+				:name="
+					form.submissionMessage
+						? ''
+						: t('forms', 'Thank you for completing the form!')
+				"
 				:description="form.submissionMessage">
 				<template #icon>
 					<NcIconSvgWrapper :svg="IconCheckSvg" :size="64" />


### PR DESCRIPTION
This closes #1747 by hiding the default header of the submission message if a custom submission message is set.