### PR TITLE
fix(a11y): announce form submission success to screen readers

### DIFF
--- a/src/views/Submit.vue
+++ b/src/views/Submit.vue
@@ -49,6 +49,11 @@
 				</p>
 			</header>
 
+			<!-- Screen-reader-only live region for submission success announcement -->
+			<div class="hidden-visually" aria-live="polite">
+				{{ successAnnouncement }}
+			</div>
+
 			<NcEmptyContent
 				v-if="loading"
 				class="forms-emptycontent"
@@ -323,6 +328,7 @@ export default {
 			answers: {},
 			loading: false,
 			success: false,
+			successAnnouncement: '',
 			/** Submit state of the form, true if changes are currently submitted */
 			submitForm: false,
 			showConfirmEmptyModal: false,
@@ -495,6 +501,22 @@ export default {
 	},
 
 	watch: {
+		success(newVal) {
+			if (newVal) {
+				// Delay populating the live region to avoid the announcement being
+				// swallowed by the simultaneous large DOM change (form replaced by
+				// success view). Screen readers need a moment to process the new DOM
+				// before a polite live region update registers.
+				setTimeout(() => {
+					this.successAnnouncement =
+						this.form.submissionMessage
+						|| t('forms', 'Thank you for completing the form!')
+				}, 100)
+			} else {
+				this.successAnnouncement = ''
+			}
+		},
+
 		hash() {
 			// If public view, abort. Should normally not occur.
 			if (this.publicView) {


### PR DESCRIPTION
* Resolves: #3349

## Summary

After submitting a form, screen readers had no way to know the submission succeeded — the success view rendered silently. This adds a visually-hidden `aria-live` region that announces the success message.

The live region is populated via a watcher with a short delay (100ms) because the submission triggers a large DOM change (form replaced by success view) that causes screen readers to miss a synchronous `aria-live="polite"` update.

### Not addressed here

The remaining issues from #2858 (checkbox keyboard toggle, date picker keyboard nav, dropdown announcements) are tracked separately:
- Checkbox double-toggle on spacebar: fix to be submitted upstream to `nextcloud-vue`
- Date picker keyboard issues: will be resolved by the Vue 3 / `@nextcloud/vue` v9 migration (#2972), which replaces the underlying `vue2-datepicker` with `@vuepic/vue-datepicker`
- Dropdown (`NcSelect`) screen reader announcements: upstream issue in `nextcloud-vue`

An alternative approach worth considering for the success announcement is using `showSuccess()` from `@nextcloud/dialogs`, which handles its own screen reader announcements. The tradeoff is it also shows a visible toast to sighted users.

## Checklist

- [x] Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [x] [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests (unit, integration, api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation (manuals or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version
