### PR TITLE
fix(a11y): Prevent escaping of aria-labels in QuestionLong and QuestionShort components

### DIFF
--- a/src/components/Questions/QuestionLong.vue
+++ b/src/components/Questions/QuestionLong.vue
@@ -13,9 +13,15 @@
 			<textarea
 				ref="textarea"
 				:aria-label="
-					t('forms', 'A long answer for the question “{text}”', {
-						text,
-					})
+					t(
+						'forms',
+						'A long answer for the question “{text}”',
+						{
+							text,
+						},
+						undefined,
+						{ escape: false },
+					)
 				"
 				:placeholder="submissionInputPlaceholder"
 				:disabled="!readOnly"

--- a/src/components/Questions/QuestionShort.vue
+++ b/src/components/Questions/QuestionShort.vue
@@ -13,9 +13,15 @@
 			<input
 				ref="input"
 				:aria-label="
-					t('forms', 'A short answer for the question “{text}”', {
-						text,
-					})
+					t(
+						'forms',
+						'A short answer for the question “{text}”',
+						{
+							text,
+						},
+						undefined,
+						{ escape: false },
+					)
 				"
 				:placeholder="submissionInputPlaceholder"
 				:disabled="!readOnly"


### PR DESCRIPTION
This fixes #3213.

Signed-off-by: Christian Hartmann <chris-hartmann@gmx.de>