### PR TITLE
feat(docs): Add embed permission description for link shares in DataStructure.md

### DIFF
--- a/docs/DataStructure.md
+++ b/docs/DataStructure.md
@@ -193,6 +193,7 @@ Array of permissions, the user has on the form. Permissions are named by resp. r
 | results | User is allowed to access the form results |
 | results_delete | User is allowed to delete form submissions |
 | submit | User is allowed to submit to the form |
+| embed | only for `shareType: IShare::TYPE_LINK = 3` (link shares): allow [embedding](Embedding.md) |
 
 ## Access Object
 


### PR DESCRIPTION
This closes #2931 by adding missing documentation about the `embed` permission

Signed-off-by: Christian Hartmann <chris-hartmann@gmx.de>