### PR TITLE
feat: shows a confirmation dialog on question deletion

### DIFF
--- a/src/components/Questions/Question.vue
+++ b/src/components/Questions/Question.vue
@@ -114,7 +114,7 @@
 						</template>
 						{{ t('forms', 'Copy question') }}
 					</NcActionButton>
-					<NcActionButton @click="onDelete">
+					<NcActionButton close-after-click @click="onDelete">
 						<template #icon>
 							<IconDelete :size="20" />
 						</template>


### PR DESCRIPTION
We've found that sometimes users can accidentally delete their questions. Let's add confirmation dialog to be more consistent with other deletions.

<img width="400" alt="image" src="https://github.com/user-attachments/assets/b3d69192-67b9-44c1-9dd3-9e82860f55a6" />
