### PR TITLE
fix: do not add result permissions to see own submissions

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -6,7 +6,4 @@
 import { recommendedVue2 } from '@nextcloud/eslint-config'
 import eslintPluginPrettierRecommended from 'eslint-plugin-prettier/recommended'
 
-export default [
-	...recommendedVue2,
-	eslintPluginPrettierRecommended,
-]
+export default [...recommendedVue2, eslintPluginPrettierRecommended]

--- a/lib/Controller/ApiController.php
+++ b/lib/Controller/ApiController.php
@@ -22,6 +22,7 @@ use OCA\Forms\Db\Submission;
 use OCA\Forms\Db\SubmissionMapper;
 use OCA\Forms\Db\UploadedFile;
 use OCA\Forms\Db\UploadedFileMapper;
+use OCA\Forms\Exception\NoSuchFormException;
 use OCA\Forms\ResponseDefinitions;
 use OCA\Forms\Service\ConfigService;
 use OCA\Forms\Service\FormsService;
@@ -1161,8 +1162,14 @@ class ApiController extends OCSController {
 	#[ApiRoute(verb: 'GET', url: '/api/v3/forms/{formId}/submissions')]
 	public function getSubmissions(int $formId, ?string $query = null, ?int $limit = null, int $offset = 0, ?string $fileFormat = null): DataResponse|DataDownloadResponse {
 		$form = $this->formsService->getFormIfAllowed($formId, Constants::PERMISSION_RESULTS);
+		$permissions = $this->formsService->getPermissions($form);
+		$canSeeAllSubmissions = in_array(Constants::PERMISSION_RESULTS, $permissions, true);
 
 		if ($fileFormat !== null) {
+			if (!$canSeeAllSubmissions) {
+				throw new NoSuchFormException('The current user has no permission to get the results for this form', Http::STATUS_FORBIDDEN);
+			}
+
 			$submissionsData = $this->submissionService->getSubmissionsData($form, $fileFormat);
 			$fileName = $this->formsService->getFileName($form, $fileFormat);
 
@@ -1170,7 +1177,7 @@ class ApiController extends OCSController {
 		}
 
 		// Load submissions and currently active questions
-		if (in_array(Constants::PERMISSION_RESULTS, $this->formsService->getPermissions($form))) {
+		if ($canSeeAllSubmissions) {
 			$submissions = $this->submissionService->getSubmissions($formId, null, $query, $limit, $offset);
 			$filteredSubmissionsCount = $this->submissionMapper->countSubmissions($formId, null, $query);
 		} else {

--- a/lib/Service/FormsService.php
+++ b/lib/Service/FormsService.php
@@ -212,8 +212,6 @@ class FormsService {
 			$userSubmissionCount = $this->submissionMapper->countSubmissions($form->getId(), $this->currentUser->getUID());
 			if ($userSubmissionCount > 0) {
 				$result['submissionCount'] = $userSubmissionCount;
-				// Append `results` permission if user has submitted to the form
-				$result['permissions'][] = Constants::PERMISSION_RESULTS;
 			}
 		}
 

--- a/src/Forms.vue
+++ b/src/Forms.vue
@@ -269,8 +269,15 @@ export default {
 				return false
 			}
 
+			if (this.$route.name === 'results') {
+				return (
+					form.permissions.includes(this.$route.name)
+					|| form.submissionCount > 0
+				)
+			}
+
 			// Return whether route is in the permissions-list
-			return form?.permissions.includes(this.$route.name)
+			return form.permissions.includes(this.$route.name)
 		},
 
 		selectedForm: {

--- a/src/views/Results.vue
+++ b/src/views/Results.vue
@@ -50,6 +50,7 @@
 
 				<!-- Action menu for cloud export and deletion -->
 				<NcActions
+					v-if="canExportSubmissions"
 					:aria-label="t('forms', 'Options')"
 					force-name
 					:inline="isMobile ? 0 : 1"
@@ -447,6 +448,12 @@ export default {
 	computed: {
 		isFormArchived() {
 			return this.form.state === FormState.FormArchived
+		},
+
+		canExportSubmissions() {
+			return this.form.permissions.includes(
+				this.PERMISSION_TYPES.PERMISSION_RESULTS,
+			)
 		},
 
 		canDeleteSubmissions() {


### PR DESCRIPTION
* resolves https://github.com/nextcloud/forms/issues/3121

When a user has submitted a form they should not have result permissions, but instead we should only show their own submissions.