### PR TITLE
feat: introduce Section as a new question type

### DIFF
--- a/lib/Constants.php
+++ b/lib/Constants.php
@@ -76,6 +76,7 @@ class Constants {
 	public const ANSWER_TYPE_LONG = 'long';
 	public const ANSWER_TYPE_MULTIPLE = 'multiple';
 	public const ANSWER_TYPE_MULTIPLEUNIQUE = 'multiple_unique';
+	public const ANSWER_TYPE_SECTION = 'section';
 	public const ANSWER_TYPE_SHORT = 'short';
 	public const ANSWER_TYPE_TIME = 'time';
 
@@ -95,6 +96,7 @@ class Constants {
 		self::ANSWER_TYPE_LONG,
 		self::ANSWER_TYPE_MULTIPLE,
 		self::ANSWER_TYPE_MULTIPLEUNIQUE,
+		self::ANSWER_TYPE_SECTION,
 		self::ANSWER_TYPE_SHORT,
 		self::ANSWER_TYPE_TIME,
 	];

--- a/lib/Controller/ApiController.php
+++ b/lib/Controller/ApiController.php
@@ -1187,9 +1187,12 @@ class ApiController extends OCSController {
 		}
 		$questions = [];
 		foreach ($this->formsService->getQuestions($formId) as $question) {
+			if ($question['type'] === Constants::ANSWER_TYPE_SECTION) {
+				continue;
+			}
+
 			$questions[$question['id']] = $question;
 		}
-
 
 		// Append Display Names
 		$submissions = array_map(function (array $submission) use ($questions) {

--- a/lib/ResponseDefinitions.php
+++ b/lib/ResponseDefinitions.php
@@ -43,7 +43,7 @@ namespace OCA\Forms;
  *   questionType?: string,
  * }
  *
- * @psalm-type FormsQuestionType = "dropdown"|"multiple"|"multiple_unique"|"date"|"time"|"short"|"long"|"file"|"datetime"|"grid"
+ * @psalm-type FormsQuestionType = "dropdown"|"multiple"|"multiple_unique"|"date"|"time"|"short"|"long"|"file"|"datetime"|"grid"|"section"
  * @psalm-type FormsQuestionGridCellType = "checkbox"|"number"|"radio"
  *
  * @psalm-type FormsQuestion = array{

--- a/lib/Service/SubmissionService.php
+++ b/lib/Service/SubmissionService.php
@@ -233,6 +233,11 @@ class SubmissionService {
 		$submissionEntities = array_reverse($submissionEntities);
 
 		$questions = $this->questionMapper->findByForm($form->getId());
+
+		$questions = array_filter($questions, function (Question $question) {
+			return $question->getType() !== Constants::ANSWER_TYPE_SECTION;
+		});
+
 		$defaultTimeZone = $this->config->getSystemValueString('default_timezone', 'UTC');
 
 		if (!$this->currentUser) {

--- a/openapi.json
+++ b/openapi.json
@@ -548,7 +548,8 @@
                     "long",
                     "file",
                     "datetime",
-                    "grid"
+                    "grid",
+                    "section"
                 ]
             },
             "Share": {

--- a/src/components/Questions/Question.vue
+++ b/src/components/Questions/Question.vue
@@ -8,6 +8,7 @@
 		class="question"
 		:class="{
 			'question--editable': !readOnly,
+			'question--section': readOnly && isSection,
 		}"
 		:aria-label="t('forms', 'Question number {index}', { index })">
 		<!-- Drag handle -->
@@ -91,6 +92,7 @@
 						</IconOverlay>
 					</template>
 					<NcActionCheckbox
+						v-if="!isSection"
 						:model-value="isRequired"
 						@update:model-value="onRequiredChange">
 						<!-- TRANSLATORS Making this question necessary to be answered when submitting to a form -->
@@ -98,6 +100,7 @@
 					</NcActionCheckbox>
 					<slot name="actions" />
 					<NcActionInput
+						v-if="!isSection"
 						:label="t('forms', 'Technical name of the question')"
 						:label-outside="false"
 						:show-trailing-button="false"
@@ -259,6 +262,11 @@ export default {
 			type: Boolean,
 			default: false,
 		},
+
+		type: {
+			type: String,
+			default: '',
+		},
 	},
 
 	emits: [
@@ -308,6 +316,10 @@ export default {
 
 		hasDescription() {
 			return this.description !== ''
+		},
+
+		isSection() {
+			return this.type === 'section'
 		},
 	},
 
@@ -518,6 +530,24 @@ export default {
 				@include markdown-output;
 			}
 		}
+	}
+}
+
+.question--section {
+	margin-block-end: 16px;
+	position: sticky;
+	top: 0;
+	background: var(--color-main-background);
+	z-index: 2;
+
+	h3 {
+		font-size: 24px !important;
+		border-bottom: 1px solid;
+	}
+
+	.question__header__description {
+		max-height: calc(var(--default-font-size) * 8);
+		overflow-y: auto;
 	}
 }
 </style>

--- a/src/components/Questions/QuestionSection.vue
+++ b/src/components/Questions/QuestionSection.vue
@@ -1,0 +1,27 @@
+<!--
+  - SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+  - SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
+<template>
+	<Question
+		v-bind="questionProps"
+		:title-placeholder="answerType.titlePlaceholder"
+		:warning-invalid="answerType.warningInvalid"
+		v-on="commonListeners">
+	</Question>
+</template>
+
+<script>
+import Question from './Question.vue'
+import QuestionMixin from '../../mixins/QuestionMixin.js'
+
+export default {
+	name: 'QuestionSection',
+	components: {
+		Question,
+	},
+
+	mixins: [QuestionMixin],
+}
+</script>

--- a/src/models/AnswerTypes.js
+++ b/src/models/AnswerTypes.js
@@ -8,6 +8,7 @@ import IconCalendar from 'vue-material-design-icons/CalendarOutline.vue'
 import IconCheckboxOutline from 'vue-material-design-icons/CheckboxOutline.vue'
 import IconClockOutline from 'vue-material-design-icons/ClockOutline.vue'
 import IconFile from 'vue-material-design-icons/FileOutline.vue'
+import IconFormatSection from 'vue-material-design-icons/FormatSection.vue'
 import IconGrid from 'vue-material-design-icons/Grid.vue'
 import IconNumeric from 'vue-material-design-icons/Numeric.vue'
 import IconRadioboxMarked from 'vue-material-design-icons/RadioboxMarked.vue'
@@ -23,6 +24,7 @@ import QuestionGrid from '../components/Questions/QuestionGrid.vue'
 import QuestionLinearScale from '../components/Questions/QuestionLinearScale.vue'
 import QuestionLong from '../components/Questions/QuestionLong.vue'
 import QuestionMultiple from '../components/Questions/QuestionMultiple.vue'
+import QuestionSection from '../components/Questions/QuestionSection.vue'
 import QuestionShort from '../components/Questions/QuestionShort.vue'
 import { OptionType } from './Constants.ts'
 
@@ -262,5 +264,15 @@ export default {
 		createPlaceholder: t('forms', 'People can pick a color'),
 		submitPlaceholder: t('forms', 'Pick a color'),
 		warningInvalid: t('forms', 'This question needs a title!'),
+	},
+
+	section: {
+		component: QuestionSection,
+		icon: IconFormatSection,
+		label: t('forms', 'Section'),
+		predefined: false,
+
+		titlePlaceholder: t('forms', 'Section title'),
+		warningInvalid: t('forms', 'This section needs a title!'),
 	},
 }

--- a/src/views/Create.vue
+++ b/src/views/Create.vue
@@ -138,6 +138,7 @@
 							:answer-type="answerTypes[question.type]"
 							:index="index + 1"
 							:max-string-lengths="maxStringLengths"
+							:type="question.type"
 							v-bind.sync="form.questions[index]"
 							@clone="cloneQuestion(question)"
 							@delete="deleteQuestion(question.id)"

--- a/tests/Unit/Controller/ApiControllerTest.php
+++ b/tests/Unit/Controller/ApiControllerTest.php
@@ -223,7 +223,7 @@ class ApiControllerTest extends TestCase {
 				'submissions' => [
 					['userId' => 'anon-user-1']
 				],
-				'questions' => [['id' => 1, 'name' => 'questions']],
+				'questions' => [['id' => 1, 'name' => 'questions', 'type' => Constants::ANSWER_TYPE_SHORT]],
 				'expected' => [
 					'submissions' => [
 						[
@@ -235,6 +235,7 @@ class ApiControllerTest extends TestCase {
 						[
 							'id' => 1,
 							'name' => 'questions',
+							'type' => Constants::ANSWER_TYPE_SHORT,
 							'extraSettings' => new \stdClass(),
 						],
 					],
@@ -245,7 +246,7 @@ class ApiControllerTest extends TestCase {
 				'submissions' => [
 					['userId' => 'jdoe']
 				],
-				'questions' => [['id' => 1, 'name' => 'questions']],
+				'questions' => [['id' => 1, 'name' => 'questions', 'type' => Constants::ANSWER_TYPE_SHORT]],
 				'expected' => [
 					'submissions' => [
 						[
@@ -257,6 +258,7 @@ class ApiControllerTest extends TestCase {
 						[
 							'id' => 1,
 							'name' => 'questions',
+							'type' => Constants::ANSWER_TYPE_SHORT,
 							'extraSettings' => new \stdClass(),
 						],
 					],


### PR DESCRIPTION
Based on https://github.com/nextcloud/forms/pull/2824

@Chartman123  This is an interesting feature because in the future it can be expanded to split one form into pages by section. It can also be expanded to display pages only when a certain condition is met. Much has already been written about this.

Demo:
https://github.com/user-attachments/assets/fc7edb0d-1f24-4493-9c48-0a90dda21052

The only problem I haven't figured out how to solve is that on the mobile layout, the menu partially overlaps the Section (you can see it in the demo).