### PR TITLE
fix: Update permission checks for archiving forms and transfer ownership

### DIFF
--- a/src/components/SidebarTabs/SettingsSidebarTab.vue
+++ b/src/components/SidebarTabs/SettingsSidebarTab.vue
@@ -103,7 +103,7 @@
 		<NcCheckboxRadioSwitch
 			:model-value="formArchived"
 			aria-describedby="forms-settings__archive-form"
-			:disabled="locked"
+			:disabled="locked || !isCurrentUserOwner"
 			type="switch"
 			@update:model-value="onFormArchivedChange">
 			{{ t('forms', 'Archive form') }}
@@ -168,7 +168,10 @@
 			</div>
 		</div>
 
-		<TransferOwnership :locked="locked" :form="form" />
+		<TransferOwnership
+			:locked="locked"
+			:is-owner="isCurrentUserOwner"
+			:form="form" />
 	</div>
 </template>
 

--- a/src/components/SidebarTabs/TransferOwnership.vue
+++ b/src/components/SidebarTabs/TransferOwnership.vue
@@ -10,7 +10,7 @@
 			alignment="start"
 			variant="tertiary"
 			wide
-			:disabled="locked"
+			:disabled="locked || !isOwner"
 			@click="openModal">
 			<span class="transfer-button__text">{{
 				t('forms', 'Transfer ownership')
@@ -114,6 +114,11 @@ export default {
 	props: {
 		form: {
 			type: Object,
+			required: true,
+		},
+
+		isOwner: {
+			type: Boolean,
 			required: true,
 		},
 


### PR DESCRIPTION
This fixes #3024 by adjusting the permission checks in the backend. It also adds two fixes to disable settings in the front end if the user is not the owner.

Signed-off-by: Christian Hartmann <chris-hartmann@gmx.de>