### PR TITLE
Fix IME composition handling in option inputs

### DIFF
--- a/src/components/Questions/AnswerInput.vue
+++ b/src/components/Questions/AnswerInput.vue
@@ -22,7 +22,7 @@
 			@input="debounceOnInput"
 			@keydown.delete="deleteEntry"
 			@keydown.enter.prevent="focusNextInput"
-			@compositionstart="onCompositionEnd"
+			@compositionstart="onCompositionStart"
 			@compositionend="onCompositionEnd" />
 
 		<!-- Actions for reordering and deleting the option  -->
@@ -295,7 +295,10 @@ export default {
 		/**
 		 * Request a new answer
 		 */
-		focusNextInput() {
+		focusNextInput(e) {
+			if (this.isIMEComposing || e?.isComposing) {
+				return
+			}
 			if (this.index <= this.maxIndex) {
 				this.$emit('focus-next', this.index, this.optionType)
 			}
@@ -308,6 +311,10 @@ export default {
 		 * @param {Event} e the event
 		 */
 		async deleteEntry(e) {
+			if (this.isIMEComposing || e?.isComposing) {
+				return
+			}
+
 			if (this.answer.local) {
 				return
 			}


### PR DESCRIPTION
## Summary

This PR now includes a follow-up fix after the initial IME handling patch.

- Prevent unintended option creation while IME composition is in progress
- Move new option creation for the local "Add a new answer option" row to explicit user intent
  - create only on `Enter` (after composition ends) or explicit `+` button click
- Keep normal live updates for already-created options
- Move focus to the next empty local option after creating one with Enter
- Fix delayed "Delete form" confirmation dialog opening by rendering the dialog outside the actions slot

## Why this follow-up was needed

The previous attempt improved composition guards, but real Korean IME usage still hit edge cases where input-driven side effects could trigger unexpectedly in the local option row.

In practice, automatic creation on input was still risky under composition timing differences across browsers/IME implementations.

## Behavioral change and trade-off

The local empty option row no longer auto-creates an option purely from input events.
Instead, creation is explicit (`Enter` or `+` button).

This slightly reduces automation, but removes IME race/side-effect paths and gives deterministic behavior for CJK input users.

## Repro (before)

- Create form
- Add multiple-choice/dropdown/radio options
- Type Korean with IME in the local "Add a new answer option" field
- Observe unexpected creation timing / side effects in some flows

## Verification (after)

- During IME composition: no automatic option creation
- After composition ends: `Enter` creates exactly one option
- `+` button creates exactly one option
- Focus moves to the newly appended empty local option row
- "Delete form" shows confirmation dialog immediately on click