### PR TITLE
fix: Reset submission count after clearing submissions

### DIFF
--- a/src/views/Results.vue
+++ b/src/views/Results.vue
@@ -799,6 +799,7 @@ export default {
 					}),
 				)
 				this.submissions = []
+				this.form.submissionCount = 0
 				emit('forms:last-updated:set', this.form.id)
 			} catch (error) {
 				logger.error('Error while removing responses', { error })


### PR DESCRIPTION
This fixes #3013 by resetting the submissionCount to 0 when all submissions are deleted

Signed-off-by: Christian Hartmann <chris-hartmann@gmx.de>