### PR TITLE
feat: extract subtype check and show submenu indicator for questions with subtypes

### DIFF
--- a/src/views/Create.vue
+++ b/src/views/Create.vue
@@ -162,11 +162,12 @@
 							<NcActionButton
 								v-for="(answer, type) in answerTypesFilter"
 								:key="answer.label"
-								:close-after-click="!answer.subtypes"
+								:close-after-click="!hasSubtypes(answer)"
 								:disabled="isLoadingQuestions"
+								:is-menu="hasSubtypes(answer)"
 								class="question-menu__question"
 								@click="
-									answer.subtypes
+									hasSubtypes(answer)
 										? (activeQuestionType = type)
 										: addQuestion(type)
 								">
@@ -342,6 +343,11 @@ export default {
 			// eslint-disable-next-line @typescript-eslint/no-unused-vars
 			const { datetime, ...filteredAnswerTypes } = answerTypes
 			return filteredAnswerTypes
+		},
+
+		hasSubtypes() {
+			return (answer) =>
+				answer && answer.subtypes && Object.keys(answer.subtypes).length > 0
 		},
 
 		lockedUntilFormatted() {


### PR DESCRIPTION
This adds a computed prop `hasSubtypes` that is true if a question type has subtypes. In this case it adds the submenu indicator to the create question menu.

Signed-off-by: Christian Hartmann <chris-hartmann@gmx.de>