### PR TITLE
feat: introduce Grid as a new question type

### DIFF
--- a/lib/Constants.php
+++ b/lib/Constants.php
@@ -71,12 +71,18 @@ class Constants {
 	public const ANSWER_TYPE_DATETIME = 'datetime';
 	public const ANSWER_TYPE_DROPDOWN = 'dropdown';
 	public const ANSWER_TYPE_FILE = 'file';
+	public const ANSWER_TYPE_GRID = 'grid';
 	public const ANSWER_TYPE_LINEARSCALE = 'linearscale';
 	public const ANSWER_TYPE_LONG = 'long';
 	public const ANSWER_TYPE_MULTIPLE = 'multiple';
 	public const ANSWER_TYPE_MULTIPLEUNIQUE = 'multiple_unique';
 	public const ANSWER_TYPE_SHORT = 'short';
 	public const ANSWER_TYPE_TIME = 'time';
+
+    public const ANSWER_GRID_TYPE_CHECKBOX = 'checkbox';
+    public const ANSWER_GRID_TYPE_NUMBER = 'number';
+    public const ANSWER_GRID_TYPE_RADIO = 'radio';
+    public const ANSWER_GRID_TYPE_TEXT = 'text';
 
 	// All AnswerTypes
 	public const ANSWER_TYPES = [
@@ -85,6 +91,7 @@ class Constants {
 		self::ANSWER_TYPE_DATETIME,
 		self::ANSWER_TYPE_DROPDOWN,
 		self::ANSWER_TYPE_FILE,
+		self::ANSWER_TYPE_GRID,
 		self::ANSWER_TYPE_LINEARSCALE,
 		self::ANSWER_TYPE_LONG,
 		self::ANSWER_TYPE_MULTIPLE,
@@ -178,6 +185,21 @@ class Constants {
 		'optionsLabelLowest' => ['string', 'NULL'],
 		'optionsLabelHighest' => ['string', 'NULL'],
 	];
+
+	public const EXTRA_SETTINGS_GRID = [
+		'columnsTitle' => ['string', 'NULL'],
+		'rowsTitle' => ['string', 'NULL'],
+        'columns' => ['array'],
+		'questionType' => ['string'],
+        'rows' => ['array'],
+	];
+
+    public const EXTRA_SETTINGS_GRID_QUESTION_TYPE = [
+        self::ANSWER_GRID_TYPE_CHECKBOX,
+        self::ANSWER_GRID_TYPE_NUMBER,
+        self::ANSWER_GRID_TYPE_RADIO,
+        self::ANSWER_GRID_TYPE_TEXT,
+    ];
 
 	public const FILENAME_INVALID_CHARS = [
 		"\n",

--- a/lib/Controller/ApiController.php
+++ b/lib/Controller/ApiController.php
@@ -61,6 +61,7 @@ use Psr\Log\LoggerInterface;
  * @psalm-import-type FormsPartialForm from ResponseDefinitions
  * @psalm-import-type FormsQuestion from ResponseDefinitions
  * @psalm-import-type FormsQuestionType from ResponseDefinitions
+ * @psalm-import-type FormsQuestionGridSubType from ResponseDefinitions
  * @psalm-import-type FormsSubmission from ResponseDefinitions
  * @psalm-import-type FormsSubmissions from ResponseDefinitions
  * @psalm-import-type FormsUploadedFile from ResponseDefinitions
@@ -445,6 +446,7 @@ class ApiController extends OCSController {
 	 *
 	 * @param int $formId the form id
 	 * @param FormsQuestionType $type the new question type
+	 * @param FormsQuestionGridSubType $subtype the new question subtype
 	 * @param string $text the new question title
 	 * @param ?int $fromId (optional) id of the question that should be cloned
 	 * @return DataResponse<Http::STATUS_CREATED, FormsQuestion, array{}>
@@ -461,7 +463,7 @@ class ApiController extends OCSController {
 	#[NoAdminRequired()]
 	#[BruteForceProtection(action: 'form')]
 	#[ApiRoute(verb: 'POST', url: '/api/v3/forms/{formId}/questions')]
-	public function newQuestion(int $formId, ?string $type = null, string $text = '', ?int $fromId = null): DataResponse {
+	public function newQuestion(int $formId, ?string $type = null, ?string $subtype = null, string $text = '', ?int $fromId = null): DataResponse {
 		$form = $this->formsService->getFormIfAllowed($formId, Constants::PERMISSION_EDIT);
 		$this->formsService->obtainFormLock($form);
 
@@ -505,7 +507,7 @@ class ApiController extends OCSController {
 			$question->setText($text);
 			$question->setDescription('');
 			$question->setIsRequired(false);
-			$question->setExtraSettings([]);
+			$question->setExtraSettings($subtype ? ['questionType' => $subtype] : []);
 
 			$question = $this->questionMapper->insert($question);
 
@@ -820,6 +822,7 @@ class ApiController extends OCSController {
 	 * @param int $formId id of the form
 	 * @param int $questionId id of the question
 	 * @param list<string> $optionTexts the new option text
+	 * @param string|null $optionType the new option type (e.g. 'row')
 	 * @return DataResponse<Http::STATUS_CREATED, list<FormsOption>, array{}> Returns a DataResponse containing the added options
 	 * @throws OCSBadRequestException This question is not part ot the given form
 	 * @throws OCSForbiddenException This form is archived and can not be modified
@@ -833,11 +836,12 @@ class ApiController extends OCSController {
 	#[NoAdminRequired()]
 	#[BruteForceProtection(action: 'form')]
 	#[ApiRoute(verb: 'POST', url: '/api/v3/forms/{formId}/questions/{questionId}/options')]
-	public function newOption(int $formId, int $questionId, array $optionTexts): DataResponse {
-		$this->logger->debug('Adding new options: formId: {formId}, questionId: {questionId}, text: {text}', [
+	public function newOption(int $formId, int $questionId, array $optionTexts, ?string $optionType = null): DataResponse {
+		$this->logger->debug('Adding new options: formId: {formId}, questionId: {questionId}, text: {text}, optionType: {optionType}', [
 			'formId' => $formId,
 			'questionId' => $questionId,
 			'text' => $optionTexts,
+            'optionType' => $optionType,
 		]);
 
 		$form = $this->formsService->getFormIfAllowed($formId, Constants::PERMISSION_EDIT);
@@ -863,7 +867,7 @@ class ApiController extends OCSController {
 		}
 
 		// Retrieve all options sorted by 'order'. Takes the order of the last array-element and adds one.
-		$options = $this->optionMapper->findByQuestion($questionId);
+		$options = $this->optionMapper->findByQuestion($questionId, $optionType);
 		$lastOption = array_pop($options);
 		if ($lastOption) {
 			$optionOrder = $lastOption->getOrder() + 1;
@@ -878,6 +882,7 @@ class ApiController extends OCSController {
 			$option->setQuestionId($questionId);
 			$option->setText($text);
 			$option->setOrder($optionOrder++);
+            $option->setOptionType($optionType);
 
 			try {
 				$option = $this->optionMapper->insert($option);
@@ -1034,6 +1039,7 @@ class ApiController extends OCSController {
 	 * @param int $formId id of form
 	 * @param int $questionId id of question
 	 * @param list<int> $newOrder Array of option ids in new order.
+     * @param string|null $optionType the new option type (e.g. 'row')
 	 * @return DataResponse<Http::STATUS_OK, array<string, FormsOrder>, array{}>
 	 * @throws OCSBadRequestException The given question id doesn't match the form
 	 * @throws OCSBadRequestException The given array contains duplicates
@@ -1050,7 +1056,7 @@ class ApiController extends OCSController {
 	#[NoAdminRequired()]
 	#[BruteForceProtection(action: 'form')]
 	#[ApiRoute(verb: 'PATCH', url: '/api/v3/forms/{formId}/questions/{questionId}/options')]
-	public function reorderOptions(int $formId, int $questionId, array $newOrder) {
+	public function reorderOptions(int $formId, int $questionId, array $newOrder, ?string $optionType = null): DataResponse {
 		$form = $this->formsService->getFormIfAllowed($formId, Constants::PERMISSION_EDIT);
 		$this->formsService->obtainFormLock($form);
 
@@ -1077,7 +1083,7 @@ class ApiController extends OCSController {
 			throw new OCSBadRequestException('The given array contains duplicates');
 		}
 
-		$options = $this->optionMapper->findByQuestion($questionId);
+		$options = $this->optionMapper->findByQuestion($questionId, $optionType);
 
 		if (sizeof($options) !== sizeof($newOrder)) {
 			$this->logger->debug('The length of the given array does not match the number of stored options');

--- a/lib/Db/Option.php
+++ b/lib/Db/Option.php
@@ -20,6 +20,8 @@ use OCP\AppFramework\Db\Entity;
  * @method void setText(string $value)
  * @method int getOrder();
  * @method void setOrder(int $value)
+ * @method string getOptionType()
+ * @method void setOptionType(string $value)
  */
 class Option extends Entity {
 
@@ -27,6 +29,10 @@ class Option extends Entity {
 	protected int|float|null $questionId;
 	protected ?string $text;
 	protected ?int $order;
+	protected ?string $optionType;
+
+    public const OPTION_TYPE_ROW = 'row';
+    public const OPTION_TYPE_COLUMN = 'column';
 
 	/**
 	 * Option constructor.
@@ -35,20 +41,20 @@ class Option extends Entity {
 		$this->questionId = null;
 		$this->text = null;
 		$this->order = null;
+		$this->optionType = null;
 		$this->addType('questionId', 'integer');
 		$this->addType('order', 'integer');
 		$this->addType('text', 'string');
+		$this->addType('optionType', 'string');
 	}
 
-	/**
-	 * @return FormsOption
-	 */
 	public function read(): array {
 		return [
 			'id' => $this->getId(),
 			'questionId' => $this->getQuestionId(),
 			'order' => $this->getOrder(),
 			'text' => (string)$this->getText(),
+            'optionType' => $this->getOptionType(),
 		];
 	}
 }

--- a/lib/Db/OptionMapper.php
+++ b/lib/Db/OptionMapper.php
@@ -27,17 +27,20 @@ class OptionMapper extends QBMapper {
 
 	/**
 	 * @param int|float $questionId
+     * @param string|null $optionType
 	 * @return Option[]
 	 */
-	public function findByQuestion(int|float $questionId): array {
+	public function findByQuestion(int|float $questionId, ?string $optionType = null): array {
 		$qb = $this->db->getQueryBuilder();
 
 		$qb->select('*')
 			->from($this->getTableName())
-			->where(
-				$qb->expr()->eq('question_id', $qb->createNamedParameter($questionId))
-			)
-			->orderBy('order')
+			->where($qb->expr()->eq('question_id', $qb->createNamedParameter($questionId)));
+        if ($optionType) {
+            $qb->andWhere($qb->expr()->eq('option_type', $qb->createNamedParameter($optionType)));
+        }
+        $qb
+            ->orderBy('order')
 			->addOrderBy('id');
 
 		return $this->findEntities($qb);

--- a/lib/Migration/Version050300Date20250914000000.php
+++ b/lib/Migration/Version050300Date20250914000000.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Forms\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\DB\Types;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+class Version050300Date20250914000000 extends SimpleMigrationStep {
+
+	/**
+	 * @param IOutput $output
+	 * @param Closure $schemaClosure The `\Closure` returns a `ISchemaWrapper`
+	 * @param array $options
+	 * @return null|ISchemaWrapper
+	 */
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
+		/** @var ISchemaWrapper $schema */
+		$schema = $schemaClosure();
+		$table = $schema->getTable('forms_v2_options');
+
+		if (!$table->hascolumn('option_type')) {
+			$table->addColumn('option_type', Types::STRING, [
+				'notnull' => false,
+				'default' => null,
+			]);
+		}
+
+		return $schema;
+	}
+}

--- a/lib/ResponseDefinitions.php
+++ b/lib/ResponseDefinitions.php
@@ -42,7 +42,8 @@ namespace OCA\Forms;
  *   validationType?: string
  * }
  *
- * @psalm-type FormsQuestionType = "dropdown"|"multiple"|"multiple_unique"|"date"|"time"|"short"|"long"|"file"|"datetime"
+ * @psalm-type FormsQuestionType = "dropdown"|"multiple"|"multiple_unique"|"date"|"time"|"short"|"long"|"file"|"datetime"|"grid"
+ * @psalm-type FormsQuestionGridSubType = "checkbox"|"number"|"radio"|"text"
  *
  * @psalm-type FormsQuestion = array{
  *   id: int,

--- a/lib/Service/FormsService.php
+++ b/lib/Service/FormsService.php
@@ -805,6 +805,9 @@ class FormsService {
 			case Constants::ANSWER_TYPE_DATE:
 				$allowed = Constants::EXTRA_SETTINGS_DATE;
 				break;
+            case Constants::ANSWER_TYPE_GRID:
+                $allowed = Constants::EXTRA_SETTINGS_GRID;
+				break;
 			case Constants::ANSWER_TYPE_TIME:
 				$allowed = Constants::EXTRA_SETTINGS_TIME;
 				break;

--- a/openapi.json
+++ b/openapi.json
@@ -536,7 +536,8 @@
                     "short",
                     "long",
                     "file",
-                    "datetime"
+                    "datetime",
+                    "grid"
                 ]
             },
             "Share": {
@@ -2622,6 +2623,12 @@
                                         "items": {
                                             "type": "string"
                                         }
+                                    },
+                                    "optionType": {
+                                        "type": "string",
+                                        "nullable": true,
+                                        "default": null,
+                                        "description": "the new option type (e.g. 'row')"
                                     }
                                 }
                             }

--- a/src/components/Questions/QuestionGrid.vue
+++ b/src/components/Questions/QuestionGrid.vue
@@ -1,0 +1,545 @@
+<!--
+  - SPDX-FileCopyrightText: 2020 Nextcloud GmbH and Nextcloud contributors
+  - SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
+<template>
+	<Question
+		v-bind="questionProps"
+		:title-placeholder="answerType.titlePlaceholder"
+		:warning-invalid="answerType.warningInvalid"
+		:content-valid="contentValid"
+		:shift-drag-handle="shiftDragHandle"
+		v-on="commonListeners">
+		<template #actions>
+
+      <NcActionInput
+          :model-value.sync="columnsTitle"
+          :label-outside="false"
+          :show-trailing-button="false"
+          :label="t('forms', 'Columns Title')">
+        <template #icon>
+          <IconArrowRight :size="20" />
+        </template>
+        {{ t('forms', 'Columns Title') }}
+      </NcActionInput>
+
+      <NcActionInput
+          :modelValue.sync="rowsTitle"
+          :label-outside="false"
+          :show-trailing-button="false"
+          :label="t('forms', 'Rows Title')">
+        <template #icon>
+          <IconArrowDown :size="20" />
+        </template>
+        {{ t('forms', 'Rows Title') }}
+      </NcActionInput>
+    </template>
+		<template v-if="readOnly">
+			<fieldset :name="name || undefined" :aria-labelledby="titleId">
+				<NcNoteCard v-if="hasError" :id="errorId" type="error">
+					{{ errorMessage }}
+				</NcNoteCard>
+
+        <table class="answer-grid">
+          <thead>
+            <tr>
+              <th class="legend">
+                <div v-if="columnsTitle || rowsTitle">
+                  <span class="columns-title">{{ columnsTitle }}</span>
+                  <span class="rows-title">{{ rowsTitle }}</span>
+                  <div class="line"></div>
+                </div>
+              </th>
+
+              <th v-for="column of columns" :key="column.local ? 'option-local' : column.id">{{ column.text }}</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr v-for="row of rows" :key="row.local ? 'option-local' : row.id">
+              <td class="first-column">{{ row.text }}</td>
+              <td v-for="column of columns" :key="column.local ? 'option-local' : column.id">
+
+                <template v-if="questionType === 'radio'">
+<!--                  <input type="radio" />-->
+<!--                    @keydown.enter.exact.prevent="onKeydownEnter"-->
+
+<!--                    :required="checkRequired(answer.id)"-->
+
+                  <NcCheckboxRadioSwitch
+                    :aria-errormessage="hasError ? errorId : undefined"
+                    :aria-invalid="hasError ? 'true' : undefined"
+                    :model-value="values[row.id]"
+                    :value="column.id.toString()"
+                    :name="`${row.id}-answer`"
+                    @update:modelValue="onChangeCheckboxRadio(row.id, $event)"
+                    type="radio"
+                  />
+                </template>
+
+                <template v-if="questionType === 'checkbox'">
+                  <NcCheckboxRadioSwitch
+                      :aria-errormessage="hasError ? errorId : undefined"
+                      :aria-invalid="hasError ? 'true' : undefined"
+                      :model-value="values[row.id] || []"
+                      :value="column.id.toString()"
+                      :name="`${row.id}-answer`"
+                      @update:modelValue="onChangeCheckboxRadio(row.id, $event)"
+                      type="checkbox"
+                  />
+                </template>
+
+                <template v-if="questionType === 'number'">
+                  <input type="number" />
+                </template>
+
+                <template v-if="questionType === 'text'">
+                  <input type="text" />
+                </template>
+
+              </td>
+            </tr>
+          </tbody>
+        </table>
+
+			</fieldset>
+		</template>
+
+		<template v-else>
+			<div v-if="isLoading">
+				<NcLoadingIcon :size="64" />
+			</div>
+
+      <template v-else>
+
+        <div>{{ t('forms', 'Columns') }}</div>
+        <Draggable
+				    v-model="columns"
+            class="question__content"
+            animation="200"
+            direction="vertical"
+            handle=".option__drag-handle"
+            invert-swap
+            tag="ul"
+            @change="saveOptionsOrder('column')"
+            @start="isDragging = true"
+            @end="isDragging = false">
+          <TransitionGroup
+              :name="
+						isDragging
+							? 'no-external-transition-on-drag'
+							: 'options-list-transition'
+					">
+            <!-- Column input edit -->
+            <AnswerInput
+                v-for="(answer, index) in columns"
+                :key="answer.local ? 'option-local' : answer.id"
+                ref="input"
+                :answer="answer"
+                :form-id="formId"
+                :index="index"
+                :is-unique="isUnique"
+                :max-index="columns.length - 2"
+                :max-option-length="maxStringLengths.optionText"
+                option-type="column"
+                @create-answer="onCreateAnswer"
+                @update:answer="updateAnswer"
+                @delete="deleteOption"
+                @focus-next="focusNextInput"
+                @move-up="onOptionMoveUp(index, 'column')"
+                @move-down="onOptionMoveDown(index, 'column')"
+                @tabbed-out="checkValidOption('column')" />
+          </TransitionGroup>
+        </Draggable>
+
+        <div>{{ t('forms', 'Rows') }}</div>
+        <Draggable
+				v-model="rows"
+				class="question__content"
+				animation="200"
+				direction="vertical"
+				handle=".option__drag-handle"
+				invert-swap
+				tag="ul"
+				@change="saveOptionsOrder('row')"
+				@start="isDragging = true"
+				@end="isDragging = false">
+				<TransitionGroup
+					:name="
+						isDragging
+							? 'no-external-transition-on-drag'
+							: 'options-list-transition'
+					">
+					<!-- Row input edit -->
+					<AnswerInput
+						v-for="(answer, index) in rows"
+						:key="answer.local ? 'option-local' : answer.id"
+						ref="input"
+						:answer="answer"
+						:form-id="formId"
+						:index="index"
+						:is-unique="isUnique"
+						:max-index="rows.length - 2"
+						:max-option-length="maxStringLengths.optionText"
+            option-type="row"
+						@create-answer="onCreateAnswer"
+						@update:answer="updateAnswer"
+						@delete="deleteOption"
+						@focus-next="focusNextInput"
+						@move-up="onOptionMoveUp(index, 'row')"
+						@move-down="onOptionMoveDown(index, 'row')"
+						@tabbed-out="checkValidOption('row')" />
+				</TransitionGroup>
+			</Draggable>
+      </template>
+		</template>
+
+	</Question>
+</template>
+
+<script>
+import { translate as t, translatePlural as n } from '@nextcloud/l10n'
+import Draggable from 'vuedraggable'
+import NcActionButton from '@nextcloud/vue/components/NcActionButton'
+import NcActionCheckbox from '@nextcloud/vue/components/NcActionCheckbox'
+import NcActionInput from '@nextcloud/vue/components/NcActionInput'
+import NcCheckboxRadioSwitch from '@nextcloud/vue/components/NcCheckboxRadioSwitch'
+import NcInputField from '@nextcloud/vue/components/NcInputField'
+import NcLoadingIcon from '@nextcloud/vue/components/NcLoadingIcon'
+import NcNoteCard from '@nextcloud/vue/components/NcNoteCard'
+
+import IconArrowRight from 'vue-material-design-icons/ArrowRight.vue'
+import IconArrowDown from 'vue-material-design-icons/ArrowDown.vue'
+import IconCheckboxBlankOutline from 'vue-material-design-icons/CheckboxBlankOutline.vue'
+import IconContentPaste from 'vue-material-design-icons/ContentPaste.vue'
+import IconRadioboxBlank from 'vue-material-design-icons/RadioboxBlank.vue'
+
+import AnswerInput from './AnswerInput.vue'
+import QuestionMixin from '../../mixins/QuestionMixin.js'
+import QuestionMultipleMixin from '../../mixins/QuestionMultipleMixin.ts'
+
+export default {
+	name: 'QuestionGrid',
+
+	components: {
+    IconArrowRight,
+    IconArrowDown,
+		AnswerInput,
+		Draggable,
+		IconCheckboxBlankOutline,
+		IconContentPaste,
+		IconRadioboxBlank,
+		NcActionButton,
+		NcActionCheckbox,
+		NcActionInput,
+		NcCheckboxRadioSwitch,
+		NcInputField,
+		NcLoadingIcon,
+		NcNoteCard,
+	},
+
+	mixins: [QuestionMixin, QuestionMultipleMixin],
+
+	data() {
+		return {
+			/**
+			 * The shown error message
+			 */
+			errorMessage: null,
+
+			isDragging: false,
+			isLoading: false,
+      questionTypes: [
+        { label: t('forms', 'Radio'), id: 'radio' },
+        { label: t('forms', 'Checkbox'), id: 'checkbox' },
+        { label: t('forms', 'Number'), id: 'number' },
+        { label: t('forms', 'Text'), id: 'text' },
+      ]
+		}
+	},
+
+	computed: {
+		isUnique() {
+			return this.answerType.unique === true
+		},
+
+		hasError() {
+			return !!this.errorMessage
+		},
+
+		shiftDragHandle() {
+			return !this.readOnly && this.options.length !== 0 && !this.isLastEmpty
+		},
+
+		questionValues() {
+			return this.isUnique ? this.values?.[0] : this.values
+		},
+
+		titleId() {
+			return `q${this.index}_title`
+		},
+
+		errorId() {
+			return `q${this.index}_error`
+		},
+
+		questionType() {
+			return this.extraSettings?.questionType ?? 'radio'
+		},
+
+    columns: {
+      get() {
+        return this.sortOptionsOfType(this.options, 'column')
+      },
+      set(value) {
+        this.updateOptionsOrder(value, 'column')
+      }
+    },
+
+    rows: {
+      get() {
+        return this.sortOptionsOfType(this.options, 'row')
+      },
+      set(value) {
+        this.updateOptionsOrder(value, 'row')
+      }
+    },
+
+    columnsTitle: {
+      get() {
+        return this.extraSettings?.columnsTitle ?? ''
+      },
+      set(value) {
+        this.onExtraSettingsChange({ columnsTitle : value })
+      }
+    },
+
+    rowsTitle: {
+      get() {
+        return this.extraSettings?.rowsTitle ?? ''
+      },
+      set(value) {
+        this.onExtraSettingsChange({ rowsTitle : value })
+      }
+    },
+	},
+
+	methods: {
+		async validate() {
+			if (!this.isUnique) {
+				// Validate limits
+				const max = this.extraSettings.optionsLimitMax ?? 0
+				const min = this.extraSettings.optionsLimitMin ?? 0
+				if (max && this.values.length > max) {
+					this.errorMessage = n(
+						'forms',
+						'You must choose at most one option',
+						'You must choose a maximum of %n options',
+						max,
+					)
+					return false
+				}
+				if (min && this.values.length < min) {
+					this.errorMessage = n(
+						'forms',
+						'You must choose at least one option',
+						'You must choose at least %n options',
+						min,
+					)
+					return false
+				}
+			}
+
+			this.errorMessage = null
+			return true
+		},
+
+    onChangeCheckboxRadio(rowId, value) {
+      const values = { ...this.values }
+      values[rowId] = value
+
+			this.$emit('update:values', values)
+		},
+
+		/**
+		 * Is the provided answer required ?
+		 * This is needed for checkboxes as html5
+		 * doesn't allow to require at least ONE checked.
+		 * So we require the one that are checked or all
+		 * if none are checked yet.
+		 *
+		 * @return {boolean}
+		 */
+		checkRequired() {
+			// false, if question not required
+			if (!this.isRequired) {
+				return false
+			}
+
+			// true for Radiobuttons
+			if (this.isUnique) {
+				return true
+			}
+
+			// For checkboxes, only required if no other is checked
+			return this.areNoneChecked
+		},
+  },
+}
+</script>
+
+<style lang="scss" scoped>
+.question__content {
+	display: flex;
+	flex-direction: column;
+	gap: var(--default-grid-baseline);
+}
+
+.question__item {
+	position: relative;
+	display: inline-flex;
+	min-height: var(--default-clickable-area);
+
+	&__pseudoInput {
+		color: var(--color-primary-element);
+		margin-inline-start: -2px;
+		z-index: 1;
+	}
+
+	.question__input {
+		width: calc(100% - var(--default-clickable-area));
+		position: relative;
+		inset-inline-start: -34px;
+		inset-block-start: 1px;
+		margin-inline-end: 10px !important;
+		padding-inline-start: 36px !important;
+	}
+
+	.question__label {
+		flex: 1 1 100%;
+		// Overwrite guest page core styles
+		text-align: start !important;
+		// Some rounding issues lead to this strange number, so label and answerInput show up a the same position, working on different browsers.
+		padding-block: 6.5px 0;
+		padding-inline: 30px 0;
+		line-height: 22px;
+		min-height: 34px;
+		height: min-content;
+		position: relative;
+
+		&::before {
+			box-sizing: border-box;
+			// Adjust position manually for proper position to text
+			position: absolute;
+			inset-block-start: 10px;
+			width: 16px;
+			height: 16px;
+			margin-inline: -30px 14px !important;
+			margin-block-end: 0;
+		}
+	}
+}
+
+.question__other-answer {
+	display: flex;
+	gap: 4px 16px;
+	flex-wrap: wrap;
+
+	.question__label {
+		flex-basis: content;
+	}
+
+	.question__input {
+		flex: 1;
+		min-width: 260px;
+	}
+
+	.input-field__input {
+		min-height: var(--default-clickable-area);
+	}
+}
+
+.question__other-answer:deep() .input-field__input {
+	min-height: var(--default-clickable-area);
+}
+
+.options-list-transition-move,
+.options-list-transition-enter-active,
+.options-list-transition-leave-active {
+	transition: all var(--animation-slow) ease;
+}
+
+.options-list-transition-enter-from,
+.options-list-transition-leave-to {
+	opacity: 0;
+	transform: translateX(44px);
+}
+
+/* ensure leaving items are taken out of layout flow so that moving
+   animations can be calculated correctly. */
+.options-list-transition-leave-active {
+	position: absolute;
+}
+
+.answer-grid {
+  border-collapse: separate;
+  width: 100%;
+  border-spacing: 8px 4px;
+
+  thead {
+    border-bottom: 2px solid var(--color-border);
+  }
+
+  td {
+    min-height: 34px;
+    min-width: 64px;
+    text-align: center;
+  }
+
+  th {
+    min-height: 44px;
+    text-align: center;
+  }
+
+  .first-column {
+    min-width: 200px;
+    text-align: left;
+  }
+
+  .legend {
+    width: 200px;
+    height: 80px;
+    padding: 0;
+    margin: 0;
+
+    .line {
+      width: 200px;
+      height: 80px;
+      border-bottom: 1px solid red;
+      transform: translateY(-36px) translateX(12px) rotate(20deg);
+      position: absolute;
+    }
+
+    .columns-title {
+      position: absolute;
+      bottom: 1px;
+      left: 1px;
+    }
+
+    .rows-title {
+      position: absolute;
+      top: 1px;
+      right: 1px;
+    }
+  }
+
+  .legend>div {
+    position: relative;
+    height: 100%;
+    width: 100%;
+    top: 0;
+    left: 0;
+  }
+
+}
+</style>

--- a/src/mixins/QuestionMixin.js
+++ b/src/mixins/QuestionMixin.js
@@ -76,7 +76,7 @@ export default {
 		 * The user answers
 		 */
 		values: {
-			type: Array,
+			type: [Array, Object],
 			default() {
 				return []
 			},
@@ -387,6 +387,7 @@ export default {
 						id: option.id, // Use the ID from the server
 						questionId: this.id,
 						text: option.text,
+                        optionType: option.optionType,
 						local: false,
 					})
 				})

--- a/src/models/AnswerTypes.js
+++ b/src/models/AnswerTypes.js
@@ -7,6 +7,7 @@ import QuestionColor from '../components/Questions/QuestionColor.vue'
 import QuestionDate from '../components/Questions/QuestionDate.vue'
 import QuestionDropdown from '../components/Questions/QuestionDropdown.vue'
 import QuestionFile from '../components/Questions/QuestionFile.vue'
+import QuestionGrid from '../components/Questions/QuestionGrid.vue'
 import QuestionLinearScale from '../components/Questions/QuestionLinearScale.vue'
 import QuestionLong from '../components/Questions/QuestionLong.vue'
 import QuestionMultiple from '../components/Questions/QuestionMultiple.vue'
@@ -17,11 +18,14 @@ import IconCalendar from 'vue-material-design-icons/CalendarOutline.vue'
 import IconCheckboxOutline from 'vue-material-design-icons/CheckboxOutline.vue'
 import IconClockOutline from 'vue-material-design-icons/ClockOutline.vue'
 import IconFile from 'vue-material-design-icons/FileOutline.vue'
+import IconGrid from 'vue-material-design-icons/Grid.vue'
 import IconLinearScale from '../components/Icons/IconLinearScale.vue'
 import IconPalette from '../components/Icons/IconPalette.vue'
 import IconRadioboxMarked from 'vue-material-design-icons/RadioboxMarked.vue'
 import IconTextLong from 'vue-material-design-icons/TextLong.vue'
 import IconTextShort from 'vue-material-design-icons/TextShort.vue'
+import IconNumeric from 'vue-material-design-icons/Numeric.vue'
+import IconRadioboxBlank from "vue-material-design-icons/RadioboxBlank.vue";
 
 /**
  * @typedef {object} AnswerTypes
@@ -115,6 +119,51 @@ export default {
 		titlePlaceholder: t('forms', 'File question title'),
 		warningInvalid: t('forms', 'This question needs a title!'),
 	},
+
+	grid: {
+		component: QuestionGrid,
+		icon: IconGrid,
+		label: t('forms', 'Grid'),
+        // fixme: remove non-needed properties
+
+        subtypes: {
+            radio: {
+                label: t('forms', 'Radio'),
+                icon: IconRadioboxBlank,
+                extraSettings: {
+                    questionType: 'radio',
+                },
+            },
+            checkbox: {
+                label: t('forms', 'Checkbox'),
+                icon: IconCheckboxOutline,
+                extraSettings: {
+                    questionType: 'checkbox',
+                },
+            },
+            number: {
+                label: t('forms', 'Number'),
+                icon: IconNumeric,
+                extraSettings: {
+                    questionType: 'number',
+                },
+            },
+            text: {
+                label: t('forms', 'Text'),
+                icon: IconTextShort,
+                extraSettings: {
+                    questionType: 'text',
+                },
+            }
+        },
+
+        validate: (question) => question.options.length > 0,
+
+        titlePlaceholder: t('forms', 'Grid question title'),
+        warningInvalid: t('forms', 'This question needs a title!'),
+        createPlaceholder: t('forms', 'People can submit a different answer'),
+        submitPlaceholder: t('forms', 'Enter your answer'),
+    },
 
 	short: {
 		component: QuestionShort,

--- a/src/models/Constants.ts
+++ b/src/models/Constants.ts
@@ -31,3 +31,9 @@ export const INPUT_DEBOUNCE_MS = 400
  * A constant representing the prefix used for identifying "other" answers
  */
 export const QUESTION_EXTRASETTINGS_OTHER_PREFIX = 'system-other-answer:'
+
+export enum OptionType {
+    Row = 'row',
+    Column = 'column',
+    Choice = 'choice',
+}

--- a/src/models/Entities.d.ts
+++ b/src/models/Entities.d.ts
@@ -7,5 +7,6 @@ export interface FormsOption {
 	id: number
 	text: string
 	order?: number
-	questionId: number
+	questionId: number,
+    optionType: string,
 }

--- a/src/views/Create.vue
+++ b/src/views/Create.vue
@@ -157,18 +157,38 @@
 							<NcLoadingIcon v-if="isLoadingQuestions" :size="20" />
 							<IconPlus v-else :size="20" />
 						</template>
-						<NcActionButton
-							v-for="(answer, type) in answerTypesFilter"
-							:key="answer.label"
-							close-after-click
-							:disabled="isLoadingQuestions"
-							class="question-menu__question"
-							@click="addQuestion(type)">
-							<template #icon>
-								<Icon :is="answer.icon" :size="20" />
-							</template>
-							{{ answer.label }}
-						</NcActionButton>
+
+            <template v-if="!activeQuestionType">
+              <NcActionButton
+                v-for="(answer, type) in answerTypesFilter"
+                :key="answer.label"
+                :close-after-click="!answer.subtypes"
+                :disabled="isLoadingQuestions"
+                class="question-menu__question"
+                @click="answer.subtypes ? activeQuestionType = type : addQuestion(type)">
+                <template #icon>
+                  <Icon :is="answer.icon" :size="20" />
+                </template>
+                {{ answer.label }}
+              </NcActionButton>
+            </template>
+            <!--            <NcActionSeparator />-->
+
+            <template v-else>
+              <NcActionButton
+                  v-for="(answer, type) in answerTypesFilter[activeQuestionType].subtypes"
+                  :key="'subtype-' + answer.label"
+                  close-after-click
+                  :disabled="isLoadingQuestions"
+                  class="question-menu__question"
+                  @click="addQuestion(activeQuestionType, type)">
+                <template #icon>
+                  <Icon :is="answer.icon" :size="20" />
+                </template>
+                {{ answer.label }}
+              </NcActionButton>
+            </template>
+
 					</NcActions>
 				</div>
 			</section>
@@ -240,6 +260,7 @@ export default {
 
 			maxStringLengths: loadState('forms', 'maxStringLengths'),
 			questionMenuOpened: false,
+      activeQuestionType: null,
 		}
 	},
 
@@ -327,6 +348,12 @@ export default {
 				this.resizeDescription()
 			}
 		},
+
+    questionTypeSubtypes(value) {
+      // if (!value) {
+      //   this.activeQuestionType = null
+      // }
+    },
 	},
 
 	mounted() {
@@ -405,8 +432,9 @@ export default {
 		 * Add a new question to the current form
 		 *
 		 * @param {string} type the question type, see AnswerTypes
+		 * @param {string|null} subtype the question subtype, see AnswerTypes.subtypes
 		 */
-		async addQuestion(type) {
+		async addQuestion(type, subtype = null) {
 			const text = ''
 			this.isLoadingQuestions = true
 
@@ -418,6 +446,7 @@ export default {
 					{
 						type,
 						text,
+            subtype,
 					},
 				)
 				const question = OcsResponse2Data(response)


### PR DESCRIPTION
Closes #2606

:construction: Development still in progress. This is reopening of the #2924 but pushed to upstream instead of my fork.

I'm trying to reuse already existent `Option` entity by adding extra column `optionType=row|column`.

## :heavy_check_mark: Implemented
<details><summary>:mag: Various input type</summary>
<p>

<img width="400" alt="image" src="https://github.com/user-attachments/assets/72057b01-664b-4ddc-9492-7df57e4e0ce7" />

<img width="400" alt="image" src="https://github.com/user-attachments/assets/f69ae99d-3339-4df3-bc06-835a9b0c8580" />

</p>
</details> 


<details><summary>:mag: Cols/Rows management + legend titles</summary>
<p>

<img width="400" alt="image" src="https://github.com/user-attachments/assets/95b6c3d4-6ed3-4fdc-b118-4d4b2fc94ccf" />

</p>
</details> 


<details><summary>:mag: Table rendering</summary>
<p>

<img width="400" alt="image" src="https://github.com/user-attachments/assets/b2dfcdad-3c64-44b4-abb6-5586153d95ae" />

<img width="400" alt="image" src="https://github.com/user-attachments/assets/e4615c67-8e25-4ce3-ac0d-18cc21899840" />

<img width="400" alt="image" src="https://github.com/user-attachments/assets/2f825b39-9fef-46a2-b73a-36c2b8832e88" />

</p>
</details> 

## :spiral_notepad: Todo
- [ ] Store and display results
- [ ] Export
- [ ] Tests
