### PR TITLE
fix: clone shared form and set default values

### DIFF
--- a/lib/Controller/ApiController.php
+++ b/lib/Controller/ApiController.php
@@ -193,9 +193,19 @@ class ApiController extends OCSController {
 			unset($formData['fileFormat']);
 			unset($formData['lockedBy']);
 			unset($formData['lockedUntil']);
+			$formData['ownerId'] = $this->currentUser->getUID();
 			$formData['hash'] = $this->formsService->generateFormHash();
 			// TRANSLATORS Appendix to the form Title of a duplicated/copied form.
 			$formData['title'] .= ' - ' . $this->l10n->t('Copy');
+			$formData['access'] = [
+				'permitAllUsers' => false,
+				'showToAllUsers' => false,
+			];
+			$formData['submitMultiple'] = false;
+			$formData['allowEditSubmissions'] = false;
+			$formData['showExpiration'] = false;
+			$formData['expires'] = 0;
+			$formData['isAnonymous'] = false;
 
 			$form = Form::fromParams($formData);
 			$this->formMapper->insert($form);

--- a/src/Forms.vue
+++ b/src/Forms.vue
@@ -50,6 +50,7 @@
 						:form="form"
 						read-only
 						@open-sharing="openSharing"
+						@clone="onCloneForm"
 						@mobile-close-navigation="mobileCloseNavigation" />
 				</ul>
 			</template>


### PR DESCRIPTION
This fixes #3186 by adding the missing event handler to the list of shared forms. Also fixed some missing default values in the backend when a form is cloned.

Signed-off-by: Christian Hartmann <chris-hartmann@gmx.de>