### PR TITLE
fix(export): Handle exceptions when reading file content and ignore whitespace-only files

### DIFF
--- a/lib/Service/SubmissionService.php
+++ b/lib/Service/SubmissionService.php
@@ -380,9 +380,19 @@ class SubmissionService {
 	 * @param list<non-empty-list<array{columns?: list<mixed|string>, label?: string, url?: string}|mixed|null|string>> $data
 	 */
 	private function exportData(array $header, array $data, string $fileFormat, ?File $file = null): string {
-		if ($file && $file->getContent()) {
+		$content = null;
+		if ($file) {
+			try {
+				$content = $file->getContent();
+			} catch (\Exception $e) {
+				$this->logger->warning('Failed to read existing linked file content: {msg}', ['msg' => $e->getMessage()]);
+			}
+		}
+
+		// Ignore whitespace-only files (e.g. S3 single-space placeholder).
+		if ($content !== null && trim($content) !== '') {
 			$existentFile = $this->tempManager->getTemporaryFile($fileFormat);
-			file_put_contents($existentFile, $file->getContent());
+			file_put_contents($existentFile, $content);
 			$spreadsheet = IOFactory::load($existentFile);
 		} else {
 			$spreadsheet = new Spreadsheet();


### PR DESCRIPTION
This fixes #3175 by adding a check if the file really has content.

Signed-off-by: Christian Hartmann <chris-hartmann@gmx.de>