### PR TITLE
fix(Results): enhance response loading logic based on active response view

### DIFF
--- a/src/components/PillMenu.vue
+++ b/src/components/PillMenu.vue
@@ -9,7 +9,7 @@
 			v-for="option of options"
 			:key="option.id"
 			:aria-label="isMobile ? option.ariaLabel : null"
-			:checked="active.id"
+			:model-value="active.id"
 			:disabled="disabled || option.disabled"
 			class="pill-menu__toggle"
 			:class="{ 'pill-menu__toggle--icon-only': isMobile && option.icon }"
@@ -17,7 +17,7 @@
 			button-variant-grouped="horizontal"
 			type="radio"
 			:value="option.id"
-			@update:checked="$emit('update:active', option)">
+			@update:modelValue="$emit('update:active', option)">
 			<template v-if="option.icon" #icon>
 				<NcIconSvgWrapper :path="option.icon" />
 			</template>

--- a/src/views/Results.vue
+++ b/src/views/Results.vue
@@ -45,7 +45,8 @@
 					:disabled="noSubmissions"
 					:options="responseViews"
 					:active.sync="activeResponseView"
-					class="response-actions__toggle" />
+					class="response-actions__toggle"
+					@update:active="loadFormResults" />
 
 				<!-- Action menu for cloud export and deletion -->
 				<NcActions
@@ -556,17 +557,26 @@ export default {
 			logger.debug(`Loading results for form ${this.form.hash}`)
 
 			try {
-				const response = await axios.get(
-					generateOcsUrl(
-						'apps/forms/api/v3/forms/{id}/submissions?limit={limit}&offset={offset}&query={query}',
-						{
+				let response = null
+				if (this.activeResponseView.id === 'summary') {
+					response = await axios.get(
+						generateOcsUrl('apps/forms/api/v3/forms/{id}/submissions', {
 							id: this.form.id,
-							limit: this.limit,
-							offset: this.offset,
-							query: this.submissionSearch,
-						},
-					),
-				)
+						}),
+					)
+				} else {
+					response = await axios.get(
+						generateOcsUrl(
+							'apps/forms/api/v3/forms/{id}/submissions?limit={limit}&offset={offset}&query={query}',
+							{
+								id: this.form.id,
+								limit: this.limit,
+								offset: this.offset,
+								query: this.submissionSearch,
+							},
+						),
+					)
+				}
 				const data = OcsResponse2Data(response)
 
 				// Append questions & submissions


### PR DESCRIPTION
This fixes #2943 by always loading all submissions in the summary view

Signed-off-by: Christian Hartmann <chris-hartmann@gmx.de>