### PR TITLE
fix: remove unused props and fix event name in user select

### DIFF
--- a/src/components/SidebarTabs/SharingSearchDiv.vue
+++ b/src/components/SidebarTabs/SharingSearchDiv.vue
@@ -6,18 +6,14 @@
 <template>
 	<div>
 		<NcSelectUsers
-			:clear-search-on-select="false"
 			keep-open
 			:loading="showLoadingCircle"
 			:disabled="locked"
-			:get-option-key="(option) => option.key"
 			:options="options"
 			:placeholder="t('forms', 'Search for user, group or team …')"
-			:filter-by="() => true"
-			label="displayName"
-			:aria-label-combobox="t('forms', 'Search for user, group or team …')"
+			:aria-label-listbox="t('forms', 'Search for user, group or team …')"
 			@search="asyncSearch"
-			@update:model-value="addShare">
+			@update:modelValue="addShare">
 			<template #no-options>
 				{{ noResultText }}
 			</template>

--- a/src/components/SidebarTabs/TransferOwnership.vue
+++ b/src/components/SidebarTabs/TransferOwnership.vue
@@ -41,12 +41,9 @@
 				<NcSelectUsers
 					v-model="selected"
 					class="modal-content__select"
-					:reset-on-options-change="false"
 					:loading="loading"
-					:get-option-key="(option) => option.key"
 					:options="options"
 					:placeholder="t('forms', 'Search for a user')"
-					label="displayName"
 					@search="asyncSearch">
 					<template #no-options>
 						{{ noResultText }}
@@ -199,9 +196,6 @@ export default {
 					t('forms', 'An error occurred while transfering ownership'),
 				)
 			}
-		},
-		clearSelected() {
-			this.selected = null
 		},
 	},
 }


### PR DESCRIPTION
This fixes a regression in the integration of NcSelectUsers where the kebab-case event name `@update:model-value` is not available in the Nextcloud Vue lib and the event must be called with the camelCase `@update:modelValue`.

Further some props that are not available in NcSelectUsers but in NcSelect were removed.

Signed-off-by: Christian Hartmann <chris-hartmann@gmx.de>