### PR TITLE
enh(l10n): Unify wording for form responses across multiple components

### DIFF
--- a/src/FormsEmptyContent.vue
+++ b/src/FormsEmptyContent.vue
@@ -53,7 +53,7 @@ export default {
 					title: t('forms', 'Form expired'),
 					description: t(
 						'forms',
-						'This form has expired and is no longer taking answers',
+						'This form has expired and is no longer taking responses',
 					),
 
 					icon: IconCheck,

--- a/src/components/AppNavigationForm.vue
+++ b/src/components/AppNavigationForm.vue
@@ -57,7 +57,7 @@
 				<template #icon>
 					<IconPoll :size="20" />
 				</template>
-				{{ t('forms', 'Results') }}
+				{{ t('forms', 'Responses') }}
 			</NcActionRouter>
 			<NcActionButton v-if="canEdit" close-after-click @click="onCloneForm">
 				<template #icon>

--- a/src/components/SidebarTabs/SettingsSidebarTab.vue
+++ b/src/components/SidebarTabs/SettingsSidebarTab.vue
@@ -87,7 +87,7 @@
 			{{ t('forms', 'Close form') }}
 		</NcCheckboxRadioSwitch>
 		<p id="forms-settings__close-form" class="settings-hint">
-			{{ t('forms', 'Closed forms do not accept new submissions.') }}
+			{{ t('forms', 'Closed forms do not accept new responses.') }}
 		</p>
 		<NcCheckboxRadioSwitch
 			:model-value="isFormLockedPermanently"
@@ -112,7 +112,7 @@
 			{{
 				t(
 					'forms',
-					'Archived forms do not accept new submissions and can not be modified.',
+					'Archived forms do not accept new responses and cannot be modified.',
 				)
 			}}
 		</p>

--- a/src/components/TopBar.vue
+++ b/src/components/TopBar.vue
@@ -54,9 +54,9 @@ const editView = {
 	disabled: false,
 }
 const resultsView = {
-	ariaLabel: t('forms', 'Show results'),
+	ariaLabel: t('forms', 'Show responses'),
 	icon: mdiPoll,
-	title: t('forms', 'Results'),
+	title: t('forms', 'Responses'),
 	id: 'results',
 }
 

--- a/src/views/Results.vue
+++ b/src/views/Results.vue
@@ -4,7 +4,7 @@
 -->
 
 <template>
-	<NcAppContent :page-heading="t('forms', 'Results')">
+	<NcAppContent :page-heading="t('forms', 'Responses')">
 		<NcDialog
 			:open.sync="showLinkedFileNotAvailableDialog"
 			:name="t('forms', 'Linked file not available')"
@@ -192,10 +192,10 @@
 		<!-- Empty search results -->
 		<NcEmptyContent
 			v-else-if="noFilteredSubmissions && submissionSearch.length > 0"
-			:name="t('forms', 'No results found')"
+			:name="t('forms', 'No responses found')"
 			class="forms-emptycontent"
 			:description="
-				t('forms', 'No results found for {submissionSearch}', {
+				t('forms', 'No responses found for \'{submissionSearch}\'', {
 					submissionSearch,
 				})
 			">
@@ -209,9 +209,7 @@
 			v-else-if="noSubmissions"
 			:name="t('forms', 'No responses yet')"
 			class="forms-emptycontent"
-			:description="
-				t('forms', 'Results of submitted forms will show up here')
-			">
+			:description="t('forms', 'Responses will show up here')">
 			<template #icon>
 				<IconPoll :size="64" />
 			</template>
@@ -259,14 +257,8 @@
 		<!-- Confirmation dialog for deleting all submissions -->
 		<NcDialog
 			:open.sync="showConfirmDeleteDialog"
-			:name="t('forms', 'Delete submissions')"
-			:message="
-				t(
-					'forms',
-					'Are you sure you want to delete all responses of {title}?',
-					{ title: formTitle },
-				)
-			"
+			:name="t('forms', 'Delete responses')"
+			:message="t('forms', 'Are you sure you want to delete all responses?')"
 			:buttons="confirmDeleteButtons" />
 	</NcAppContent>
 </template>
@@ -435,7 +427,7 @@ export default {
 					},
 				},
 				{
-					label: t('forms', 'Delete submissions'),
+					label: t('forms', 'Delete responses'),
 					icon: IconDeleteSvg,
 					type: 'error',
 					callback: () => {
@@ -565,7 +557,7 @@ export default {
 
 		async loadFormResults() {
 			this.loadingResults = true
-			logger.debug(`Loading results for form ${this.form.hash}`)
+			logger.debug(`Loading responses for form ${this.form.hash}`)
 
 			try {
 				let response = null
@@ -598,8 +590,8 @@ export default {
 				this.questions = data.questions
 				this.filteredSubmissionsCount = data.filteredSubmissionsCount
 			} catch (error) {
-				logger.error('Error while loading results', { error })
-				showError(t('forms', 'There was an error while loading the results'))
+				logger.error('Error while loading responses', { error })
+				showError(t('forms', 'An error occurred while loading responses'))
 			} finally {
 				this.loadingResults = false
 			}
@@ -777,16 +769,16 @@ export default {
 						},
 					),
 				)
-				showSuccess(t('forms', 'Submission deleted'))
+				showSuccess(t('forms', 'Response deleted'))
 				const index = this.submissions.findIndex(
 					(search) => search.id === id,
 				)
 				this.submissions.splice(index, 1)
 				emit('forms:last-updated:set', this.form.id)
 			} catch (error) {
-				logger.error(`Error while removing response ${id}`, { error })
+				logger.error(`Error while deleting response ${id}`, { error })
 				showError(
-					t('forms', 'There was an error while removing this response'),
+					t('forms', 'An error occurred while deleting this response'),
 				)
 			} finally {
 				this.loadingResults = false
@@ -810,8 +802,8 @@ export default {
 				this.form.submissionCount = 0
 				emit('forms:last-updated:set', this.form.id)
 			} catch (error) {
-				logger.error('Error while removing responses', { error })
-				showError(t('forms', 'There was an error while removing responses'))
+				logger.error('Error while deleting responses', { error })
+				showError(t('forms', 'An error occurred while deleting responses'))
 			} finally {
 				this.loadingResults = false
 			}

--- a/src/views/Submit.vue
+++ b/src/views/Submit.vue
@@ -81,7 +81,7 @@
 				:description="
 					t(
 						'forms',
-						'This form has expired and is no longer taking answers',
+						'This form has expired and is no longer taking responses',
 					)
 				">
 				<template #icon>
@@ -95,7 +95,7 @@
 				:description="
 					t(
 						'forms',
-						'This form was closed and is no longer taking answers',
+						'This form was closed and is no longer taking responses',
 					)
 				">
 				<template #icon>
@@ -480,7 +480,7 @@ export default {
 		hash() {
 			// If public view, abort. Should normally not occur.
 			if (this.publicView) {
-				logger.error('Hash changed on public View. Aborting.')
+				logger.error('Hash changed on public view. Aborting.')
 				return
 			}
 			this.resetData()
@@ -596,7 +596,7 @@ export default {
 		},
 
 		async fetchSubmission() {
-			logger.debug(`Loading submission ${this.submissionId}`)
+			logger.debug(`Loading response ${this.submissionId}`)
 
 			try {
 				const response = await axios.get(
@@ -667,9 +667,9 @@ export default {
 
 				this.answers = answers
 			} catch (error) {
-				logger.error('Error while loading submission', { error })
+				logger.error('Error while loading response', { error })
 				showError(
-					t('forms', 'There was an error while loading the submission'),
+					t('forms', 'There was an error while loading the response'),
 				)
 			}
 		},


### PR DESCRIPTION
This fixes #3217 by unifying the wording for responses.

Signed-off-by: GitHub <noreply@github.com>