### PR TITLE
fix: remove name from icon for better a11y

### DIFF
--- a/src/components/SidebarTabs/SettingsSidebarTab.vue
+++ b/src/components/SidebarTabs/SettingsSidebarTab.vue
@@ -21,10 +21,7 @@
 			wide
 			@click="onFormLockChange(false)">
 			<template #icon>
-				<!-- TRANSLATORS description of the icon that shows an open lock -->
-				<NcIconSvgWrapper
-					:svg="svgLockOpen"
-					:name="t('forms', 'Open lock')" />
+				<NcIconSvgWrapper :svg="svgLockOpen" />
 			</template>
 			<!-- TRANSLATORS text for the action triggered by the button -->
 			{{ t('forms', 'Unlock form') }}


### PR DESCRIPTION
This improves a11y by removing a description of a button icon, so that only the button action is described

Signed-off-by: Christian Hartmann <chris-hartmann@gmx.de>