### PR TITLE
[stable5.2] fix: do not add result permissions to see own submissions

### DIFF
--- a/lib/Service/FormsService.php
+++ b/lib/Service/FormsService.php
@@ -212,8 +212,6 @@ class FormsService {
 			$userSubmissionCount = $this->submissionMapper->countSubmissions($form->getId(), $this->currentUser->getUID());
 			if ($userSubmissionCount > 0) {
 				$result['submissionCount'] = $userSubmissionCount;
-				// Append `results` permission if user has submitted to the form
-				$result['permissions'][] = Constants::PERMISSION_RESULTS;
 			}
 		}
 

--- a/src/Forms.vue
+++ b/src/Forms.vue
@@ -272,8 +272,15 @@ export default {
 				return false
 			}
 
+			if (this.$route.name === 'results') {
+				return (
+					form.permissions.includes(this.$route.name)
+					|| form.submissionCount > 0
+				)
+			}
+
 			// Return whether route is in the permissions-list
-			return form?.permissions.includes(this.$route.name)
+			return form.permissions.includes(this.$route.name)
 		},
 
 		selectedForm: {

--- a/src/views/Results.vue
+++ b/src/views/Results.vue
@@ -50,6 +50,7 @@
 
 				<!-- Action menu for cloud export and deletion -->
 				<NcActions
+					v-if="canExportSubmissions"
 					:aria-label="t('forms', 'Options')"
 					force-name
 					:inline="isMobile ? 0 : 1"
@@ -447,6 +448,12 @@ export default {
 	computed: {
 		isFormArchived() {
 			return this.form.state === FormState.FormArchived
+		},
+
+		canExportSubmissions() {
+			return this.form.permissions.includes(
+				this.PERMISSION_TYPES.PERMISSION_RESULTS,
+			)
 		},
 
 		canDeleteSubmissions() {


### PR DESCRIPTION
* manual backport of https://github.com/nextcloud/forms/pull/3128