### PR TITLE
feat: introduce Grid as a new question type

### DIFF
--- a/lib/Constants.php
+++ b/lib/Constants.php
@@ -71,6 +71,7 @@ class Constants {
 	public const ANSWER_TYPE_DATETIME = 'datetime';
 	public const ANSWER_TYPE_DROPDOWN = 'dropdown';
 	public const ANSWER_TYPE_FILE = 'file';
+	public const ANSWER_TYPE_GRID = 'grid';
 	public const ANSWER_TYPE_LINEARSCALE = 'linearscale';
 	public const ANSWER_TYPE_LONG = 'long';
 	public const ANSWER_TYPE_MULTIPLE = 'multiple';
@@ -85,6 +86,7 @@ class Constants {
 		self::ANSWER_TYPE_DATETIME,
 		self::ANSWER_TYPE_DROPDOWN,
 		self::ANSWER_TYPE_FILE,
+		self::ANSWER_TYPE_GRID,
 		self::ANSWER_TYPE_LINEARSCALE,
 		self::ANSWER_TYPE_LONG,
 		self::ANSWER_TYPE_MULTIPLE,
@@ -178,6 +180,20 @@ class Constants {
 		'optionsLabelLowest' => ['string', 'NULL'],
 		'optionsLabelHighest' => ['string', 'NULL'],
 	];
+
+	public const EXTRA_SETTINGS_GRID = [
+		'columnsTitle' => ['string', 'NULL'],
+		'rowsTitle' => ['string', 'NULL'],
+        'columns' => ['array'],
+		'questionType' => ['string'],
+        'rows' => ['array'],
+	];
+
+    public const EXTRA_SETTINGS_GRID_QUESTION_TYPE = [
+        self::ANSWER_TYPE_SHORT,
+        self::ANSWER_TYPE_SHORT,
+        self::ANSWER_TYPE_SHORT,
+    ];
 
 	public const FILENAME_INVALID_CHARS = [
 		"\n",

--- a/lib/Db/Option.php
+++ b/lib/Db/Option.php
@@ -20,6 +20,8 @@ use OCP\AppFramework\Db\Entity;
  * @method void setText(string $value)
  * @method int getOrder();
  * @method void setOrder(int $value)
+ * @method string getOptionType()
+ * @method void setOptionType(string $value)
  */
 class Option extends Entity {
 
@@ -27,6 +29,10 @@ class Option extends Entity {
 	protected int|float|null $questionId;
 	protected ?string $text;
 	protected ?int $order;
+	protected ?string $optionType;
+
+    public const OPTION_TYPE_ROW = 'row';
+    public const OPTION_TYPE_COLUMN = 'column';
 
 	/**
 	 * Option constructor.
@@ -35,20 +41,20 @@ class Option extends Entity {
 		$this->questionId = null;
 		$this->text = null;
 		$this->order = null;
+		$this->optionType = null;
 		$this->addType('questionId', 'integer');
 		$this->addType('order', 'integer');
 		$this->addType('text', 'string');
+		$this->addType('optionType', 'string');
 	}
 
-	/**
-	 * @return FormsOption
-	 */
 	public function read(): array {
 		return [
 			'id' => $this->getId(),
 			'questionId' => $this->getQuestionId(),
 			'order' => $this->getOrder(),
 			'text' => (string)$this->getText(),
+            'optionType' => $this->getOptionType(),
 		];
 	}
 }

--- a/lib/Db/OptionMapper.php
+++ b/lib/Db/OptionMapper.php
@@ -27,17 +27,20 @@ class OptionMapper extends QBMapper {
 
 	/**
 	 * @param int|float $questionId
+     * @param string|null $optionType
 	 * @return Option[]
 	 */
-	public function findByQuestion(int|float $questionId): array {
+	public function findByQuestion(int|float $questionId, ?string $optionType = null): array {
 		$qb = $this->db->getQueryBuilder();
 
 		$qb->select('*')
 			->from($this->getTableName())
-			->where(
-				$qb->expr()->eq('question_id', $qb->createNamedParameter($questionId))
-			)
-			->orderBy('order')
+			->where($qb->expr()->eq('question_id', $qb->createNamedParameter($questionId)));
+        if ($optionType) {
+            $qb->andWhere($qb->expr()->eq('option_type', $qb->createNamedParameter($optionType)));
+        }
+        $qb
+            ->orderBy('order')
 			->addOrderBy('id');
 
 		return $this->findEntities($qb);

--- a/lib/Migration/Version050200Date20250914000000.php
+++ b/lib/Migration/Version050200Date20250914000000.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Forms\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\DB\Types;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+class Version050200Date20250914000000 extends SimpleMigrationStep {
+
+	/**
+	 * @param IOutput $output
+	 * @param Closure $schemaClosure The `\Closure` returns a `ISchemaWrapper`
+	 * @param array $options
+	 * @return null|ISchemaWrapper
+	 */
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
+		/** @var ISchemaWrapper $schema */
+		$schema = $schemaClosure();
+		$table = $schema->getTable('forms_v2_options');
+
+		if (!$table->hascolumn('option_type')) {
+			$table->addColumn('option_type', Types::STRING, [
+				'notnull' => false,
+				'default' => null,
+			]);
+		}
+
+		return $schema;
+	}
+}

--- a/lib/ResponseDefinitions.php
+++ b/lib/ResponseDefinitions.php
@@ -42,7 +42,7 @@ namespace OCA\Forms;
  *   validationType?: string
  * }
  *
- * @psalm-type FormsQuestionType = "dropdown"|"multiple"|"multiple_unique"|"date"|"time"|"short"|"long"|"file"|"datetime"
+ * @psalm-type FormsQuestionType = "dropdown"|"multiple"|"multiple_unique"|"date"|"time"|"short"|"long"|"file"|"datetime"|"grid"
  *
  * @psalm-type FormsQuestion = array{
  *   id: int,

--- a/lib/Service/FormsService.php
+++ b/lib/Service/FormsService.php
@@ -805,6 +805,9 @@ class FormsService {
 			case Constants::ANSWER_TYPE_DATE:
 				$allowed = Constants::EXTRA_SETTINGS_DATE;
 				break;
+            case Constants::ANSWER_TYPE_GRID:
+                $allowed = Constants::EXTRA_SETTINGS_GRID;
+				break;
 			case Constants::ANSWER_TYPE_TIME:
 				$allowed = Constants::EXTRA_SETTINGS_TIME;
 				break;

--- a/openapi.json
+++ b/openapi.json
@@ -536,7 +536,8 @@
                     "short",
                     "long",
                     "file",
-                    "datetime"
+                    "datetime",
+                    "grid"
                 ]
             },
             "Share": {
@@ -2622,6 +2623,12 @@
                                         "items": {
                                             "type": "string"
                                         }
+                                    },
+                                    "optionType": {
+                                        "type": "string",
+                                        "nullable": true,
+                                        "default": null,
+                                        "description": "the new option type (e.g. 'row')"
                                     }
                                 }
                             }

--- a/src/components/Questions/QuestionGrid.vue
+++ b/src/components/Questions/QuestionGrid.vue
@@ -1,0 +1,512 @@
+<!--
+  - SPDX-FileCopyrightText: 2020 Nextcloud GmbH and Nextcloud contributors
+  - SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
+<template>
+	<Question
+		v-bind="questionProps"
+		:title-placeholder="answerType.titlePlaceholder"
+		:warning-invalid="answerType.warningInvalid"
+		:content-valid="contentValid"
+		:shift-drag-handle="shiftDragHandle"
+		v-on="commonListeners">
+		<template #actions>
+
+      <NcActionInput
+          :model-value.sync="columnsTitle"
+          :label-outside="false"
+          :show-trailing-button="false"
+          :label="t('forms', 'Columns Title')">
+        <template #icon>
+          <IconArrowRight :size="20" />
+        </template>
+        {{ t('forms', 'Columns Title') }}
+      </NcActionInput>
+
+      <NcActionInput
+          :modelValue.sync="rowsTitle"
+          :label-outside="false"
+          :show-trailing-button="false"
+          :label="t('forms', 'Rows Title')">
+        <template #icon>
+          <IconArrowDown :size="20" />
+        </template>
+        {{ t('forms', 'Rows Title') }}
+      </NcActionInput>
+
+      <NcActionInput
+          type="multiselect"
+          :value="questionType"
+          track-by="id"
+          :options="questionTypes">
+<!--        <template #icon>-->
+<!--          <Pencil :size="20" />-->
+<!--        </template>-->
+        {{ t('forms', 'Question type') }}
+      </NcActionInput>
+
+    </template>
+		<template v-if="readOnly">
+			<fieldset :name="name || undefined" :aria-labelledby="titleId">
+				<NcNoteCard v-if="hasError" :id="errorId" type="error">
+					{{ errorMessage }}
+				</NcNoteCard>
+
+        <!-- fixme: render grid based on a question type -->
+        <!-- fixme: render titles https://stackoverflow.com/questions/45506550/how-can-a-split-diagonally-a-table-header-cell -->
+
+        <table class="answer-grid">
+          <thead>
+            <tr>
+              <th class="legend">
+                <div>
+                  <span class="columns-title">{{ columnsTitle }}</span>
+                  <span class="rows-title">{{ rowsTitle }}</span>
+                  <div class="line"></div>
+                </div>
+
+              </th>
+              <th v-for="column of columns" :key="column.local ? 'option-local' : column.id">{{ column.text }}</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr v-for="row of rows" :key="row.local ? 'option-local' : row.id">
+              <td>{{ row.text }}</td>
+              <td v-for="column of columns" :key="column.local ? 'option-local' : column.id"> O </td>
+            </tr>
+          </tbody>
+        </table>
+
+<!--				<NcCheckboxRadioSwitch-->
+<!--					v-for="answer in sortedOptions"-->
+<!--					:key="answer.id"-->
+<!--					:aria-errormessage="hasError ? errorId : undefined"-->
+<!--					:aria-invalid="hasError ? 'true' : undefined"-->
+<!--					:model-value="questionValues"-->
+<!--					:value="answer.id.toString()"-->
+<!--					:name="`${id}-answer`"-->
+<!--					:type="isUnique ? 'radio' : 'checkbox'"-->
+<!--					:required="checkRequired(answer.id)"-->
+<!--					@update:modelValue="onChange"-->
+<!--					@keydown.enter.exact.prevent="onKeydownEnter">-->
+<!--					{{ answer.text }}-->
+<!--				</NcCheckboxRadioSwitch>-->
+
+			</fieldset>
+		</template>
+
+		<template v-else>
+			<div v-if="isLoading">
+				<NcLoadingIcon :size="64" />
+			</div>
+
+      <template v-else>
+
+        <div>{{ t('forms', 'Grid columns') }}</div>
+        <Draggable
+				    v-model="columns"
+            class="question__content"
+            animation="200"
+            direction="vertical"
+            handle=".option__drag-handle"
+            invert-swap
+            tag="ul"
+            @change="saveOptionsOrder('column')"
+            @start="isDragging = true"
+            @end="isDragging = false">
+          <TransitionGroup
+              :name="
+						isDragging
+							? 'no-external-transition-on-drag'
+							: 'options-list-transition'
+					">
+            <!-- Column input edit -->
+            <AnswerInput
+                v-for="(answer, index) in columns"
+                :key="answer.local ? 'option-local' : answer.id"
+                ref="input"
+                :answer="answer"
+                :form-id="formId"
+                :index="index"
+                :is-unique="isUnique"
+                :max-index="columns.length - 2"
+                :max-option-length="maxStringLengths.optionText"
+                option-type="column"
+                @create-answer="onCreateAnswer"
+                @update:answer="updateAnswer"
+                @delete="deleteOption"
+                @focus-next="focusNextInput"
+                @move-up="onOptionMoveUp(index, 'column')"
+                @move-down="onOptionMoveDown(index, 'column')"
+                @tabbed-out="checkValidOption('column')" />
+          </TransitionGroup>
+        </Draggable>
+
+        <div>{{ t('forms', 'Grid rows') }}</div>
+        <Draggable
+				v-model="rows"
+				class="question__content"
+				animation="200"
+				direction="vertical"
+				handle=".option__drag-handle"
+				invert-swap
+				tag="ul"
+				@change="saveOptionsOrder('row')"
+				@start="isDragging = true"
+				@end="isDragging = false">
+				<TransitionGroup
+					:name="
+						isDragging
+							? 'no-external-transition-on-drag'
+							: 'options-list-transition'
+					">
+					<!-- Row input edit -->
+					<AnswerInput
+						v-for="(answer, index) in rows"
+						:key="answer.local ? 'option-local' : answer.id"
+						ref="input"
+						:answer="answer"
+						:form-id="formId"
+						:index="index"
+						:is-unique="isUnique"
+						:max-index="rows.length - 2"
+						:max-option-length="maxStringLengths.optionText"
+            option-type="row"
+						@create-answer="onCreateAnswer"
+						@update:answer="updateAnswer"
+						@delete="deleteOption"
+						@focus-next="focusNextInput"
+						@move-up="onOptionMoveUp(index, 'row')"
+						@move-down="onOptionMoveDown(index, 'row')"
+						@tabbed-out="checkValidOption('row')" />
+				</TransitionGroup>
+			</Draggable>
+      </template>
+		</template>
+
+	</Question>
+</template>
+
+<script>
+import { translate as t, translatePlural as n } from '@nextcloud/l10n'
+import Draggable from 'vuedraggable'
+import NcActionButton from '@nextcloud/vue/components/NcActionButton'
+import NcActionCheckbox from '@nextcloud/vue/components/NcActionCheckbox'
+import NcActionInput from '@nextcloud/vue/components/NcActionInput'
+import NcCheckboxRadioSwitch from '@nextcloud/vue/components/NcCheckboxRadioSwitch'
+import NcInputField from '@nextcloud/vue/components/NcInputField'
+import NcLoadingIcon from '@nextcloud/vue/components/NcLoadingIcon'
+import NcNoteCard from '@nextcloud/vue/components/NcNoteCard'
+
+import IconArrowRight from 'vue-material-design-icons/ArrowRight.vue'
+import IconArrowDown from 'vue-material-design-icons/ArrowDown.vue'
+import IconCheckboxBlankOutline from 'vue-material-design-icons/CheckboxBlankOutline.vue'
+import IconContentPaste from 'vue-material-design-icons/ContentPaste.vue'
+import IconRadioboxBlank from 'vue-material-design-icons/RadioboxBlank.vue'
+
+import AnswerInput from './AnswerInput.vue'
+import QuestionMixin from '../../mixins/QuestionMixin.js'
+import QuestionMultipleMixin from '../../mixins/QuestionMultipleMixin.ts'
+
+export default {
+	name: 'QuestionGrid',
+
+	components: {
+    IconArrowRight,
+    IconArrowDown,
+		AnswerInput,
+		Draggable,
+		IconCheckboxBlankOutline,
+		IconContentPaste,
+		IconRadioboxBlank,
+		NcActionButton,
+		NcActionCheckbox,
+		NcActionInput,
+		NcCheckboxRadioSwitch,
+		NcInputField,
+		NcLoadingIcon,
+		NcNoteCard,
+	},
+
+	mixins: [QuestionMixin, QuestionMultipleMixin],
+
+	data() {
+		return {
+			/**
+			 * The shown error message
+			 */
+			errorMessage: null,
+
+			isDragging: false,
+			isLoading: false,
+      questionTypes: [
+        { label: t('forms', 'Radio'), id: 'radio' },
+        { label: t('forms', 'Checkbox'), id: 'checkbox' },
+        { label: t('forms', 'Number'), id: 'number' },
+        { label: t('forms', 'Text'), id: 'text' },
+      ]
+		}
+	},
+
+	computed: {
+		isUnique() {
+			return this.answerType.unique === true
+		},
+
+		hasError() {
+			return !!this.errorMessage
+		},
+
+		shiftDragHandle() {
+			return !this.readOnly && this.options.length !== 0 && !this.isLastEmpty
+		},
+
+		questionValues() {
+			return this.isUnique ? this.values?.[0] : this.values
+		},
+
+		titleId() {
+			return `q${this.index}_title`
+		},
+
+		errorId() {
+			return `q${this.index}_error`
+		},
+
+		questionType() {
+			return this.extraSettings?.questionType ?? 'radio'
+		},
+
+    columns: {
+      get() {
+        return this.sortOptionsOfType(this.options, 'column')
+      },
+      set(value) {
+        this.updateOptionsOrder(value, 'column')
+      }
+    },
+
+    rows: {
+      get() {
+        return this.sortOptionsOfType(this.options, 'row')
+      },
+      set(value) {
+        this.updateOptionsOrder(value, 'row')
+      }
+    },
+
+    columnsTitle: {
+      get() {
+        return this.extraSettings?.columnsTitle ?? ''
+      },
+      set(value) {
+        this.onExtraSettingsChange({ columnsTitle : value })
+      }
+    },
+
+    rowsTitle: {
+      get() {
+        return this.extraSettings?.rowsTitle ?? ''
+      },
+      set(value) {
+        this.onExtraSettingsChange({ rowsTitle : value })
+      }
+    },
+	},
+
+	methods: {
+		async validate() {
+			if (!this.isUnique) {
+				// Validate limits
+				const max = this.extraSettings.optionsLimitMax ?? 0
+				const min = this.extraSettings.optionsLimitMin ?? 0
+				if (max && this.values.length > max) {
+					this.errorMessage = n(
+						'forms',
+						'You must choose at most one option',
+						'You must choose a maximum of %n options',
+						max,
+					)
+					return false
+				}
+				if (min && this.values.length < min) {
+					this.errorMessage = n(
+						'forms',
+						'You must choose at least one option',
+						'You must choose at least %n options',
+						min,
+					)
+					return false
+				}
+			}
+
+			this.errorMessage = null
+			return true
+		},
+
+		onChange(value) {
+			this.$emit('update:values', this.isUnique ? [value].flat() : value)
+		},
+
+		/**
+		 * Is the provided answer required ?
+		 * This is needed for checkboxes as html5
+		 * doesn't allow to require at least ONE checked.
+		 * So we require the one that are checked or all
+		 * if none are checked yet.
+		 *
+		 * @return {boolean}
+		 */
+		checkRequired() {
+			// false, if question not required
+			if (!this.isRequired) {
+				return false
+			}
+
+			// true for Radiobuttons
+			if (this.isUnique) {
+				return true
+			}
+
+			// For checkboxes, only required if no other is checked
+			return this.areNoneChecked
+		},
+  },
+}
+</script>
+
+<style lang="scss" scoped>
+.question__content {
+	display: flex;
+	flex-direction: column;
+	gap: var(--default-grid-baseline);
+}
+
+.question__item {
+	position: relative;
+	display: inline-flex;
+	min-height: var(--default-clickable-area);
+
+	&__pseudoInput {
+		color: var(--color-primary-element);
+		margin-inline-start: -2px;
+		z-index: 1;
+	}
+
+	.question__input {
+		width: calc(100% - var(--default-clickable-area));
+		position: relative;
+		inset-inline-start: -34px;
+		inset-block-start: 1px;
+		margin-inline-end: 10px !important;
+		padding-inline-start: 36px !important;
+	}
+
+	.question__label {
+		flex: 1 1 100%;
+		// Overwrite guest page core styles
+		text-align: start !important;
+		// Some rounding issues lead to this strange number, so label and answerInput show up a the same position, working on different browsers.
+		padding-block: 6.5px 0;
+		padding-inline: 30px 0;
+		line-height: 22px;
+		min-height: 34px;
+		height: min-content;
+		position: relative;
+
+		&::before {
+			box-sizing: border-box;
+			// Adjust position manually for proper position to text
+			position: absolute;
+			inset-block-start: 10px;
+			width: 16px;
+			height: 16px;
+			margin-inline: -30px 14px !important;
+			margin-block-end: 0;
+		}
+	}
+}
+
+.question__other-answer {
+	display: flex;
+	gap: 4px 16px;
+	flex-wrap: wrap;
+
+	.question__label {
+		flex-basis: content;
+	}
+
+	.question__input {
+		flex: 1;
+		min-width: 260px;
+	}
+
+	.input-field__input {
+		min-height: var(--default-clickable-area);
+	}
+}
+
+.question__other-answer:deep() .input-field__input {
+	min-height: var(--default-clickable-area);
+}
+
+.options-list-transition-move,
+.options-list-transition-enter-active,
+.options-list-transition-leave-active {
+	transition: all var(--animation-slow) ease;
+}
+
+.options-list-transition-enter-from,
+.options-list-transition-leave-to {
+	opacity: 0;
+	transform: translateX(44px);
+}
+
+/* ensure leaving items are taken out of layout flow so that moving
+   animations can be calculated correctly. */
+.options-list-transition-leave-active {
+	position: absolute;
+}
+
+.answer-grid {
+  border-collapse: collapse;
+  width: 100%;
+
+  .legend {
+    width: 200px;
+    height: 80px;
+    padding: 0;
+    margin: 0;
+
+    .line {
+      width: 200px;
+      height: 80px;
+      border-bottom: 1px solid red;
+      transform: translateY(-40px) translateX(0px) rotate(20deg);
+      position: absolute;
+    }
+
+    .columns-title {
+      position: absolute;
+      bottom: 1px;
+      left: 1px;
+    }
+
+    .rows-title {
+      position: absolute;
+      top: 1px;
+      right: 1px;
+    }
+  }
+
+  .legend>div {
+    position: relative;
+    height: 100%;
+    width: 100%;
+    top: 0;
+    left: 0;
+  }
+
+}
+</style>

--- a/src/mixins/QuestionMixin.js
+++ b/src/mixins/QuestionMixin.js
@@ -387,6 +387,7 @@ export default {
 						id: option.id, // Use the ID from the server
 						questionId: this.id,
 						text: option.text,
+                        optionType: option.optionType,
 						local: false,
 					})
 				})

--- a/src/models/AnswerTypes.js
+++ b/src/models/AnswerTypes.js
@@ -7,6 +7,7 @@ import QuestionColor from '../components/Questions/QuestionColor.vue'
 import QuestionDate from '../components/Questions/QuestionDate.vue'
 import QuestionDropdown from '../components/Questions/QuestionDropdown.vue'
 import QuestionFile from '../components/Questions/QuestionFile.vue'
+import QuestionGrid from '../components/Questions/QuestionGrid.vue'
 import QuestionLinearScale from '../components/Questions/QuestionLinearScale.vue'
 import QuestionLong from '../components/Questions/QuestionLong.vue'
 import QuestionMultiple from '../components/Questions/QuestionMultiple.vue'
@@ -17,11 +18,14 @@ import IconCalendar from 'vue-material-design-icons/CalendarOutline.vue'
 import IconCheckboxOutline from 'vue-material-design-icons/CheckboxOutline.vue'
 import IconClockOutline from 'vue-material-design-icons/ClockOutline.vue'
 import IconFile from 'vue-material-design-icons/FileOutline.vue'
+import IconGrid from 'vue-material-design-icons/Grid.vue'
 import IconLinearScale from '../components/Icons/IconLinearScale.vue'
 import IconPalette from '../components/Icons/IconPalette.vue'
 import IconRadioboxMarked from 'vue-material-design-icons/RadioboxMarked.vue'
 import IconTextLong from 'vue-material-design-icons/TextLong.vue'
 import IconTextShort from 'vue-material-design-icons/TextShort.vue'
+import IconNumeric from 'vue-material-design-icons/Numeric.vue'
+import IconRadioboxBlank from "vue-material-design-icons/RadioboxBlank.vue";
 
 /**
  * @typedef {object} AnswerTypes
@@ -115,6 +119,52 @@ export default {
 		titlePlaceholder: t('forms', 'File question title'),
 		warningInvalid: t('forms', 'This question needs a title!'),
 	},
+
+	grid: {
+		component: QuestionGrid,
+		icon: IconGrid,
+		label: t('forms', 'Grid'),
+        // fixme: remove non-needed properties
+		predefined: false,
+
+        subtypes: {
+            radio: {
+                label: t('forms', 'Radio'),
+                icon: IconRadioboxBlank,
+                extraSettings: {
+                    questionType: 'radio',
+                },
+            },
+            checkbox: {
+                label: t('forms', 'Checkbox'),
+                icon: IconCheckboxOutline,
+                extraSettings: {
+                    questionType: 'checkbox',
+                },
+            },
+            number: {
+                label: t('forms', 'Number'),
+                icon: IconNumeric,
+                extraSettings: {
+                    questionType: 'number',
+                },
+            },
+            text: {
+                label: t('forms', 'Text'),
+                icon: IconTextShort,
+                extraSettings: {
+                    questionType: 'text',
+                },
+            }
+        },
+
+        validate: (question) => question.options.length > 0,
+
+        titlePlaceholder: t('forms', 'Grid question title'),
+        warningInvalid: t('forms', 'This question needs a title!'),
+        createPlaceholder: t('forms', 'People can submit a different answer'),
+        submitPlaceholder: t('forms', 'Enter your answer'),
+    },
 
 	short: {
 		component: QuestionShort,

--- a/src/models/Constants.ts
+++ b/src/models/Constants.ts
@@ -31,3 +31,9 @@ export const INPUT_DEBOUNCE_MS = 400
  * A constant representing the prefix used for identifying "other" answers
  */
 export const QUESTION_EXTRASETTINGS_OTHER_PREFIX = 'system-other-answer:'
+
+export enum OptionType {
+    Row = 'row',
+    Column = 'column',
+    Choice = 'choice',
+}

--- a/src/models/Entities.d.ts
+++ b/src/models/Entities.d.ts
@@ -7,5 +7,6 @@ export interface FormsOption {
 	id: number
 	text: string
 	order?: number
-	questionId: number
+	questionId: number,
+    optionType: string,
 }

--- a/src/views/Create.vue
+++ b/src/views/Create.vue
@@ -157,6 +157,7 @@
 							<NcLoadingIcon v-if="isLoadingQuestions" :size="20" />
 							<IconPlus v-else :size="20" />
 						</template>
+<!--            <NcActionSeparator />-->
 						<NcActionButton
 							v-for="(answer, type) in answerTypesFilter"
 							:key="answer.label"


### PR DESCRIPTION
Closes #2606

:construction: Development still in progress

I'm trying to reuse already existent `Option` entity by adding extra column `optionType=row|column`.

## :heavy_check_mark: Implemented
<details><summary>:mag: Cols/Rows management</summary>
<p>

<img width="400" alt="image" src="https://github.com/user-attachments/assets/8c6e114e-1002-4738-89f9-5ea2c310d2b1" />

</p>
</details> 

<details><summary>:mag: Cols/Rows titles and various input type</summary>
<p>

<img width="400" alt="image" src="https://github.com/user-attachments/assets/9f4e993b-06dc-4902-8b0d-e2c1a396e654" />

</p>
</details> 

<details><summary>:mag: Very basic table rendering</summary>
<p>

<img width="400" alt="image" src="https://github.com/user-attachments/assets/7d019605-dcc4-4369-8382-30ab5475d509" />

</p>
</details> 

## :spiral_notepad: Todo
- [x] Fix total mess with input focus
- [x] Fix items reordering
- [x] Create nested menu to create type of the answer (it is impossible to change answer type later)
- [ ] Proper rendering on answer mode
- [ ] Store and display results
- [ ] Export
