### PR TITLE
feat: Add confirmation email for form respondents

### DIFF
--- a/CHANGELOG.en.md
+++ b/CHANGELOG.en.md
@@ -5,6 +5,18 @@
 
 # Changelog
 
+## Unreleased
+
+- **Confirmation emails for respondents**
+
+    Form owners can enable an automatic confirmation email that is sent to the respondent after a successful submission.
+    Requires an email-validated short text question in the form.
+
+    Supported placeholders in subject/body:
+
+    - `{formTitle}`, `{formDescription}`
+    - `{<fieldName>}` (question `name` or text, sanitized)
+
 ## v5.2.0 - 2025-09-25
 
 - **Time: restrictions and ranges**

--- a/docs/API_v3.md
+++ b/docs/API_v3.md
@@ -175,6 +175,9 @@ Returns the full-depth object of the requested form (without submissions).
   "state": 0,
   "lockedBy": null,
   "lockedUntil": null,
+  "confirmationEmailEnabled": false,
+  "confirmationEmailSubject": null,
+  "confirmationEmailBody": null,
   "permissions": [
     "edit",
     "results",

--- a/docs/DataStructure.md
+++ b/docs/DataStructure.md
@@ -21,6 +21,9 @@ This document describes the Object-Structure, that is used within the Forms App 
 | description          | String                               | max. 8192 ch.                           | The Form description                                                                                                             |
 | ownerId              | String                               |                                         | The nextcloud userId of the form owner                                                                                           |
 | submissionMessage    | String                               | max. 2048 ch.                           | Optional custom message, with Markdown support, to be shown to users when the form is submitted (default is used if set to null) |
+| confirmationEmailEnabled | Boolean                          |                                         | If enabled, send a confirmation email to the respondent after submission                                                         |
+| confirmationEmailSubject | String                           | max. 255 ch.                            | Optional confirmation email subject template (supports placeholders)                                                              |
+| confirmationEmailBody    | String                           |                                         | Optional confirmation email body template (plain text, supports placeholders)                                                    |
 | created              | unix timestamp                       |                                         | When the form has been created                                                                                                   |
 | access               | [Access-Object](#access-object)      |                                         | Describing access-settings of the form                                                                                           |
 | expires              | unix-timestamp                       |                                         | When the form should expire. Timestamp `0` indicates _never_                                                                     |
@@ -46,6 +49,9 @@ This document describes the Object-Structure, that is used within the Forms App 
   "title": "Form 1",
   "description": "Description Text",
   "ownerId": "jonas",
+  "confirmationEmailEnabled": false,
+  "confirmationEmailSubject": null,
+  "confirmationEmailBody": null,
   "created": 1611240961,
   "access": {},
   "expires": 0,

--- a/lib/Constants.php
+++ b/lib/Constants.php
@@ -147,6 +147,7 @@ class Constants {
 	];
 
 	public const EXTRA_SETTINGS_SHORT = [
+		'confirmationEmailRecipient' => ['boolean'],
 		'validationType' => ['string'],
 		'validationRegex' => ['string'],
 	];

--- a/lib/Db/Form.php
+++ b/lib/Db/Form.php
@@ -53,6 +53,14 @@ use OCP\AppFramework\Db\Entity;
  * @method int|null getMaxSubmissions()
  * @method void setMaxSubmissions(int|null $value)
  * @method void setLockedUntil(int|null $value)
+ * @method int getConfirmationEmailEnabled()
+ * @method void setConfirmationEmailEnabled(bool $value)
+ * @method string|null getConfirmationEmailSubject()
+ * @method void setConfirmationEmailSubject(string|null $value)
+ * @method string|null getConfirmationEmailBody()
+ * @method void setConfirmationEmailBody(string|null $value)
+ * @method int|null getConfirmationEmailRecipient()
+ * @method void setConfirmationEmailRecipient(int|null $value)
  */
 class Form extends Entity {
 	protected $hash;
@@ -74,6 +82,10 @@ class Form extends Entity {
 	protected $lockedBy;
 	protected $lockedUntil;
 	protected $maxSubmissions;
+	protected $confirmationEmailEnabled;
+	protected $confirmationEmailSubject;
+	protected $confirmationEmailBody;
+	protected $confirmationEmailRecipient;
 
 	/**
 	 * Form constructor.
@@ -90,6 +102,8 @@ class Form extends Entity {
 		$this->addType('lockedBy', 'string');
 		$this->addType('lockedUntil', 'integer');
 		$this->addType('maxSubmissions', 'integer');
+		$this->addType('confirmationEmailEnabled', 'boolean');
+		$this->addType('confirmationEmailRecipient', 'integer');
 	}
 
 	// JSON-Decoding of access-column.
@@ -164,6 +178,10 @@ class Form extends Entity {
 	 *   lockedBy: ?string,
 	 *   lockedUntil: ?int,
 	 *   maxSubmissions: ?int,
+	 *   confirmationEmailEnabled: bool,
+	 *   confirmationEmailSubject: ?string,
+	 *   confirmationEmailBody: ?string,
+	 *   confirmationEmailRecipient: ?int,
 	 *  }
 	 */
 	public function read() {
@@ -188,6 +206,10 @@ class Form extends Entity {
 			'lockedBy' => $this->getLockedBy(),
 			'lockedUntil' => $this->getLockedUntil(),
 			'maxSubmissions' => $this->getMaxSubmissions(),
+			'confirmationEmailEnabled' => (bool)$this->getConfirmationEmailEnabled(),
+			'confirmationEmailSubject' => $this->getConfirmationEmailSubject(),
+			'confirmationEmailBody' => $this->getConfirmationEmailBody(),
+			'confirmationEmailRecipient' => $this->getConfirmationEmailRecipient(),
 		];
 	}
 }

--- a/lib/Migration/Version050301Date20260413233000.php
+++ b/lib/Migration/Version050301Date20260413233000.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Forms\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\DB\Types;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+/**
+ * Add confirmation email fields to forms
+ */
+class Version050301Date20260413233000 extends SimpleMigrationStep {
+
+	/**
+	 * @param IOutput $output
+	 * @param Closure $schemaClosure The `\Closure` returns a `ISchemaWrapper`
+	 * @param array $options
+	 * @return null|ISchemaWrapper
+	 */
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
+		/** @var ISchemaWrapper $schema */
+		$schema = $schemaClosure();
+		$table = $schema->getTable('forms_v2_forms');
+
+		if (!$table->hasColumn('confirmation_email_enabled')) {
+			$table->addColumn('confirmation_email_enabled', Types::BOOLEAN, [
+				'notnull' => false,
+				'default' => 0,
+			]);
+		}
+
+		if (!$table->hasColumn('confirmation_email_subject')) {
+			$table->addColumn('confirmation_email_subject', Types::STRING, [
+				'notnull' => false,
+				'default' => null,
+				'length' => 255,
+			]);
+		}
+
+		if (!$table->hasColumn('confirmation_email_body')) {
+			$table->addColumn('confirmation_email_body', Types::TEXT, [
+				'notnull' => false,
+				'default' => null,
+			]);
+		}
+
+		if (!$table->hasColumn('confirmation_email_recipient')) {
+			$table->addColumn('confirmation_email_recipient', Types::INTEGER, [
+				'notnull' => false,
+				'default' => null,
+			]);
+		}
+
+		return $schema;
+	}
+}

--- a/lib/ResponseDefinitions.php
+++ b/lib/ResponseDefinitions.php
@@ -26,6 +26,7 @@ namespace OCA\Forms;
  *   dateMax?: int,
  *   dateMin?: int,
  *   dateRange?: bool,
+ *   confirmationEmailRecipient?: bool,
  *   maxAllowedFilesCount?: int,
  *   maxFileSize?: int,
  *   optionsHighest?: 2|3|4|5|6|7|8|9|10,
@@ -141,8 +142,11 @@ namespace OCA\Forms;
  *   shares: list<FormsShare>,
  *   submissionCount?: int,
  *   submissionMessage: ?string,
- * }
- *
+ *   confirmationEmailEnabled: bool,
+ *   confirmationEmailSubject: ?string,
+ *   confirmationEmailBody: ?string,
+ *   confirmationEmailRecipient: ?int,
+ * } *
  * @psalm-type FormsUploadedFile = array{
  *   uploadedFileId: int,
  *   fileName: string

--- a/lib/Service/FormsService.php
+++ b/lib/Service/FormsService.php
@@ -9,6 +9,7 @@ namespace OCA\Forms\Service;
 
 use OCA\Forms\Activity\ActivityManager;
 use OCA\Forms\Constants;
+use OCA\Forms\Db\AnswerMapper;
 use OCA\Forms\Db\Form;
 use OCA\Forms\Db\FormMapper;
 use OCA\Forms\Db\OptionMapper;
@@ -34,6 +35,8 @@ use OCP\IL10N;
 use OCP\IUser;
 use OCP\IUserManager;
 use OCP\IUserSession;
+use OCP\Mail\IEmailValidator;
+use OCP\Mail\IMailer;
 use OCP\Search\ISearchQuery;
 use OCP\Security\ISecureRandom;
 use OCP\Share\IShare;
@@ -67,6 +70,9 @@ class FormsService {
 		private IL10N $l10n,
 		private LoggerInterface $logger,
 		private IEventDispatcher $eventDispatcher,
+		private IMailer $mailer,
+		private IEmailValidator $emailValidator,
+		private AnswerMapper $answerMapper,
 	) {
 		$this->currentUser = $userSession->getUser();
 	}
@@ -739,6 +745,170 @@ class FormsService {
 		}
 
 		$this->eventDispatcher->dispatchTyped(new FormSubmittedEvent($form, $submission));
+
+		// Send confirmation email if enabled
+		$this->sendConfirmationEmail($form, $submission);
+	}
+
+	/**
+	 * Send confirmation email to the respondent
+	 *
+	 * @param Form $form The form that was submitted
+	 * @param Submission $submission The submission
+	 */
+	private function sendConfirmationEmail(Form $form, Submission $submission): void {
+		// Check if confirmation email is enabled
+		if (!$form->getConfirmationEmailEnabled()) {
+			return;
+		}
+
+		$subject = $form->getConfirmationEmailSubject();
+		$body = $form->getConfirmationEmailBody();
+
+		// If no subject or body is set, use defaults
+		if (empty($subject)) {
+			$subject = $this->l10n->t('Thank you for your submission');
+		}
+		if (empty($body)) {
+			$body = $this->l10n->t('Thank you for submitting the form "%s".', [$form->getTitle()]);
+		}
+
+		// Get questions and answers
+		$questions = $this->getQuestions($form->getId());
+		$answers = $this->answerMapper->findBySubmission($submission->getId());
+
+		$answerMap = [];
+		foreach ($answers as $answer) {
+			$questionId = $answer->getQuestionId();
+			if (!isset($answerMap[$questionId])) {
+				$answerMap[$questionId] = [];
+			}
+			$answerMap[$questionId][] = $answer->getText();
+		}
+
+		$recipientQuestion = $this->getConfirmationEmailRecipientQuestion($questions);
+		if ($recipientQuestion === null) {
+			$this->logger->debug('No confirmation email recipient question is available', [
+				'formId' => $form->getId(),
+				'submissionId' => $submission->getId(),
+			]);
+			return;
+		}
+
+		$recipientQuestionId = $recipientQuestion['id'];
+		$recipientEmail = $answerMap[$recipientQuestionId][0] ?? null;
+		if ($recipientEmail === null || !$this->emailValidator->isValid($recipientEmail)) {
+			$this->logger->debug('No valid email address found in submission for confirmation email', [
+				'formId' => $form->getId(),
+				'submissionId' => $submission->getId(),
+			]);
+			return;
+		}
+
+		// Replace placeholders in subject and body
+		$replacements = [
+			'{formTitle}' => $form->getTitle(),
+			'{formDescription}' => $form->getDescription() ?? '',
+		];
+
+		// Add field placeholders (e.g., {name}, {email})
+		foreach ($questions as $question) {
+			$questionId = $question['id'];
+			$questionName = $question['name'] ?? '';
+			$questionText = $question['text'] ?? '';
+
+			// Use question name if available, otherwise use text
+			$fieldKey = !empty($questionName) ? $questionName : $questionText;
+			// Sanitize field key for placeholder (remove special chars, lowercase)
+			$fieldKey = strtolower(preg_replace('/[^a-zA-Z0-9]/', '', $fieldKey));
+
+			if (!empty($answerMap[$questionId])) {
+				$answerValue = implode('; ', $answerMap[$questionId]);
+				$replacements['{' . $fieldKey . '}'] = $answerValue;
+				// Also support {questionName} format
+				if (!empty($questionName)) {
+					$replacements['{' . strtolower(preg_replace('/[^a-zA-Z0-9]/', '', $questionName)) . '}'] = $answerValue;
+				}
+			}
+		}
+
+		// Apply replacements
+		$subject = str_replace(array_keys($replacements), array_values($replacements), $subject);
+		$body = str_replace(array_keys($replacements), array_values($replacements), $body);
+
+		try {
+			$message = $this->mailer->createMessage();
+			$message->setSubject($subject);
+			$message->setPlainBody($body);
+			$message->setTo([$recipientEmail]);
+
+			$this->mailer->send($message);
+			$this->logger->debug('Confirmation email sent successfully', [
+				'formId' => $form->getId(),
+				'submissionId' => $submission->getId(),
+				'recipient' => $recipientEmail,
+			]);
+		} catch (\Exception $e) {
+			// Handle exceptions silently, as this is not critical.
+			// We don't want to break the submission process just because of an email error.
+			$this->logger->error(
+				'Error while sending confirmation email',
+				[
+					'exception' => $e,
+					'formId' => $form->getId(),
+					'submissionId' => $submission->getId(),
+				]
+			);
+		}
+	}
+
+	/**
+	 * @param list<FormsQuestion> $questions
+	 * @return FormsQuestion|null
+	 */
+	private function getConfirmationEmailRecipientQuestion(array $questions): ?array {
+		$emailQuestions = array_values(array_filter(
+			$questions,
+			fn (array $question): bool => $this->isConfirmationEmailQuestion($question),
+		));
+
+		if ($emailQuestions === []) {
+			return null;
+		}
+
+		$explicitRecipients = array_values(array_filter(
+			$emailQuestions,
+			function (array $question): bool {
+				$extraSettings = (array)($question['extraSettings'] ?? []);
+				return !empty($extraSettings['confirmationEmailRecipient']);
+			},
+		));
+
+		if (count($explicitRecipients) === 1) {
+			return $explicitRecipients[0];
+		}
+
+		if (count($explicitRecipients) > 1) {
+			return null;
+		}
+
+		if (count($emailQuestions) === 1) {
+			return $emailQuestions[0];
+		}
+
+		return null;
+	}
+
+	/**
+	 * @param FormsQuestion $question
+	 */
+	private function isConfirmationEmailQuestion(array $question): bool {
+		if (($question['type'] ?? null) !== Constants::ANSWER_TYPE_SHORT) {
+			return false;
+		}
+
+		$extraSettings = (array)($question['extraSettings'] ?? []);
+		return ($extraSettings['validationType'] ?? null) === 'email';
 	}
 
 	/**

--- a/openapi.json
+++ b/openapi.json
@@ -119,7 +119,11 @@
                     "lockedUntil",
                     "maxSubmissions",
                     "shares",
-                    "submissionMessage"
+                    "submissionMessage",
+                    "confirmationEmailEnabled",
+                    "confirmationEmailSubject",
+                    "confirmationEmailBody",
+                    "confirmationEmailRecipient"
                 ],
                 "properties": {
                     "id": {
@@ -231,6 +235,22 @@
                     },
                     "submissionMessage": {
                         "type": "string",
+                        "nullable": true
+                    },
+                    "confirmationEmailEnabled": {
+                        "type": "boolean"
+                    },
+                    "confirmationEmailSubject": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "confirmationEmailBody": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "confirmationEmailRecipient": {
+                        "type": "integer",
+                        "format": "int64",
                         "nullable": true
                     }
                 }

--- a/src/components/Questions/QuestionShort.vue
+++ b/src/components/Questions/QuestionShort.vue
@@ -66,12 +66,19 @@
 					/^[a-z]{3}$/i
 					<!-- ^ Some example RegExp for the placeholder text -->
 				</NcActionInput>
+				<NcActionCheckbox
+					v-if="validationType === 'email'"
+					:modelValue="isConfirmationEmailRecipient"
+					@update:modelValue="onConfirmationEmailRecipientChange">
+					{{ t('forms', 'Use for confirmation emails') }}
+				</NcActionCheckbox>
 			</NcActions>
 		</div>
 	</Question>
 </template>
 
 <script>
+import NcActionCheckbox from '@nextcloud/vue/components/NcActionCheckbox'
 import NcActionInput from '@nextcloud/vue/components/NcActionInput'
 import NcActionRadio from '@nextcloud/vue/components/NcActionRadio'
 import NcActions from '@nextcloud/vue/components/NcActions'
@@ -86,6 +93,7 @@ export default {
 
 	components: {
 		IconRegex,
+		NcActionCheckbox,
 		NcActions,
 		NcActionInput,
 		NcActionRadio,
@@ -143,6 +151,10 @@ export default {
 		validationRegex() {
 			return this.extraSettings?.validationRegex || ''
 		},
+
+		isConfirmationEmailRecipient() {
+			return this.extraSettings?.confirmationEmailRecipient ?? false
+		},
 	},
 
 	methods: {
@@ -182,6 +194,7 @@ export default {
 			if (validationType === 'regex') {
 				// Make sure to also submit a regex (even if empty)
 				this.onExtraSettingsChange({
+					confirmationEmailRecipient: undefined,
 					validationType,
 					validationRegex: this.validationRegex,
 				})
@@ -189,10 +202,22 @@ export default {
 				// For all other types except regex we close the menu (for regex we keep it open to allow entering a regex)
 				this.isValidationTypeMenuOpen = false
 				this.onExtraSettingsChange({
+					confirmationEmailRecipient:
+						validationType === 'email'
+							? this.isConfirmationEmailRecipient || undefined
+							: undefined,
 					validationType:
 						validationType === 'text' ? undefined : validationType,
 				})
 			}
+		},
+
+		onConfirmationEmailRecipientChange(confirmationEmailRecipient) {
+			this.onExtraSettingsChange({
+				confirmationEmailRecipient: confirmationEmailRecipient
+					? true
+					: undefined,
+			})
 		},
 
 		/**

--- a/src/components/Questions/QuestionShort.vue
+++ b/src/components/Questions/QuestionShort.vue
@@ -66,19 +66,12 @@
 					/^[a-z]{3}$/i
 					<!-- ^ Some example RegExp for the placeholder text -->
 				</NcActionInput>
-				<NcActionCheckbox
-					v-if="validationType === 'email'"
-					:modelValue="isConfirmationEmailRecipient"
-					@update:modelValue="onConfirmationEmailRecipientChange">
-					{{ t('forms', 'Use for confirmation emails') }}
-				</NcActionCheckbox>
 			</NcActions>
 		</div>
 	</Question>
 </template>
 
 <script>
-import NcActionCheckbox from '@nextcloud/vue/components/NcActionCheckbox'
 import NcActionInput from '@nextcloud/vue/components/NcActionInput'
 import NcActionRadio from '@nextcloud/vue/components/NcActionRadio'
 import NcActions from '@nextcloud/vue/components/NcActions'
@@ -93,7 +86,6 @@ export default {
 
 	components: {
 		IconRegex,
-		NcActionCheckbox,
 		NcActions,
 		NcActionInput,
 		NcActionRadio,
@@ -151,10 +143,6 @@ export default {
 		validationRegex() {
 			return this.extraSettings?.validationRegex || ''
 		},
-
-		isConfirmationEmailRecipient() {
-			return this.extraSettings?.confirmationEmailRecipient ?? false
-		},
 	},
 
 	methods: {
@@ -202,22 +190,11 @@ export default {
 				// For all other types except regex we close the menu (for regex we keep it open to allow entering a regex)
 				this.isValidationTypeMenuOpen = false
 				this.onExtraSettingsChange({
-					confirmationEmailRecipient:
-						validationType === 'email'
-							? this.isConfirmationEmailRecipient || undefined
-							: undefined,
+					confirmationEmailRecipient: undefined,
 					validationType:
 						validationType === 'text' ? undefined : validationType,
 				})
 			}
-		},
-
-		onConfirmationEmailRecipientChange(confirmationEmailRecipient) {
-			this.onExtraSettingsChange({
-				confirmationEmailRecipient: confirmationEmailRecipient
-					? true
-					: undefined,
-			})
 		},
 
 		/**

--- a/src/components/SidebarTabs/SettingsSidebarTab.vue
+++ b/src/components/SidebarTabs/SettingsSidebarTab.vue
@@ -205,53 +205,104 @@
 			v-show="form.confirmationEmailEnabled && !formArchived"
 			class="settings-div--indent confirmation-email">
 			<p class="confirmation-email__hint">
+				{{ t('forms', 'Set up confirmation emails in three steps:') }}
+			</p>
+			<ol class="confirmation-email__steps">
+				<li>{{ t('forms', 'Add an email field to the form.') }}</li>
+				<li>
+					{{
+						t(
+							'forms',
+							'Select which email field receives the confirmation email.',
+						)
+					}}
+				</li>
+				<li>{{ t('forms', 'Customize the subject and message.') }}</li>
+			</ol>
+			<NcNoteCard
+				v-if="hasConfirmationEmailRecipientConflict"
+				type="error"
+				:text="
+					t(
+						'forms',
+						'Only one email field can be used for confirmation emails. Select the recipient field below to fix this.',
+					)
+				" />
+			<NcNoteCard
+				v-else-if="emailQuestionCount === 0"
+				type="error"
+				:text="
+					t(
+						'forms',
+						'Add at least one email field before confirmation emails can be used.',
+					)
+				" />
+			<NcNoteCard
+				v-else-if="requiresConfirmationEmailRecipientSelection"
+				type="error"
+				:text="
+					t(
+						'forms',
+						'Select which email field should receive confirmation emails before finishing this setup.',
+					)
+				" />
+			<div v-if="emailQuestionCount > 0" class="confirmation-email__recipient">
+				<label class="confirmation-email__label">
+					{{ t('forms', 'Recipient field') }}
+				</label>
+				<p
+					v-if="emailQuestionCount === 1"
+					class="confirmation-email__recipient-summary">
+					<strong>{{ selectedConfirmationEmailQuestionLabel }}</strong>
+					<br />
+					{{
+						t(
+							'forms',
+							'Selected automatically because this is the only email field in the form.',
+						)
+					}}
+				</p>
+				<template v-else>
+					<select
+						:value="selectedConfirmationEmailQuestionId"
+						:disabled="locked || isSavingConfirmationEmailRecipient"
+						class="confirmation-email__select"
+						@change="onConfirmationEmailRecipientSelectionChange">
+						<option value="">
+							{{ t('forms', 'Select an email field') }}
+						</option>
+						<option
+							v-for="question in confirmationEmailQuestions"
+							:key="question.id"
+							:value="question.id">
+							{{ confirmationEmailQuestionLabel(question) }}
+						</option>
+					</select>
+					<p
+						v-if="selectedConfirmationEmailQuestionLabel"
+						class="confirmation-email__recipient-summary">
+						{{
+							t('forms', 'Current recipient field: {question}', {
+								question: selectedConfirmationEmailQuestionLabel,
+							})
+						}}
+					</p>
+				</template>
+			</div>
+			<p class="confirmation-email__placeholder-hint">
 				{{
 					t(
 						'forms',
-						'Requires an email field in the form. If the form has multiple email fields, mark one question with “Use for confirmation emails”. Available placeholders: {formTitle}, {formDescription}, and field names like {name}.',
+						'Available placeholders: {formTitle}, {formDescription}, and field names like {name}.',
 					)
 				}}
 			</p>
-			<NcNoteCard
-				v-if="form.confirmationEmailEnabled && emailQuestionCount === 0"
-				type="error"
-				:text="
-					t(
-						'forms',
-						'Add at least one email field to send confirmation emails.',
-					)
-				" />
-			<NcNoteCard
-				v-else-if="
-					form.confirmationEmailEnabled
-					&& emailQuestionCount > 1
-					&& confirmationEmailRecipientCount === 0
-				"
-				type="error"
-				:text="
-					t(
-						'forms',
-						'Select one email field and enable “Use for confirmation emails” on that question.',
-					)
-				" />
-			<NcNoteCard
-				v-else-if="
-					form.confirmationEmailEnabled
-					&& confirmationEmailRecipientCount > 1
-				"
-				type="error"
-				:text="
-					t(
-						'forms',
-						'Only one email field can be used for confirmation emails.',
-					)
-				" />
 			<label class="confirmation-email__label">
 				{{ t('forms', 'Email subject') }}
 			</label>
 			<input
 				v-model="confirmationEmailSubject"
-				:disabled="locked"
+				:disabled="locked || isConfirmationEmailConfigurationBlocked"
 				:maxlength="255"
 				:placeholder="t('forms', 'Thank you for your submission')"
 				class="confirmation-email__input"
@@ -262,7 +313,7 @@
 			</label>
 			<textarea
 				:value="confirmationEmailBody"
-				:disabled="locked"
+				:disabled="locked || isConfirmationEmailConfigurationBlocked"
 				:placeholder="emailBodyPlaceholder"
 				class="confirmation-email__textarea"
 				@input="onConfirmationEmailBodyInput"
@@ -278,8 +329,12 @@
 
 <script>
 import { getCurrentUser } from '@nextcloud/auth'
+import axios from '@nextcloud/axios'
+import { showError } from '@nextcloud/dialogs'
+import { emit } from '@nextcloud/event-bus'
 import { loadState } from '@nextcloud/initial-state'
 import moment from '@nextcloud/moment'
+import { generateOcsUrl } from '@nextcloud/router'
 import { vOnClickOutside as ClickOutside } from '@vueuse/components'
 import NcButton from '@nextcloud/vue/components/NcButton'
 import NcCheckboxRadioSwitch from '@nextcloud/vue/components/NcCheckboxRadioSwitch'
@@ -343,6 +398,7 @@ export default {
 			svgLockOpen,
 			confirmationEmailSubject: this.form?.confirmationEmailSubject || '',
 			confirmationEmailBody: this.form?.confirmationEmailBody || '',
+			isSavingConfirmationEmailRecipient: false,
 		}
 	},
 
@@ -468,6 +524,55 @@ export default {
 				(question) => question.extraSettings?.confirmationEmailRecipient,
 			).length
 		},
+
+		selectedConfirmationEmailQuestion() {
+			const selectedQuestion = this.confirmationEmailQuestions.find(
+				(question) => question.extraSettings?.confirmationEmailRecipient,
+			)
+			if (selectedQuestion) {
+				return selectedQuestion
+			}
+
+			if (this.emailQuestionCount === 1) {
+				return this.confirmationEmailQuestions[0]
+			}
+
+			return null
+		},
+
+		selectedConfirmationEmailQuestionId() {
+			return this.selectedConfirmationEmailQuestion?.id ?? ''
+		},
+
+		selectedConfirmationEmailQuestionLabel() {
+			if (!this.selectedConfirmationEmailQuestion) {
+				return ''
+			}
+
+			return this.confirmationEmailQuestionLabel(
+				this.selectedConfirmationEmailQuestion,
+			)
+		},
+
+		hasConfirmationEmailRecipientConflict() {
+			return this.confirmationEmailRecipientCount > 1
+		},
+
+		requiresConfirmationEmailRecipientSelection() {
+			return (
+				this.emailQuestionCount > 1
+				&& this.confirmationEmailRecipientCount !== 1
+			)
+		},
+
+		isConfirmationEmailConfigurationBlocked() {
+			return (
+				this.form.confirmationEmailEnabled
+				&& (this.emailQuestionCount === 0
+					|| this.hasConfirmationEmailRecipientConflict
+					|| this.requiresConfirmationEmailRecipientSelection)
+			)
+		},
 	},
 
 	watch: {
@@ -480,9 +585,29 @@ export default {
 
 			deep: true,
 		},
+
+		confirmationEmailQuestions: {
+			async handler() {
+				if (
+					this.form.confirmationEmailEnabled
+					&& this.emailQuestionCount === 1
+					&& this.confirmationEmailRecipientCount !== 1
+				) {
+					await this.saveConfirmationEmailRecipient(
+						this.confirmationEmailQuestions[0].id,
+					)
+				}
+			},
+
+			deep: true,
+		},
 	},
 
 	methods: {
+		confirmationEmailQuestionLabel(question) {
+			return question.text || t('forms', 'Untitled question')
+		},
+
 		/**
 		 * Save Form-Properties
 		 *
@@ -576,12 +701,12 @@ export default {
 		},
 
 		onConfirmationEmailEnabledChange(checked) {
-			this.$emit('update:form-prop', 'confirmationEmailEnabled', checked)
+			this.$emit('update:formProp', 'confirmationEmailEnabled', checked)
 		},
 
 		onConfirmationEmailSubjectChange() {
 			this.$emit(
-				'update:form-prop',
+				'update:formProp',
 				'confirmationEmailSubject',
 				this.confirmationEmailSubject,
 			)
@@ -592,7 +717,105 @@ export default {
 		},
 
 		onConfirmationEmailBodyChange({ target }) {
-			this.$emit('update:form-prop', 'confirmationEmailBody', target.value)
+			this.$emit('update:formProp', 'confirmationEmailBody', target.value)
+		},
+
+		async onConfirmationEmailRecipientSelectionChange(event) {
+			const questionId = Number.parseInt(event.target.value, 10)
+			if (Number.isNaN(questionId)) {
+				return
+			}
+
+			await this.saveConfirmationEmailRecipient(questionId)
+		},
+
+		async saveConfirmationEmailRecipient(selectedQuestionId) {
+			if (!this.form?.id) {
+				return
+			}
+
+			const emailQuestions = this.confirmationEmailQuestions
+			const pendingUpdates = emailQuestions
+				.map((question) => {
+					const nextExtraSettings = { ...(question.extraSettings || {}) }
+					if (selectedQuestionId === question.id) {
+						nextExtraSettings.confirmationEmailRecipient = true
+					} else {
+						delete nextExtraSettings.confirmationEmailRecipient
+					}
+
+					const hasRecipientFlag =
+						!!question.extraSettings?.confirmationEmailRecipient
+					const shouldHaveRecipientFlag =
+						selectedQuestionId === question.id
+
+					if (hasRecipientFlag === shouldHaveRecipientFlag) {
+						return null
+					}
+
+					return {
+						question,
+						nextExtraSettings,
+					}
+				})
+				.filter((update) => update !== null)
+
+			if (pendingUpdates.length === 0) {
+				return
+			}
+
+			const previousExtraSettings = new Map(
+				pendingUpdates.map(({ question }) => [
+					question.id,
+					{ ...(question.extraSettings || {}) },
+				]),
+			)
+
+			pendingUpdates.forEach(({ question, nextExtraSettings }) => {
+				const localQuestion = this.form.questions.find(
+					(searchQuestion) => searchQuestion.id === question.id,
+				)
+				if (localQuestion) {
+					localQuestion.extraSettings = nextExtraSettings
+				}
+			})
+
+			this.isSavingConfirmationEmailRecipient = true
+
+			try {
+				await Promise.all(
+					pendingUpdates.map(({ question, nextExtraSettings }) =>
+						axios.patch(
+							generateOcsUrl(
+								'apps/forms/api/v3/forms/{id}/questions/{questionId}',
+								{
+									id: this.form.id,
+									questionId: question.id,
+								},
+							),
+							{
+								keyValuePairs: {
+									extraSettings: nextExtraSettings,
+								},
+							},
+						),
+					),
+				)
+				emit('forms:last-updated:set', this.form.id)
+			} catch {
+				pendingUpdates.forEach(({ question }) => {
+					const localQuestion = this.form.questions.find(
+						(searchQuestion) => searchQuestion.id === question.id,
+					)
+					if (localQuestion) {
+						localQuestion.extraSettings =
+							previousExtraSettings.get(question.id) || {}
+					}
+				})
+				showError(t('forms', 'Error while saving question'))
+			} finally {
+				this.isSavingConfirmationEmailRecipient = false
+			}
 		},
 
 		/**
@@ -694,7 +917,25 @@ export default {
 	&__hint {
 		color: var(--color-text-maxcontrast);
 		font-size: 13px;
+		margin-bottom: 8px;
+	}
+
+	&__steps {
+		margin: 0 0 12px;
+		padding-inline-start: 20px;
+		color: var(--color-text-maxcontrast);
+		font-size: 13px;
+	}
+
+	&__recipient {
 		margin-bottom: 12px;
+	}
+
+	&__recipient-summary,
+	&__placeholder-hint {
+		color: var(--color-text-maxcontrast);
+		font-size: 13px;
+		margin-top: 8px;
 	}
 
 	&__label {
@@ -711,6 +952,20 @@ export default {
 		border: 2px solid var(--color-border-maxcontrast);
 		border-radius: var(--border-radius-large);
 		font-size: 14px;
+
+		&:focus {
+			outline: none;
+			border-color: var(--color-primary-element);
+		}
+	}
+
+	&__select {
+		width: 100%;
+		padding: 8px;
+		border: 2px solid var(--color-border-maxcontrast);
+		border-radius: var(--border-radius-large);
+		font-size: 14px;
+		background: var(--color-main-background);
 
 		&:focus {
 			outline: none;

--- a/src/components/SidebarTabs/SettingsSidebarTab.vue
+++ b/src/components/SidebarTabs/SettingsSidebarTab.vue
@@ -194,6 +194,81 @@
 			</div>
 		</div>
 
+		<NcCheckboxRadioSwitch
+			:modelValue="form.confirmationEmailEnabled"
+			:disabled="formArchived || locked"
+			type="switch"
+			@update:modelValue="onConfirmationEmailEnabledChange">
+			{{ t('forms', 'Send confirmation email to respondents') }}
+		</NcCheckboxRadioSwitch>
+		<div
+			v-show="form.confirmationEmailEnabled && !formArchived"
+			class="settings-div--indent confirmation-email">
+			<p class="confirmation-email__hint">
+				{{
+					t(
+						'forms',
+						'Requires an email field in the form. If the form has multiple email fields, mark one question with “Use for confirmation emails”. Available placeholders: {formTitle}, {formDescription}, and field names like {name}.',
+					)
+				}}
+			</p>
+			<NcNoteCard
+				v-if="form.confirmationEmailEnabled && emailQuestionCount === 0"
+				type="error"
+				:text="
+					t(
+						'forms',
+						'Add at least one email field to send confirmation emails.',
+					)
+				" />
+			<NcNoteCard
+				v-else-if="
+					form.confirmationEmailEnabled
+					&& emailQuestionCount > 1
+					&& confirmationEmailRecipientCount === 0
+				"
+				type="error"
+				:text="
+					t(
+						'forms',
+						'Select one email field and enable “Use for confirmation emails” on that question.',
+					)
+				" />
+			<NcNoteCard
+				v-else-if="
+					form.confirmationEmailEnabled
+					&& confirmationEmailRecipientCount > 1
+				"
+				type="error"
+				:text="
+					t(
+						'forms',
+						'Only one email field can be used for confirmation emails.',
+					)
+				" />
+			<label class="confirmation-email__label">
+				{{ t('forms', 'Email subject') }}
+			</label>
+			<input
+				v-model="confirmationEmailSubject"
+				:disabled="locked"
+				:maxlength="255"
+				:placeholder="t('forms', 'Thank you for your submission')"
+				class="confirmation-email__input"
+				type="text"
+				@blur="onConfirmationEmailSubjectChange" />
+			<label class="confirmation-email__label">
+				{{ t('forms', 'Email body') }}
+			</label>
+			<textarea
+				:value="confirmationEmailBody"
+				:disabled="locked"
+				:placeholder="emailBodyPlaceholder"
+				class="confirmation-email__textarea"
+				@input="onConfirmationEmailBodyInput"
+				@blur="onConfirmationEmailBodyChange"></textarea>
+		</div>
+
 		<TransferOwnership
 			:locked="locked"
 			:isOwner="isCurrentUserOwner"
@@ -266,6 +341,8 @@ export default {
 			/** If custom submission message is shown as input or rendered markdown */
 			editMessage: false,
 			svgLockOpen,
+			confirmationEmailSubject: this.form?.confirmationEmailSubject || '',
+			confirmationEmailBody: this.form?.confirmationEmailBody || '',
 		}
 	},
 
@@ -360,6 +437,48 @@ export default {
 		 */
 		submissionMessageHTML() {
 			return this.$markdownit.render(this.form.submissionMessage || '')
+		},
+
+		/**
+		 * Placeholder text for email body
+		 */
+		emailBodyPlaceholder() {
+			return this.t(
+				'forms',
+				'Thank you for submitting the form "{formTitle}".',
+				{ formTitle: this.form.title || '' },
+			)
+		},
+
+		emailQuestionCount() {
+			return this.confirmationEmailQuestions.length
+		},
+
+		confirmationEmailQuestions() {
+			const questions = this.form?.questions || []
+			return questions.filter(
+				(question) =>
+					question.type === 'short'
+					&& question.extraSettings?.validationType === 'email',
+			)
+		},
+
+		confirmationEmailRecipientCount() {
+			return this.confirmationEmailQuestions.filter(
+				(question) => question.extraSettings?.confirmationEmailRecipient,
+			).length
+		},
+	},
+
+	watch: {
+		form: {
+			handler(newForm) {
+				this.confirmationEmailSubject =
+					newForm?.confirmationEmailSubject || ''
+				this.confirmationEmailBody = newForm?.confirmationEmailBody || ''
+			},
+
+			deep: true,
 		},
 	},
 
@@ -456,6 +575,26 @@ export default {
 			}
 		},
 
+		onConfirmationEmailEnabledChange(checked) {
+			this.$emit('update:form-prop', 'confirmationEmailEnabled', checked)
+		},
+
+		onConfirmationEmailSubjectChange() {
+			this.$emit(
+				'update:form-prop',
+				'confirmationEmailSubject',
+				this.confirmationEmailSubject,
+			)
+		},
+
+		onConfirmationEmailBodyInput(event) {
+			this.confirmationEmailBody = event.target.value
+		},
+
+		onConfirmationEmailBodyChange({ target }) {
+			this.$emit('update:form-prop', 'confirmationEmailBody', target.value)
+		},
+
 		/**
 		 * Datepicker timestamp to string
 		 *
@@ -546,6 +685,51 @@ export default {
 		border-radius: var(--border-radius-large);
 
 		&:hover {
+			border-color: var(--color-primary-element);
+		}
+	}
+}
+
+.confirmation-email {
+	&__hint {
+		color: var(--color-text-maxcontrast);
+		font-size: 13px;
+		margin-bottom: 12px;
+	}
+
+	&__label {
+		display: block;
+		margin-top: 12px;
+		margin-bottom: 4px;
+		font-weight: 600;
+	}
+
+	&__input {
+		width: 100%;
+		padding: 8px;
+		margin-bottom: 12px;
+		border: 2px solid var(--color-border-maxcontrast);
+		border-radius: var(--border-radius-large);
+		font-size: 14px;
+
+		&:focus {
+			outline: none;
+			border-color: var(--color-primary-element);
+		}
+	}
+
+	&__textarea {
+		width: 100%;
+		min-height: 120px;
+		padding: 8px;
+		border: 2px solid var(--color-border-maxcontrast);
+		border-radius: var(--border-radius-large);
+		font-size: 14px;
+		line-height: 1.5;
+		resize: vertical;
+
+		&:focus {
+			outline: none;
 			border-color: var(--color-primary-element);
 		}
 	}

--- a/tests/Integration/Api/ApiV3Test.php
+++ b/tests/Integration/Api/ApiV3Test.php
@@ -396,6 +396,10 @@ class ApiV3Test extends IntegrationBase {
 					'fileFormat' => null,
 					'maxSubmissions' => null,
 					'isMaxSubmissionsReached' => false,
+					'confirmationEmailEnabled' => false,
+					'confirmationEmailSubject' => null,
+					'confirmationEmailBody' => null,
+					'confirmationEmailRecipient' => null,
 				]
 			]
 		];
@@ -529,6 +533,10 @@ class ApiV3Test extends IntegrationBase {
 					'fileFormat' => null,
 					'maxSubmissions' => null,
 					'isMaxSubmissionsReached' => false,
+					'confirmationEmailEnabled' => false,
+					'confirmationEmailSubject' => null,
+					'confirmationEmailBody' => null,
+					'confirmationEmailRecipient' => null,
 				]
 			]
 		];

--- a/tests/Integration/Api/RespectAdminSettingsTest.php
+++ b/tests/Integration/Api/RespectAdminSettingsTest.php
@@ -145,6 +145,10 @@ class RespectAdminSettingsTest extends IntegrationBase {
 				'submissionCount' => 0,
 				'maxSubmissions' => null,
 				'isMaxSubmissionsReached' => false,
+				'confirmationEmailEnabled' => false,
+				'confirmationEmailSubject' => null,
+				'confirmationEmailBody' => null,
+				'confirmationEmailRecipient' => null,
 			],
 		];
 	}

--- a/tests/Unit/Controller/ApiControllerTest.php
+++ b/tests/Unit/Controller/ApiControllerTest.php
@@ -516,6 +516,10 @@ class ApiControllerTest extends TestCase {
 				'lockedBy' => null,
 				'lockedUntil' => null,
 				'maxSubmissions' => null,
+				'confirmationEmailEnabled' => false,
+				'confirmationEmailSubject' => null,
+				'confirmationEmailBody' => null,
+				'confirmationEmailRecipient' => null,
 			]]
 		];
 	}
@@ -534,7 +538,10 @@ class ApiControllerTest extends TestCase {
 		$expected['id'] = null;
 		// TODO fix test, currently unset because behaviour has changed
 		$expected['state'] = null;
-		$expected['lastUpdated'] = null;
+		$expected['lastUpdated'] = 0;
+		$expected['confirmationEmailEnabled'] = false;
+		$expected['confirmationEmailSubject'] = null;
+		$expected['confirmationEmailBody'] = null;
 		$this->formMapper->expects($this->once())
 			->method('insert')
 			->with(self::callback(self::createFormValidator($expected)))

--- a/tests/Unit/FormsMigratorTest.php
+++ b/tests/Unit/FormsMigratorTest.php
@@ -111,6 +111,10 @@ class FormsMigratorTest extends TestCase {
     "showExpiration": false,
     "lastUpdated": 123456789,
     "submissionMessage": "Back to website",
+    "confirmationEmailEnabled": false,
+    "confirmationEmailSubject": null,
+    "confirmationEmailBody": null,
+    "confirmationEmailRecipient": null,
     "questions": [
       {
         "id": 14,

--- a/tests/Unit/Service/FormsServiceTest.php
+++ b/tests/Unit/Service/FormsServiceTest.php
@@ -32,6 +32,8 @@ use OCA\Circles\Model\Circle;
 use OCA\Forms\Activity\ActivityManager;
 
 use OCA\Forms\Constants;
+use OCA\Forms\Db\Answer;
+use OCA\Forms\Db\AnswerMapper;
 use OCA\Forms\Db\Form;
 use OCA\Forms\Db\FormMapper;
 use OCA\Forms\Db\Option;
@@ -56,6 +58,9 @@ use OCP\IL10N;
 use OCP\IUser;
 use OCP\IUserManager;
 use OCP\IUserSession;
+use OCP\Mail\IEmailValidator;
+use OCP\Mail\IMailer;
+use OCP\Mail\IMessage;
 use OCP\Security\ISecureRandom;
 use OCP\Share\IShare;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -110,6 +115,15 @@ class FormsServiceTest extends TestCase {
 	/** @var LoggerInterface|MockObject */
 	private $logger;
 
+	/** @var IMailer|MockObject */
+	private $mailer;
+
+	/** @var IEmailValidator|MockObject */
+	private $emailValidator;
+
+	/** @var AnswerMapper|MockObject */
+	private $answerMapper;
+
 	public function setUp(): void {
 		parent::setUp();
 		$this->activityManager = $this->createMock(ActivityManager::class);
@@ -120,6 +134,9 @@ class FormsServiceTest extends TestCase {
 		$this->submissionMapper = $this->createMock(SubmissionMapper::class);
 		$this->configService = $this->createMock(ConfigService::class);
 		$this->logger = $this->createMock(LoggerInterface::class);
+		$this->mailer = $this->createMock(IMailer::class);
+		$this->emailValidator = $this->createMock(IEmailValidator::class);
+		$this->answerMapper = $this->createMock(AnswerMapper::class);
 		$this->groupManager = $this->createMock(IGroupManager::class);
 		$this->userManager = $this->createMock(IUserManager::class);
 		$this->secureRandom = $this->createMock(ISecureRandom::class);
@@ -139,8 +156,11 @@ class FormsServiceTest extends TestCase {
 		$this->l10n = $this->createMock(IL10N::class);
 		$this->l10n->expects($this->any())
 			->method('t')
-			->will($this->returnCallback(function (string $identity) {
-				return $identity;
+			->will($this->returnCallback(function (string $text, array $params = []) {
+				if (!empty($params)) {
+					return sprintf($text, ...$params);
+				}
+				return $text;
 			}));
 
 		$this->formsService = new FormsService(
@@ -160,7 +180,9 @@ class FormsServiceTest extends TestCase {
 			$this->l10n,
 			$this->logger,
 			\OCP\Server::get(IEventDispatcher::class),
-			$this->logger,
+			$this->mailer,
+			$this->emailValidator,
+			$this->answerMapper,
 		);
 	}
 
@@ -257,6 +279,10 @@ class FormsServiceTest extends TestCase {
 				'lockedUntil' => null,
 				'maxSubmissions' => null,
 				'isMaxSubmissionsReached' => false,
+				'confirmationEmailEnabled' => false,
+				'confirmationEmailSubject' => null,
+				'confirmationEmailBody' => null,
+				'confirmationEmailRecipient' => null,
 			]]
 		];
 	}
@@ -478,6 +504,10 @@ class FormsServiceTest extends TestCase {
 				'lockedUntil' => null,
 				'maxSubmissions' => null,
 				'isMaxSubmissionsReached' => false,
+				'confirmationEmailEnabled' => false,
+				'confirmationEmailSubject' => null,
+				'confirmationEmailBody' => null,
+				'confirmationEmailRecipient' => null,
 			]]
 		];
 	}
@@ -653,7 +683,9 @@ class FormsServiceTest extends TestCase {
 			$this->l10n,
 			$this->logger,
 			\OCP\Server::get(IEventDispatcher::class),
-			$this->logger,
+			$this->mailer,
+			$this->emailValidator,
+			$this->answerMapper,
 		);
 
 		$form = new Form();
@@ -894,7 +926,9 @@ class FormsServiceTest extends TestCase {
 			$this->l10n,
 			$this->logger,
 			\OCP\Server::get(IEventDispatcher::class),
-			$this->logger,
+			$this->mailer,
+			$this->emailValidator,
+			$this->answerMapper,
 		);
 
 		$this->assertEquals(true, $formsService->canSubmit($form));
@@ -1007,7 +1041,9 @@ class FormsServiceTest extends TestCase {
 			$this->l10n,
 			$this->logger,
 			\OCP\Server::get(IEventDispatcher::class),
-			$this->logger,
+			$this->mailer,
+			$this->emailValidator,
+			$this->answerMapper,
 		);
 
 		$form = new Form();
@@ -1240,7 +1276,9 @@ class FormsServiceTest extends TestCase {
 				$this->l10n,
 				$this->logger,
 				$eventDispatcher,
-				$this->logger,
+				$this->mailer,
+				$this->emailValidator,
+				$this->answerMapper,
 			])
 			->getMock();
 
@@ -1256,6 +1294,916 @@ class FormsServiceTest extends TestCase {
 			->method('publishNewSharedSubmission');
 
 		$eventDispatcher->expects($this->exactly(1))->method('dispatchTyped')->withAnyParameters();
+
+		$formsService->notifyNewSubmission($form, $submission);
+	}
+
+	public function testNotifyNewSubmissionDoesNotSendConfirmationEmailIfDisabled(): void {
+		$submission = new Submission();
+		$submission->setId(99);
+		$submission->setUserId('someUser');
+
+		$form = Form::fromParams([
+			'id' => 42,
+			'ownerId' => 'ownerUser',
+			'confirmationEmailEnabled' => false,
+		]);
+
+		$eventDispatcher = $this->createMock(IEventDispatcher::class);
+		$eventDispatcher->expects($this->once())->method('dispatchTyped')->withAnyParameters();
+
+		$formsService = $this->getMockBuilder(FormsService::class)
+			->onlyMethods(['getShares'])
+			->setConstructorArgs([
+				$this->createMock(IUserSession::class),
+				$this->activityManager,
+				$this->formMapper,
+				$this->optionMapper,
+				$this->questionMapper,
+				$this->shareMapper,
+				$this->submissionMapper,
+				$this->configService,
+				$this->groupManager,
+				$this->userManager,
+				$this->secureRandom,
+				$this->circlesService,
+				$this->storage,
+				$this->l10n,
+				$this->logger,
+				$eventDispatcher,
+				$this->mailer,
+				$this->emailValidator,
+				$this->answerMapper,
+			])
+			->getMock();
+
+		$formsService->method('getShares')->willReturn([]);
+
+		$this->mailer->expects($this->never())->method('send');
+
+		$formsService->notifyNewSubmission($form, $submission);
+	}
+
+	public function testNotifyNewSubmissionSendsConfirmationEmailWithPlaceholders(): void {
+		$submission = new Submission();
+		$submission->setId(99);
+		$submission->setUserId('someUser');
+
+		$form = Form::fromParams([
+			'id' => 42,
+			'ownerId' => 'ownerUser',
+			'title' => 'My Form',
+			'description' => 'My Desc',
+			'confirmationEmailEnabled' => true,
+			'confirmationEmailSubject' => 'Thanks {name}',
+			'confirmationEmailBody' => 'Hello {name}',
+		]);
+
+		$questions = [
+			[
+				'id' => 1,
+				'type' => Constants::ANSWER_TYPE_SHORT,
+				'text' => 'Email',
+				'name' => 'email',
+				'extraSettings' => ['validationType' => 'email'],
+			],
+			[
+				'id' => 2,
+				'type' => Constants::ANSWER_TYPE_SHORT,
+				'text' => 'Name',
+				'name' => 'name',
+				'extraSettings' => ['validationType' => 'text'],
+			],
+		];
+
+		$emailAnswer = new Answer();
+		$emailAnswer->setSubmissionId(99);
+		$emailAnswer->setQuestionId(1);
+		$emailAnswer->setText('respondent@example.com');
+
+		$nameAnswer = new Answer();
+		$nameAnswer->setSubmissionId(99);
+		$nameAnswer->setQuestionId(2);
+		$nameAnswer->setText('Ada');
+
+		$this->answerMapper->expects($this->once())
+			->method('findBySubmission')
+			->with(99)
+			->willReturn([$emailAnswer, $nameAnswer]);
+
+		$this->emailValidator->expects($this->once())
+			->method('isValid')
+			->with('respondent@example.com')
+			->willReturn(true);
+
+		$message = $this->createMock(IMessage::class);
+
+		$message->expects($this->once())
+			->method('setSubject')
+			->with('Thanks Ada');
+		$message->expects($this->once())
+			->method('setTo')
+			->with(['respondent@example.com']);
+		$message->expects($this->once())
+			->method('setPlainBody')
+			->with($this->callback(function (string $body): bool {
+				$this->assertStringContainsString('Hello Ada', $body);
+				return true;
+			}));
+
+		$this->mailer->expects($this->once())
+			->method('createMessage')
+			->willReturn($message);
+
+		$this->mailer->expects($this->once())
+			->method('send')
+			->with($message);
+
+		$eventDispatcher = $this->createMock(IEventDispatcher::class);
+		$eventDispatcher->expects($this->once())->method('dispatchTyped')->withAnyParameters();
+
+		$formsService = $this->getMockBuilder(FormsService::class)
+			->onlyMethods(['getShares', 'getQuestions'])
+			->setConstructorArgs([
+				$this->createMock(IUserSession::class),
+				$this->activityManager,
+				$this->formMapper,
+				$this->optionMapper,
+				$this->questionMapper,
+				$this->shareMapper,
+				$this->submissionMapper,
+				$this->configService,
+				$this->groupManager,
+				$this->userManager,
+				$this->secureRandom,
+				$this->circlesService,
+				$this->storage,
+				$this->l10n,
+				$this->logger,
+				$eventDispatcher,
+				$this->mailer,
+				$this->emailValidator,
+				$this->answerMapper,
+			])
+			->getMock();
+
+		$formsService->method('getShares')->willReturn([]);
+		$formsService->method('getQuestions')->with(42)->willReturn($questions);
+
+		$formsService->notifyNewSubmission($form, $submission);
+	}
+
+	public function testNotifyNewSubmissionSendsConfirmationEmailWithFormPlaceholders(): void {
+		$submission = new Submission();
+		$submission->setId(99);
+		$submission->setUserId('someUser');
+
+		$form = Form::fromParams([
+			'id' => 42,
+			'ownerId' => 'ownerUser',
+			'title' => 'My Form',
+			'description' => 'My Desc',
+			'confirmationEmailEnabled' => true,
+			'confirmationEmailSubject' => 'Subject {formTitle}',
+			'confirmationEmailBody' => 'Body {formDescription}',
+		]);
+
+		$questions = [
+			[
+				'id' => 1,
+				'type' => Constants::ANSWER_TYPE_SHORT,
+				'text' => 'Email',
+				'name' => 'email',
+				'extraSettings' => ['validationType' => 'email'],
+			],
+		];
+
+		$emailAnswer = new Answer();
+		$emailAnswer->setSubmissionId(99);
+		$emailAnswer->setQuestionId(1);
+		$emailAnswer->setText('respondent@example.com');
+
+		$this->answerMapper->expects($this->once())
+			->method('findBySubmission')
+			->with(99)
+			->willReturn([$emailAnswer]);
+
+		$this->emailValidator->expects($this->once())
+			->method('isValid')
+			->with('respondent@example.com')
+			->willReturn(true);
+
+		$message = $this->createMock(IMessage::class);
+		$message->expects($this->once())
+			->method('setSubject')
+			->with('Subject My Form');
+		$message->expects($this->once())
+			->method('setTo')
+			->with(['respondent@example.com']);
+		$message->expects($this->once())
+			->method('setPlainBody')
+			->with('Body My Desc');
+
+		$this->mailer->expects($this->once())
+			->method('createMessage')
+			->willReturn($message);
+
+		$this->mailer->expects($this->once())
+			->method('send')
+			->with($message);
+
+		$eventDispatcher = $this->createMock(IEventDispatcher::class);
+		$eventDispatcher->expects($this->once())->method('dispatchTyped')->withAnyParameters();
+
+		$formsService = $this->getMockBuilder(FormsService::class)
+			->onlyMethods(['getShares', 'getQuestions'])
+			->setConstructorArgs([
+				$this->createMock(IUserSession::class),
+				$this->activityManager,
+				$this->formMapper,
+				$this->optionMapper,
+				$this->questionMapper,
+				$this->shareMapper,
+				$this->submissionMapper,
+				$this->configService,
+				$this->groupManager,
+				$this->userManager,
+				$this->secureRandom,
+				$this->circlesService,
+				$this->storage,
+				$this->l10n,
+				$this->logger,
+				$eventDispatcher,
+				$this->mailer,
+				$this->emailValidator,
+				$this->answerMapper,
+			])
+			->getMock();
+
+		$formsService->method('getShares')->willReturn([]);
+		$formsService->method('getQuestions')->with(42)->willReturn($questions);
+
+		$formsService->notifyNewSubmission($form, $submission);
+	}
+
+	public function testNotifyNewSubmissionConfirmationEmailUsesFirstEmailField(): void {
+		$submission = new Submission();
+		$submission->setId(99);
+		$submission->setUserId('someUser');
+
+		$form = Form::fromParams([
+			'id' => 42,
+			'ownerId' => 'ownerUser',
+			'title' => 'My Form',
+			'description' => 'My Desc',
+			'confirmationEmailEnabled' => true,
+			'confirmationEmailSubject' => 'Thanks',
+			'confirmationEmailBody' => 'Hello',
+		]);
+
+		$questions = [
+			[
+				'id' => 1,
+				'type' => Constants::ANSWER_TYPE_SHORT,
+				'text' => 'Email 1',
+				'name' => 'email1',
+				'extraSettings' => ['validationType' => 'email', 'confirmationEmailRecipient' => true],
+			],
+			[
+				'id' => 2,
+				'type' => Constants::ANSWER_TYPE_SHORT,
+				'text' => 'Email 2',
+				'name' => 'email2',
+				'extraSettings' => ['validationType' => 'email'],
+			],
+		];
+
+		$emailAnswer1 = new Answer();
+		$emailAnswer1->setSubmissionId(99);
+		$emailAnswer1->setQuestionId(1);
+		$emailAnswer1->setText('first@example.com');
+
+		$emailAnswer2 = new Answer();
+		$emailAnswer2->setSubmissionId(99);
+		$emailAnswer2->setQuestionId(2);
+		$emailAnswer2->setText('second@example.com');
+
+		$this->answerMapper->expects($this->once())
+			->method('findBySubmission')
+			->with(99)
+			->willReturn([$emailAnswer1, $emailAnswer2]);
+
+		$this->emailValidator->expects($this->once())
+			->method('isValid')
+			->with('first@example.com')
+			->willReturn(true);
+
+		$message = $this->createMock(IMessage::class);
+		$message->expects($this->once())
+			->method('setTo')
+			->with(['first@example.com']);
+
+		$this->mailer->expects($this->once())
+			->method('createMessage')
+			->willReturn($message);
+
+		$this->mailer->expects($this->once())
+			->method('send')
+			->with($message);
+
+		$logged = [];
+		$this->logger->method('debug')
+			->willReturnCallback(function (string $message, array $context) use (&$logged): void {
+				$logged[] = [$message, $context];
+			});
+
+		$eventDispatcher = $this->createMock(IEventDispatcher::class);
+		$eventDispatcher->expects($this->once())->method('dispatchTyped')->withAnyParameters();
+
+		$formsService = $this->getMockBuilder(FormsService::class)
+			->onlyMethods(['getShares', 'getQuestions'])
+			->setConstructorArgs([
+				$this->createMock(IUserSession::class),
+				$this->activityManager,
+				$this->formMapper,
+				$this->optionMapper,
+				$this->questionMapper,
+				$this->shareMapper,
+				$this->submissionMapper,
+				$this->configService,
+				$this->groupManager,
+				$this->userManager,
+				$this->secureRandom,
+				$this->circlesService,
+				$this->storage,
+				$this->l10n,
+				$this->logger,
+				$eventDispatcher,
+				$this->mailer,
+				$this->emailValidator,
+				$this->answerMapper,
+			])
+			->getMock();
+
+		$formsService->method('getShares')->willReturn([]);
+		$formsService->method('getQuestions')->with(42)->willReturn($questions);
+
+		$formsService->notifyNewSubmission($form, $submission);
+	}
+
+	public function testNotifyNewSubmissionPlaceholderUsesQuestionTextWhenNameMissing(): void {
+		$submission = new Submission();
+		$submission->setId(99);
+		$submission->setUserId('someUser');
+
+		$form = Form::fromParams([
+			'id' => 42,
+			'ownerId' => 'ownerUser',
+			'title' => 'My Form',
+			'description' => 'My Desc',
+			'confirmationEmailEnabled' => true,
+			'confirmationEmailSubject' => 'Hello {fullname}',
+			'confirmationEmailBody' => 'Body',
+		]);
+
+		$questions = [
+			[
+				'id' => 1,
+				'type' => Constants::ANSWER_TYPE_SHORT,
+				'text' => 'Email',
+				'name' => 'email',
+				'extraSettings' => ['validationType' => 'email'],
+			],
+			[
+				'id' => 2,
+				'type' => Constants::ANSWER_TYPE_SHORT,
+				'text' => 'Full Name?',
+				'name' => '',
+				'extraSettings' => ['validationType' => 'text'],
+			],
+		];
+
+		$emailAnswer = new Answer();
+		$emailAnswer->setSubmissionId(99);
+		$emailAnswer->setQuestionId(1);
+		$emailAnswer->setText('respondent@example.com');
+
+		$nameAnswer = new Answer();
+		$nameAnswer->setSubmissionId(99);
+		$nameAnswer->setQuestionId(2);
+		$nameAnswer->setText('Ada');
+
+		$this->answerMapper->expects($this->once())
+			->method('findBySubmission')
+			->with(99)
+			->willReturn([$emailAnswer, $nameAnswer]);
+
+		$this->emailValidator->expects($this->once())
+			->method('isValid')
+			->with('respondent@example.com')
+			->willReturn(true);
+
+		$message = $this->createMock(IMessage::class);
+		$message->expects($this->once())
+			->method('setSubject')
+			->with('Hello Ada');
+
+		$this->mailer->expects($this->once())
+			->method('createMessage')
+			->willReturn($message);
+
+		$this->mailer->expects($this->once())
+			->method('send')
+			->with($message);
+
+		$eventDispatcher = $this->createMock(IEventDispatcher::class);
+		$eventDispatcher->expects($this->once())->method('dispatchTyped')->withAnyParameters();
+
+		$formsService = $this->getMockBuilder(FormsService::class)
+			->onlyMethods(['getShares', 'getQuestions'])
+			->setConstructorArgs([
+				$this->createMock(IUserSession::class),
+				$this->activityManager,
+				$this->formMapper,
+				$this->optionMapper,
+				$this->questionMapper,
+				$this->shareMapper,
+				$this->submissionMapper,
+				$this->configService,
+				$this->groupManager,
+				$this->userManager,
+				$this->secureRandom,
+				$this->circlesService,
+				$this->storage,
+				$this->l10n,
+				$this->logger,
+				$eventDispatcher,
+				$this->mailer,
+				$this->emailValidator,
+				$this->answerMapper,
+			])
+			->getMock();
+
+		$formsService->method('getShares')->willReturn([]);
+		$formsService->method('getQuestions')->with(42)->willReturn($questions);
+
+		$formsService->notifyNewSubmission($form, $submission);
+	}
+
+	public function testNotifyNewSubmissionSendsConfirmationEmailWithEmptySubjectAndBody(): void {
+		$submission = new Submission();
+		$submission->setId(99);
+		$submission->setUserId('someUser');
+
+		$form = Form::fromParams([
+			'id' => 42,
+			'ownerId' => 'ownerUser',
+			'title' => 'My Form',
+			'description' => 'My Desc',
+			'confirmationEmailEnabled' => true,
+			'confirmationEmailSubject' => '',
+			'confirmationEmailBody' => '',
+		]);
+
+		$questions = [
+			[
+				'id' => 1,
+				'type' => Constants::ANSWER_TYPE_SHORT,
+				'text' => 'Email',
+				'name' => 'email',
+				'extraSettings' => ['validationType' => 'email'],
+			],
+		];
+
+		$emailAnswer = new Answer();
+		$emailAnswer->setSubmissionId(99);
+		$emailAnswer->setQuestionId(1);
+		$emailAnswer->setText('respondent@example.com');
+
+		$this->answerMapper->expects($this->once())
+			->method('findBySubmission')
+			->with(99)
+			->willReturn([$emailAnswer]);
+
+		$this->emailValidator->expects($this->once())
+			->method('isValid')
+			->with('respondent@example.com')
+			->willReturn(true);
+
+		$message = $this->createMock(IMessage::class);
+
+		$message->expects($this->once())
+			->method('setSubject')
+			->with('Thank you for your submission');
+		$message->expects($this->once())
+			->method('setTo')
+			->with(['respondent@example.com']);
+		$message->expects($this->once())
+			->method('setPlainBody')
+			->with($this->callback(function (string $body): bool {
+				$this->assertStringContainsString('Thank you for submitting the form "My Form"', $body);
+				return true;
+			}));
+
+		$this->mailer->expects($this->once())
+			->method('createMessage')
+			->willReturn($message);
+
+		$this->mailer->expects($this->once())
+			->method('send')
+			->with($message);
+
+		$eventDispatcher = $this->createMock(IEventDispatcher::class);
+		$eventDispatcher->expects($this->once())->method('dispatchTyped')->withAnyParameters();
+
+		$formsService = $this->getMockBuilder(FormsService::class)
+			->onlyMethods(['getShares', 'getQuestions'])
+			->setConstructorArgs([
+				$this->createMock(IUserSession::class),
+				$this->activityManager,
+				$this->formMapper,
+				$this->optionMapper,
+				$this->questionMapper,
+				$this->shareMapper,
+				$this->submissionMapper,
+				$this->configService,
+				$this->groupManager,
+				$this->userManager,
+				$this->secureRandom,
+				$this->circlesService,
+				$this->storage,
+				$this->l10n,
+				$this->logger,
+				$eventDispatcher,
+				$this->mailer,
+				$this->emailValidator,
+				$this->answerMapper,
+			])
+			->getMock();
+
+		$formsService->method('getShares')->willReturn([]);
+		$formsService->method('getQuestions')->with(42)->willReturn($questions);
+
+		$formsService->notifyNewSubmission($form, $submission);
+	}
+
+	public function testNotifyNewSubmissionSendsConfirmationEmailToExplicitRecipientQuestion(): void {
+		$submission = new Submission();
+		$submission->setId(99);
+		$submission->setUserId('someUser');
+
+		$form = Form::fromParams([
+			'id' => 42,
+			'ownerId' => 'ownerUser',
+			'confirmationEmailEnabled' => true,
+			'confirmationEmailSubject' => 'Thanks',
+			'confirmationEmailBody' => 'Hello',
+		]);
+
+		$questions = [
+			[
+				'id' => 1,
+				'type' => Constants::ANSWER_TYPE_SHORT,
+				'text' => 'Work email',
+				'name' => 'workEmail',
+				'extraSettings' => ['validationType' => 'email'],
+			],
+			[
+				'id' => 2,
+				'type' => Constants::ANSWER_TYPE_SHORT,
+				'text' => 'Private email',
+				'name' => 'privateEmail',
+				'extraSettings' => [
+					'validationType' => 'email',
+					'confirmationEmailRecipient' => true,
+				],
+			],
+		];
+
+		$workEmailAnswer = new Answer();
+		$workEmailAnswer->setSubmissionId(99);
+		$workEmailAnswer->setQuestionId(1);
+		$workEmailAnswer->setText('work@example.com');
+
+		$privateEmailAnswer = new Answer();
+		$privateEmailAnswer->setSubmissionId(99);
+		$privateEmailAnswer->setQuestionId(2);
+		$privateEmailAnswer->setText('private@example.com');
+
+		$this->answerMapper->expects($this->once())
+			->method('findBySubmission')
+			->with(99)
+			->willReturn([$workEmailAnswer, $privateEmailAnswer]);
+
+		$this->emailValidator->expects($this->once())
+			->method('isValid')
+			->with('private@example.com')
+			->willReturn(true);
+
+		$message = $this->createMock(IMessage::class);
+		$message->expects($this->once())->method('setSubject')->with('Thanks');
+		$message->expects($this->once())->method('setPlainBody')->with('Hello');
+		$message->expects($this->once())->method('setTo')->with(['private@example.com']);
+
+		$this->mailer->expects($this->once())
+			->method('createMessage')
+			->willReturn($message);
+		$this->mailer->expects($this->once())
+			->method('send')
+			->with($message);
+
+		$eventDispatcher = $this->createMock(IEventDispatcher::class);
+		$eventDispatcher->expects($this->once())->method('dispatchTyped')->withAnyParameters();
+
+		$formsService = $this->getMockBuilder(FormsService::class)
+			->onlyMethods(['getShares', 'getQuestions'])
+			->setConstructorArgs([
+				$this->createMock(IUserSession::class),
+				$this->activityManager,
+				$this->formMapper,
+				$this->optionMapper,
+				$this->questionMapper,
+				$this->shareMapper,
+				$this->submissionMapper,
+				$this->configService,
+				$this->groupManager,
+				$this->userManager,
+				$this->secureRandom,
+				$this->circlesService,
+				$this->storage,
+				$this->l10n,
+				$this->logger,
+				$eventDispatcher,
+				$this->mailer,
+				$this->emailValidator,
+				$this->answerMapper,
+			])
+			->getMock();
+
+		$formsService->method('getShares')->willReturn([]);
+		$formsService->method('getQuestions')->with(42)->willReturn($questions);
+
+		$formsService->notifyNewSubmission($form, $submission);
+	}
+
+	public function testNotifyNewSubmissionDoesNotSendConfirmationEmailWithoutExplicitRecipientWhenMultipleEmailFieldsExist(): void {
+		$submission = new Submission();
+		$submission->setId(99);
+		$submission->setUserId('someUser');
+
+		$form = Form::fromParams([
+			'id' => 42,
+			'ownerId' => 'ownerUser',
+			'confirmationEmailEnabled' => true,
+			'confirmationEmailSubject' => 'Thanks',
+			'confirmationEmailBody' => 'Hello',
+		]);
+
+		$questions = [
+			[
+				'id' => 1,
+				'type' => Constants::ANSWER_TYPE_SHORT,
+				'text' => 'Work email',
+				'name' => 'workEmail',
+				'extraSettings' => ['validationType' => 'email'],
+			],
+			[
+				'id' => 2,
+				'type' => Constants::ANSWER_TYPE_SHORT,
+				'text' => 'Private email',
+				'name' => 'privateEmail',
+				'extraSettings' => ['validationType' => 'email'],
+			],
+		];
+
+		$this->answerMapper->expects($this->once())
+			->method('findBySubmission')
+			->with(99)
+			->willReturn([]);
+
+		$this->emailValidator->expects($this->never())->method('isValid');
+		$this->logger->expects($this->once())
+			->method('debug')
+			->with(
+				'No confirmation email recipient question is available',
+				[
+					'formId' => 42,
+					'submissionId' => 99,
+				]
+			);
+		$this->mailer->expects($this->never())->method('send');
+
+		$eventDispatcher = $this->createMock(IEventDispatcher::class);
+		$eventDispatcher->expects($this->once())->method('dispatchTyped')->withAnyParameters();
+
+		$formsService = $this->getMockBuilder(FormsService::class)
+			->onlyMethods(['getShares', 'getQuestions'])
+			->setConstructorArgs([
+				$this->createMock(IUserSession::class),
+				$this->activityManager,
+				$this->formMapper,
+				$this->optionMapper,
+				$this->questionMapper,
+				$this->shareMapper,
+				$this->submissionMapper,
+				$this->configService,
+				$this->groupManager,
+				$this->userManager,
+				$this->secureRandom,
+				$this->circlesService,
+				$this->storage,
+				$this->l10n,
+				$this->logger,
+				$eventDispatcher,
+				$this->mailer,
+				$this->emailValidator,
+				$this->answerMapper,
+			])
+			->getMock();
+
+		$formsService->method('getShares')->willReturn([]);
+		$formsService->method('getQuestions')->with(42)->willReturn($questions);
+
+		$formsService->notifyNewSubmission($form, $submission);
+	}
+
+	public function testNotifyNewSubmissionDoesNotSendConfirmationEmailWhenNoEmailFound(): void {
+		$submission = new Submission();
+		$submission->setId(99);
+		$submission->setUserId('someUser');
+
+		$form = Form::fromParams([
+			'id' => 42,
+			'ownerId' => 'ownerUser',
+			'title' => 'My Form',
+			'confirmationEmailEnabled' => true,
+			'confirmationEmailSubject' => 'Thanks',
+			'confirmationEmailBody' => 'Hello',
+		]);
+
+		$questions = [
+			[
+				'id' => 1,
+				'type' => Constants::ANSWER_TYPE_SHORT,
+				'text' => 'Name',
+				'name' => 'name',
+				'extraSettings' => ['validationType' => 'text'],
+			],
+		];
+
+		$nameAnswer = new Answer();
+		$nameAnswer->setSubmissionId(99);
+		$nameAnswer->setQuestionId(1);
+		$nameAnswer->setText('John');
+
+		$this->answerMapper->expects($this->once())
+			->method('findBySubmission')
+			->with(99)
+			->willReturn([$nameAnswer]);
+
+		$this->logger->expects($this->once())
+			->method('debug')
+			->with(
+				'No confirmation email recipient question is available',
+				[
+					'formId' => 42,
+					'submissionId' => 99,
+				]
+			);
+
+		$this->mailer->expects($this->never())->method('send');
+
+		$eventDispatcher = $this->createMock(IEventDispatcher::class);
+		$eventDispatcher->expects($this->once())->method('dispatchTyped')->withAnyParameters();
+
+		$formsService = $this->getMockBuilder(FormsService::class)
+			->onlyMethods(['getShares', 'getQuestions'])
+			->setConstructorArgs([
+				$this->createMock(IUserSession::class),
+				$this->activityManager,
+				$this->formMapper,
+				$this->optionMapper,
+				$this->questionMapper,
+				$this->shareMapper,
+				$this->submissionMapper,
+				$this->configService,
+				$this->groupManager,
+				$this->userManager,
+				$this->secureRandom,
+				$this->circlesService,
+				$this->storage,
+				$this->l10n,
+				$this->logger,
+				$eventDispatcher,
+				$this->mailer,
+				$this->emailValidator,
+				$this->answerMapper,
+			])
+			->getMock();
+
+		$formsService->method('getShares')->willReturn([]);
+		$formsService->method('getQuestions')->with(42)->willReturn($questions);
+
+		$formsService->notifyNewSubmission($form, $submission);
+	}
+
+	public function testNotifyNewSubmissionHandlesEmailException(): void {
+		$submission = new Submission();
+		$submission->setId(99);
+		$submission->setUserId('someUser');
+
+		$form = Form::fromParams([
+			'id' => 42,
+			'ownerId' => 'ownerUser',
+			'title' => 'My Form',
+			'confirmationEmailEnabled' => true,
+			'confirmationEmailSubject' => 'Thanks',
+			'confirmationEmailBody' => 'Hello',
+		]);
+
+		$questions = [
+			[
+				'id' => 1,
+				'type' => Constants::ANSWER_TYPE_SHORT,
+				'text' => 'Email',
+				'name' => 'email',
+				'extraSettings' => ['validationType' => 'email'],
+			],
+		];
+
+		$emailAnswer = new Answer();
+		$emailAnswer->setSubmissionId(99);
+		$emailAnswer->setQuestionId(1);
+		$emailAnswer->setText('respondent@example.com');
+
+		$this->answerMapper->expects($this->once())
+			->method('findBySubmission')
+			->with(99)
+			->willReturn([$emailAnswer]);
+
+		$this->emailValidator->expects($this->once())
+			->method('isValid')
+			->with('respondent@example.com')
+			->willReturn(true);
+
+		$message = $this->createMock(IMessage::class);
+		$message->expects($this->once())->method('setSubject')->with('Thanks');
+		$message->expects($this->once())->method('setPlainBody')->with('Hello');
+		$message->expects($this->once())->method('setTo')->with(['respondent@example.com']);
+
+		$this->mailer->expects($this->once())
+			->method('createMessage')
+			->willReturn($message);
+
+		$exception = new \Exception('Mail server error');
+		$this->mailer->expects($this->once())
+			->method('send')
+			->with($message)
+			->willThrowException($exception);
+
+		$this->logger->expects($this->once())
+			->method('error')
+			->with(
+				'Error while sending confirmation email',
+				$this->callback(function (array $context): bool {
+					$this->assertArrayHasKey('exception', $context);
+					$this->assertInstanceOf(\Exception::class, $context['exception']);
+					$this->assertEquals(42, $context['formId']);
+					$this->assertEquals(99, $context['submissionId']);
+					return true;
+				})
+			);
+
+		$eventDispatcher = $this->createMock(IEventDispatcher::class);
+		$eventDispatcher->expects($this->once())->method('dispatchTyped')->withAnyParameters();
+
+		$formsService = $this->getMockBuilder(FormsService::class)
+			->onlyMethods(['getShares', 'getQuestions'])
+			->setConstructorArgs([
+				$this->createMock(IUserSession::class),
+				$this->activityManager,
+				$this->formMapper,
+				$this->optionMapper,
+				$this->questionMapper,
+				$this->shareMapper,
+				$this->submissionMapper,
+				$this->configService,
+				$this->groupManager,
+				$this->userManager,
+				$this->secureRandom,
+				$this->circlesService,
+				$this->storage,
+				$this->l10n,
+				$this->logger,
+				$eventDispatcher,
+				$this->mailer,
+				$this->emailValidator,
+				$this->answerMapper,
+			])
+			->getMock();
+
+		$formsService->method('getShares')->willReturn([]);
+		$formsService->method('getQuestions')->with(42)->willReturn($questions);
 
 		$formsService->notifyNewSubmission($form, $submission);
 	}
@@ -1291,6 +2239,14 @@ class FormsServiceTest extends TestCase {
 					'shuffleOptions' => true
 				],
 				'questionType' => Constants::ANSWER_TYPE_MULTIPLE,
+				'expected' => true
+			],
+			'valid-confirmation-recipient' => [
+				'extraSettings' => [
+					'confirmationEmailRecipient' => true,
+					'validationType' => 'email',
+				],
+				'questionType' => Constants::ANSWER_TYPE_SHORT,
 				'expected' => true
 			],
 			'valid-options-limit' => [


### PR DESCRIPTION
Implements issue #525 - Send confirmation emails to form respondents after submission.

Features:
- Add database migration for confirmation email settings (enabled, subject, body)
- Add confirmation email fields to Form entity
- Implement email sending with placeholder replacement:
  - {formTitle}, {formDescription} placeholders
  - Field name placeholders (e.g. {name}, {email})
  - Automatic data overview if {data} not in template
- Add UI in Settings sidebar to configure confirmation emails
- Automatically detect email field from form submissions
- Send email using system mail account

Technical changes:
- Add sendConfirmationEmail() method to FormsService
- Integrate email sending into notifyNewSubmission() flow
- Add unit tests for confirmation email functionality
- Update FormsService constructor with IMailer and AnswerMapper dependencies
- Update documentation (DataStructure.md, CHANGELOG.en.md)

The feature requires at least one email-validated short text question in the form. Email sending failures are logged but don't break the submission process.

<img width="837" height="862" alt="Screenshot 2025-12-19 105758" src="https://github.com/user-attachments/assets/fad62e98-fd35-4cc6-99af-4c454ff33466" />
