### PR TITLE
fix(export): escape CSV export for spreadsheet applications

### DIFF
--- a/lib/Service/SubmissionService.php
+++ b/lib/Service/SubmissionService.php
@@ -340,9 +340,12 @@ class SubmissionService {
 						->setWrapText(true);
 				} else {
 					// Explicitly set the type of the value to string for values that start with '=' to prevent it being interpreted as formulas
-					if (is_string($value) && str_starts_with($value, '=')) {
+					if (is_string($value)) {
 						$activeWorksheet->getCell([$column, $row])
-							->setValueExplicit($value);
+							->setValueExplicit($fileFormat === 'csv'
+								? $this->escapeCSV($value)
+								: $value,
+							);
 					} else {
 						$activeWorksheet->setCellValue([$column, $row], $value);
 					}
@@ -358,6 +361,19 @@ class SubmissionService {
 		$writer->save($exportedFile);
 
 		return file_get_contents($exportedFile);
+	}
+
+	/**
+	 * Escape a value for writing it to a CSV file.
+	 * This is needed to ensure the CSV, when loaded into an spreadsheet application, does not execute potential formulas.
+	 */
+	private function escapeCSV(string $value): string {
+		$BAD_CHARACTERS = ['=', '+', '-', '@', "\t", "\r"];
+		if (strlen($value) > 0 && in_array(mb_str_split($value)[0], $BAD_CHARACTERS)) {
+			// Escape the value by adding a leading single quote
+			return "'$value";
+		}
+		return $value;
 	}
 
 	/**


### PR DESCRIPTION
While in theory CSV is just plain data most users do not care and open it anyways in applications like Excel or LibreOffice. This can cause unwanted behavior if the cell value is evaluated like a formula.
So for this we manually escape suche values.