### PR TITLE
Feature/ranking question type vue3

### DIFF
--- a/lib/Constants.php
+++ b/lib/Constants.php
@@ -76,6 +76,7 @@ class Constants {
 	public const ANSWER_TYPE_LONG = 'long';
 	public const ANSWER_TYPE_MULTIPLE = 'multiple';
 	public const ANSWER_TYPE_MULTIPLEUNIQUE = 'multiple_unique';
+	public const ANSWER_TYPE_RANKING = 'ranking';
 	public const ANSWER_TYPE_SHORT = 'short';
 	public const ANSWER_TYPE_TIME = 'time';
 
@@ -95,6 +96,7 @@ class Constants {
 		self::ANSWER_TYPE_LONG,
 		self::ANSWER_TYPE_MULTIPLE,
 		self::ANSWER_TYPE_MULTIPLEUNIQUE,
+		self::ANSWER_TYPE_RANKING,
 		self::ANSWER_TYPE_SHORT,
 		self::ANSWER_TYPE_TIME,
 	];
@@ -105,6 +107,7 @@ class Constants {
 		self::ANSWER_TYPE_LINEARSCALE,
 		self::ANSWER_TYPE_MULTIPLE,
 		self::ANSWER_TYPE_MULTIPLEUNIQUE,
+		self::ANSWER_TYPE_RANKING,
 	];
 
 	// AnswerTypes for date/time questions
@@ -189,6 +192,10 @@ class Constants {
 		'columns' => ['array'],
 		'questionType' => ['string'],
 		'rows' => ['array'],
+	];
+
+	public const EXTRA_SETTINGS_RANKING = [
+		'shuffleOptions' => ['boolean'],
 	];
 
 	public const EXTRA_SETTINGS_GRID_QUESTION_TYPE = [

--- a/lib/Controller/ApiController.php
+++ b/lib/Controller/ApiController.php
@@ -1736,6 +1736,22 @@ class ApiController extends OCSController {
 			return;
 		}
 
+		if ($question['type'] === Constants::ANSWER_TYPE_RANKING) {
+			if (!$answerArray) {
+				return;
+			}
+
+			$answerEntity = new Answer();
+			$answerEntity->setSubmissionId($submissionId);
+			$answerEntity->setQuestionId($question['id']);
+
+			$answerText = json_encode($answerArray);
+			$answerEntity->setText($answerText);
+			$this->answerMapper->insert($answerEntity);
+
+			return;
+		}
+
 		foreach ($answerArray as $answer) {
 			$answerEntity = new Answer();
 			$answerEntity->setSubmissionId($submissionId);

--- a/lib/Service/FormsService.php
+++ b/lib/Service/FormsService.php
@@ -810,6 +810,9 @@ class FormsService {
 			case Constants::ANSWER_TYPE_GRID:
 				$allowed = Constants::EXTRA_SETTINGS_GRID;
 				break;
+			case Constants::ANSWER_TYPE_RANKING:
+				$allowed = Constants::EXTRA_SETTINGS_RANKING;
+				break;
 			case Constants::ANSWER_TYPE_TIME:
 				$allowed = Constants::EXTRA_SETTINGS_TIME;
 				break;

--- a/lib/Service/SubmissionService.php
+++ b/lib/Service/SubmissionService.php
@@ -367,11 +367,10 @@ class SubmissionService {
 						$carry[$questionId] = ['columns' => $columns];
 					} elseif ($questionType === Constants::ANSWER_TYPE_RANKING) {
 						$rankedIds = json_decode($answer->getText(), true);
-						// Build map: optionId -> rank position (1-based)
-						$rankByOptionId = array_flip($rankedIds);
 						$columns = [];
 						foreach ($rankingOptionsPerQuestionId[$questionId] as $optionId) {
-							$columns[] = isset($rankByOptionId[$optionId]) ? $rankByOptionId[$optionId] + 1 : '';
+							$position = array_search($optionId, $rankedIds);
+							$columns[] = $position !== false ? $position + 1 : '';
 						}
 						$carry[$questionId] = ['columns' => $columns];
 					} else {

--- a/lib/Service/SubmissionService.php
+++ b/lib/Service/SubmissionService.php
@@ -252,6 +252,8 @@ class SubmissionService {
 		$gridRowsPerQuestionId = [];
 		/** @var array<int, array<int, string>> $gridColumnsPerQuestionId */
 		$gridColumnsPerQuestionId = [];
+		/** @var array<int, list<int>> $rankingOptionsPerQuestionId */
+		$rankingOptionsPerQuestionId = [];
 
 		$optionPerOptionId = [];
 		foreach ($questions as $question) {
@@ -279,6 +281,15 @@ class SubmissionService {
 							$header[] = $question->getText() . ' (' . $optionPerOptionId[$rowId]->getText() . ' - ' . $optionPerOptionId[$columnId]->getText() . ')';
 						}
 					}
+				}
+			} elseif ($question->getType() === Constants::ANSWER_TYPE_RANKING) {
+				$options = $this->optionMapper->findByQuestion($question->getId());
+				foreach ($options as $option) {
+					$optionPerOptionId[$option->getId()] = $option;
+					$rankingOptionsPerQuestionId[$question->getId()][] = $option->getId();
+				}
+				foreach ($rankingOptionsPerQuestionId[$question->getId()] as $optionId) {
+					$header[] = $question->getText() . ' (' . $optionPerOptionId[$optionId]->getText() . ')';
 				}
 			} else {
 				$header[] = $question->getText();
@@ -311,7 +322,7 @@ class SubmissionService {
 
 			// Answers, make sure we keep the question order
 			$answers = array_reduce($this->answerMapper->findBySubmission($submission->getId()),
-				function (array $carry, Answer $answer) use ($questionPerQuestionId, $gridRowsPerQuestionId, $gridColumnsPerQuestionId, $optionPerOptionId) {
+				function (array $carry, Answer $answer) use ($questionPerQuestionId, $gridRowsPerQuestionId, $gridColumnsPerQuestionId, $rankingOptionsPerQuestionId, $optionPerOptionId) {
 					$questionId = $answer->getQuestionId();
 					$questionType = isset($questionPerQuestionId[$questionId]) ? $questionPerQuestionId[$questionId]->getType() : null;
 
@@ -352,6 +363,15 @@ class SubmissionService {
 									$columns[] = $answerText[$row][$column];
 								}
 							}
+						}
+						$carry[$questionId] = ['columns' => $columns];
+					} elseif ($questionType === Constants::ANSWER_TYPE_RANKING) {
+						$rankedIds = json_decode($answer->getText(), true);
+						// Build map: optionId -> rank position (1-based)
+						$rankByOptionId = array_flip($rankedIds);
+						$columns = [];
+						foreach ($rankingOptionsPerQuestionId[$questionId] as $optionId) {
+							$columns[] = isset($rankByOptionId[$optionId]) ? $rankByOptionId[$optionId] + 1 : '';
 						}
 						$carry[$questionId] = ['columns' => $columns];
 					} else {
@@ -510,6 +530,7 @@ class SubmissionService {
 			} elseif ($answersCount > 1
 						&& $question['type'] !== Constants::ANSWER_TYPE_FILE
 						&& $question['type'] !== Constants::ANSWER_TYPE_GRID
+						&& $question['type'] !== Constants::ANSWER_TYPE_RANKING
 						&& !($question['type'] === Constants::ANSWER_TYPE_DATE && isset($question['extraSettings']['dateRange'])
 						|| $question['type'] === Constants::ANSWER_TYPE_TIME && isset($question['extraSettings']['timeRange']))) {
 				// Check if non-multiple questions have not more than one answer
@@ -559,6 +580,19 @@ class SubmissionService {
 			// Handle custom validation of short answers
 			if ($question['type'] === Constants::ANSWER_TYPE_SHORT && !$this->validateShortQuestion($question, $answers[$questionId][0])) {
 				throw new \InvalidArgumentException(sprintf('Invalid input for question "%s".', $question['text']));
+			}
+
+			// Handle ranking questions: answers must be a permutation of all option IDs
+			if ($question['type'] === Constants::ANSWER_TYPE_RANKING) {
+				$optionIds = array_map('intval', array_column($question['options'] ?? [], 'id'));
+				$rankedIds = array_map('intval', $answers[$questionId]);
+				$sortedRanked = $rankedIds;
+				$sortedOptions = $optionIds;
+				sort($sortedRanked);
+				sort($sortedOptions);
+				if ($sortedRanked !== $sortedOptions) {
+					throw new \InvalidArgumentException(sprintf('Ranking for question "%s" must include all options exactly once.', $question['text']));
+				}
 			}
 
 			// Handle color questions

--- a/src/components/Questions/Question.vue
+++ b/src/components/Questions/Question.vue
@@ -82,7 +82,7 @@
 					forceMenu
 					placement="bottom-end"
 					class="question__header__title__menu">
-					<template v-if="isRequired && allowRequired" #icon>
+					<template v-if="isRequired" #icon>
 						<IconOverlay>
 							<template #overlay>
 								<IconAsterisk :size="20" />
@@ -91,7 +91,6 @@
 						</IconOverlay>
 					</template>
 					<NcActionCheckbox
-						v-if="allowRequired"
 						:modelValue="isRequired"
 						@update:modelValue="onRequiredChange">
 						<!-- TRANSLATORS Making this question necessary to be answered when submitting to a form -->
@@ -240,11 +239,6 @@ export default {
 		name: {
 			type: String,
 			default: '',
-		},
-
-		allowRequired: {
-			type: Boolean,
-			default: true,
 		},
 
 		contentValid: {

--- a/src/components/Questions/Question.vue
+++ b/src/components/Questions/Question.vue
@@ -82,7 +82,7 @@
 					forceMenu
 					placement="bottom-end"
 					class="question__header__title__menu">
-					<template v-if="isRequired" #icon>
+					<template v-if="isRequired && allowRequired" #icon>
 						<IconOverlay>
 							<template #overlay>
 								<IconAsterisk :size="20" />
@@ -91,6 +91,7 @@
 						</IconOverlay>
 					</template>
 					<NcActionCheckbox
+						v-if="allowRequired"
 						:modelValue="isRequired"
 						@update:modelValue="onRequiredChange">
 						<!-- TRANSLATORS Making this question necessary to be answered when submitting to a form -->
@@ -239,6 +240,11 @@ export default {
 		name: {
 			type: String,
 			default: '',
+		},
+
+		allowRequired: {
+			type: Boolean,
+			default: true,
 		},
 
 		contentValid: {

--- a/src/components/Questions/QuestionRanking.vue
+++ b/src/components/Questions/QuestionRanking.vue
@@ -10,7 +10,6 @@
 		:warningInvalid="answerType.warningInvalid"
 		:contentValid="contentValid"
 		:shiftDragHandle="shiftDragHandle"
-		:allowRequired="false"
 		v-on="commonListeners">
 		<template #actions>
 			<NcActionCheckbox
@@ -26,13 +25,38 @@
 			</NcActionButton>
 		</template>
 
-		<!-- Submit mode: drag to rank -->
+		<!-- Submit mode -->
 		<div
 			v-if="readOnly"
 			class="question__content"
 			role="list"
 			:aria-labelledby="titleId"
 			:aria-describedby="description ? descriptionId : undefined">
+			<!-- Unranked pool (visible when items remain) -->
+			<div v-if="unrankedOptions.length > 0" class="ranking-unranked">
+				<p class="ranking-unranked__label">
+					{{ t('forms', 'Tap to rank') }}
+				</p>
+				<button
+					v-for="option in unrankedOptions"
+					:key="option.id"
+					class="ranking-unranked__item"
+					@click="rankOption(option)">
+					{{ option.text }}
+				</button>
+			</div>
+
+			<!-- Empty state when nothing ranked yet -->
+			<p v-if="rankedOptions.length === 0" class="ranking-empty">
+				{{ t('forms', 'Tap items above to rank them') }}
+			</p>
+
+			<!-- Ranked list header (to separate from pool) -->
+			<p v-if="rankedOptions.length > 0" class="ranking-ranked__label">
+				{{ t('forms', 'Your ranking') }}
+			</p>
+
+			<!-- Ranked list -->
 			<Draggable
 				v-model="rankedOptions"
 				:animation="200"
@@ -49,6 +73,14 @@
 						<IconDragHorizontalVariant :size="20" />
 					</span>
 					<span class="ranking-item__text">{{ option.text }}</span>
+					<NcButton
+						variant="tertiary"
+						:ariaLabel="t('forms', 'Remove from ranking')"
+						@click="unrankOption(option)">
+						<template #icon>
+							<IconClose :size="20" />
+						</template>
+					</NcButton>
 				</div>
 			</Draggable>
 		</div>
@@ -107,7 +139,9 @@
 import { VueDraggable as Draggable } from 'vue-draggable-plus'
 import NcActionButton from '@nextcloud/vue/components/NcActionButton'
 import NcActionCheckbox from '@nextcloud/vue/components/NcActionCheckbox'
+import NcButton from '@nextcloud/vue/components/NcButton'
 import NcLoadingIcon from '@nextcloud/vue/components/NcLoadingIcon'
+import IconClose from 'vue-material-design-icons/Close.vue'
 import IconContentPaste from 'vue-material-design-icons/ContentPaste.vue'
 import IconDragHorizontalVariant from 'vue-material-design-icons/DragHorizontalVariant.vue'
 import OptionInputDialog from '../OptionInputDialog.vue'
@@ -123,10 +157,12 @@ export default {
 	components: {
 		AnswerInput,
 		Draggable,
+		IconClose,
 		IconContentPaste,
 		IconDragHorizontalVariant,
 		NcActionButton,
 		NcActionCheckbox,
+		NcButton,
 		NcLoadingIcon,
 		OptionInputDialog,
 		Question,
@@ -141,6 +177,7 @@ export default {
 			isLoading: false,
 			isOptionDialogShown: false,
 			rankedOptions: [],
+			unrankedOptions: [],
 			OptionType,
 		}
 	},
@@ -176,7 +213,7 @@ export default {
 
 	methods: {
 		/**
-		 * Initialize ranked options from existing values or default order
+		 * Initialize ranked/unranked options from existing values or default order
 		 */
 		initRankedOptions() {
 			const sorted = this.sortOptionsOfType(this.options, OptionType.Choice)
@@ -187,28 +224,64 @@ export default {
 				this.rankedOptions = this.values
 					.map((id) => byId[parseInt(id)])
 					.filter(Boolean)
+				this.unrankedOptions = sorted.filter(
+					(o) => !this.rankedOptions.some((r) => r.id === o.id),
+				)
+			} else if (this.readOnly) {
+				// Submit mode: start with all options unranked
+				this.rankedOptions = []
+				this.unrankedOptions = [...sorted]
 			} else {
+				// Edit mode: show all options in default order
 				this.rankedOptions = [...sorted]
+				this.unrankedOptions = []
 			}
+		},
 
-			// In submit mode, emit the initial ranking so the answer is always
-			// recorded – even when the user agrees with the default order.
-			if (this.readOnly && this.rankedOptions.length > 0) {
+		/**
+		 * Move an option from the unranked pool to the ranked list
+		 *
+		 * @param {object} option The option to rank
+		 */
+		rankOption(option) {
+			this.unrankedOptions = this.unrankedOptions.filter(
+				(o) => o.id !== option.id,
+			)
+			this.rankedOptions.push(option)
+			this.emitValues()
+		},
+
+		/**
+		 * Move an option from the ranked list back to the unranked pool
+		 *
+		 * @param {object} option The option to unrank
+		 */
+		unrankOption(option) {
+			this.rankedOptions = this.rankedOptions.filter((o) => o.id !== option.id)
+			this.unrankedOptions.push(option)
+			this.emitValues()
+		},
+
+		/**
+		 * Emit the current ranking after a drag reorder
+		 */
+		onRankingEnd() {
+			this.emitValues()
+		},
+
+		/**
+		 * Emit the current values based on ranking state
+		 */
+		emitValues() {
+			if (this.rankedOptions.length === 0) {
+				// Nothing ranked — emit empty to signal unanswered
+				this.$emit('update:values', [])
+			} else {
 				this.$emit(
 					'update:values',
 					this.rankedOptions.map((o) => o.id),
 				)
 			}
-		},
-
-		/**
-		 * Emit the new ranking after a drag ends
-		 */
-		onRankingEnd() {
-			this.$emit(
-				'update:values',
-				this.rankedOptions.map((o) => o.id),
-			)
 		},
 	},
 }
@@ -219,6 +292,47 @@ export default {
 	display: flex;
 	flex-direction: column;
 	gap: var(--default-grid-baseline);
+}
+
+.ranking-unranked {
+	margin-block-end: 12px;
+
+	&__label {
+		font-weight: bold;
+		color: var(--color-text-maxcontrast);
+		margin-block-end: 8px;
+	}
+
+	&__item {
+		display: inline-block;
+		padding: 8px 16px;
+		margin: 0 8px 8px 0;
+		background-color: var(--color-background-dark);
+		border: 1px solid var(--color-border);
+		border-radius: var(--border-radius-large);
+		cursor: pointer;
+		font-size: inherit;
+		color: var(--color-main-text);
+		transition: background-color var(--animation-quick);
+
+		&:hover,
+		&:focus-visible {
+			background-color: var(--color-background-hover);
+			border-color: var(--color-primary-element);
+		}
+	}
+}
+
+.ranking-empty {
+	color: var(--color-text-maxcontrast);
+	font-style: italic;
+	padding: 12px 0;
+}
+
+.ranking-ranked__label {
+	font-weight: bold;
+	color: var(--color-text-maxcontrast);
+	margin-block-end: 4px;
 }
 
 .ranking-item {

--- a/src/components/Questions/QuestionRanking.vue
+++ b/src/components/Questions/QuestionRanking.vue
@@ -10,6 +10,7 @@
 		:warningInvalid="answerType.warningInvalid"
 		:contentValid="contentValid"
 		:shiftDragHandle="shiftDragHandle"
+		:allowRequired="false"
 		v-on="commonListeners">
 		<template #actions>
 			<NcActionCheckbox
@@ -188,6 +189,15 @@ export default {
 					.filter(Boolean)
 			} else {
 				this.rankedOptions = [...sorted]
+			}
+
+			// In submit mode, emit the initial ranking so the answer is always
+			// recorded – even when the user agrees with the default order.
+			if (this.readOnly && this.rankedOptions.length > 0) {
+				this.$emit(
+					'update:values',
+					this.rankedOptions.map((o) => o.id),
+				)
 			}
 		},
 

--- a/src/components/Questions/QuestionRanking.vue
+++ b/src/components/Questions/QuestionRanking.vue
@@ -157,6 +157,7 @@ export default {
 			get() {
 				return this.sortOptionsOfType(this.options, OptionType.Choice)
 			},
+
 			set(value) {
 				this.updateOptionsOrder(value, OptionType.Choice)
 			},

--- a/src/components/Questions/QuestionRanking.vue
+++ b/src/components/Questions/QuestionRanking.vue
@@ -69,18 +69,43 @@
 					class="ranking-item"
 					role="listitem">
 					<span class="ranking-item__position">{{ index + 1 }}.</span>
-					<span class="ranking-item__drag-handle">
-						<IconDragHorizontalVariant :size="20" />
-					</span>
 					<span class="ranking-item__text">{{ option.text }}</span>
-					<NcButton
-						variant="tertiary"
-						:ariaLabel="t('forms', 'Remove from ranking')"
-						@click="unrankOption(option)">
-						<template #icon>
-							<IconClose :size="20" />
-						</template>
-					</NcButton>
+					<div class="ranking-item__actions">
+						<NcActions
+							:aria-label="t('forms', 'Move option actions')"
+							class="ranking-item__drag-handle"
+							variant="tertiary-no-background">
+							<template #icon>
+								<IconDragIndicator :size="20" />
+							</template>
+							<NcActionButton
+								ref="buttonOptionUp"
+								:disabled="index === 0"
+								@click="onMoveUp(index)">
+								<template #icon>
+									<IconArrowUp :size="20" />
+								</template>
+								{{ t('forms', 'Move option up') }}
+							</NcActionButton>
+							<NcActionButton
+								ref="buttonOptionDown"
+								:disabled="index === rankedOptions.length - 1"
+								@click="onMoveDown(index)">
+								<template #icon>
+									<IconArrowDown :size="20" />
+								</template>
+								{{ t('forms', 'Move option down') }}
+							</NcActionButton>
+						</NcActions>
+						<NcButton
+							variant="tertiary"
+							:ariaLabel="t('forms', 'Remove from ranking')"
+							@click="unrankOption(option)">
+							<template #icon>
+								<IconClose :size="20" />
+							</template>
+						</NcButton>
+					</div>
 				</div>
 			</Draggable>
 		</div>
@@ -139,11 +164,14 @@
 import { VueDraggable as Draggable } from 'vue-draggable-plus'
 import NcActionButton from '@nextcloud/vue/components/NcActionButton'
 import NcActionCheckbox from '@nextcloud/vue/components/NcActionCheckbox'
+import NcActions from '@nextcloud/vue/components/NcActions'
 import NcButton from '@nextcloud/vue/components/NcButton'
 import NcLoadingIcon from '@nextcloud/vue/components/NcLoadingIcon'
+import IconArrowDown from 'vue-material-design-icons/ArrowDown.vue'
+import IconArrowUp from 'vue-material-design-icons/ArrowUp.vue'
 import IconClose from 'vue-material-design-icons/Close.vue'
 import IconContentPaste from 'vue-material-design-icons/ContentPaste.vue'
-import IconDragHorizontalVariant from 'vue-material-design-icons/DragHorizontalVariant.vue'
+import IconDragIndicator from '../Icons/IconDragIndicator.vue'
 import OptionInputDialog from '../OptionInputDialog.vue'
 import AnswerInput from './AnswerInput.vue'
 import Question from './Question.vue'
@@ -157,11 +185,14 @@ export default {
 	components: {
 		AnswerInput,
 		Draggable,
+		IconArrowDown,
+		IconArrowUp,
 		IconClose,
 		IconContentPaste,
-		IconDragHorizontalVariant,
+		IconDragIndicator,
 		NcActionButton,
 		NcActionCheckbox,
+		NcActions,
 		NcButton,
 		NcLoadingIcon,
 		OptionInputDialog,
@@ -263,6 +294,32 @@ export default {
 		},
 
 		/**
+		 * Move the ranked option at index up by one position
+		 *
+		 * @param {number} index Current index
+		 */
+		onMoveUp(index) {
+			if (index <= 0) return
+			const items = [...this.rankedOptions]
+			;[items[index - 1], items[index]] = [items[index], items[index - 1]]
+			this.rankedOptions = items
+			this.emitValues()
+		},
+
+		/**
+		 * Move the ranked option at index down by one position
+		 *
+		 * @param {number} index Current index
+		 */
+		onMoveDown(index) {
+			if (index >= this.rankedOptions.length - 1) return
+			const items = [...this.rankedOptions]
+			;[items[index], items[index + 1]] = [items[index + 1], items[index]]
+			this.rankedOptions = items
+			this.emitValues()
+		},
+
+		/**
 		 * Emit the current ranking after a drag reorder
 		 */
 		onRankingEnd() {
@@ -353,18 +410,29 @@ export default {
 		color: var(--color-text-maxcontrast);
 	}
 
-	&__drag-handle {
+	&__text {
+		flex: 1;
+	}
+
+	&__actions {
 		display: flex;
-		align-items: center;
+		gap: var(--default-grid-baseline);
+		margin-inline-start: auto;
+	}
+
+	&__drag-handle {
+		color: var(--color-text-maxcontrast);
 		cursor: grab;
+
+		&:hover,
+		&:focus,
+		&:focus-within {
+			color: var(--color-main-text);
+		}
 
 		&:active {
 			cursor: grabbing;
 		}
-	}
-
-	&__text {
-		flex: 1;
 	}
 }
 

--- a/src/components/Questions/QuestionRanking.vue
+++ b/src/components/Questions/QuestionRanking.vue
@@ -1,0 +1,261 @@
+<!--
+  - SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+  - SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
+<template>
+	<Question
+		v-bind="questionProps"
+		:titlePlaceholder="answerType.titlePlaceholder"
+		:warningInvalid="answerType.warningInvalid"
+		:contentValid="contentValid"
+		:shiftDragHandle="shiftDragHandle"
+		v-on="commonListeners">
+		<template #actions>
+			<NcActionCheckbox
+				:modelValue="extraSettings?.shuffleOptions"
+				@update:modelValue="onShuffleOptionsChange">
+				{{ t('forms', 'Shuffle options') }}
+			</NcActionCheckbox>
+			<NcActionButton closeAfterClick @click="isOptionDialogShown = true">
+				<template #icon>
+					<IconContentPaste :size="20" />
+				</template>
+				{{ t('forms', 'Add multiple options') }}
+			</NcActionButton>
+		</template>
+
+		<!-- Submit mode: drag to rank -->
+		<div
+			v-if="readOnly"
+			class="question__content"
+			role="list"
+			:aria-labelledby="titleId"
+			:aria-describedby="description ? descriptionId : undefined">
+			<Draggable
+				v-model="rankedOptions"
+				:animation="200"
+				direction="vertical"
+				handle=".ranking-item__drag-handle"
+				@end="onRankingEnd">
+				<div
+					v-for="(option, index) in rankedOptions"
+					:key="option.id"
+					class="ranking-item"
+					role="listitem">
+					<span class="ranking-item__position">{{ index + 1 }}.</span>
+					<span class="ranking-item__drag-handle">
+						<IconDragHorizontalVariant :size="20" />
+					</span>
+					<span class="ranking-item__text">{{ option.text }}</span>
+				</div>
+			</Draggable>
+		</div>
+
+		<!-- Edit mode: manage options -->
+		<template v-else>
+			<div v-if="isLoading">
+				<NcLoadingIcon :size="64" />
+			</div>
+			<Draggable
+				v-else
+				v-model="choices"
+				class="question__content"
+				:animation="200"
+				direction="vertical"
+				handle=".option__drag-handle"
+				invertSwap
+				tag="transition-group"
+				:componentData="{
+					name: isDragging
+						? 'no-external-transition-on-drag'
+						: 'options-list-transition',
+				}"
+				@change="saveOptionsOrder('choice')"
+				@start="isDragging = true"
+				@end="isDragging = false">
+				<AnswerInput
+					v-for="(answer, index) in choices"
+					:key="answer.local ? 'option-local' : answer.id"
+					ref="input"
+					:answer="answer"
+					:formId="formId"
+					:index="index"
+					:isUnique="true"
+					:maxIndex="options.length - 1"
+					:maxOptionLength="maxStringLengths.optionText"
+					optionType="choice"
+					@createAnswer="onCreateAnswer"
+					@update:answer="updateAnswer"
+					@delete="deleteOption"
+					@focusNext="focusNextInput"
+					@moveUp="onOptionMoveUp(index, OptionType.Choice)"
+					@moveDown="onOptionMoveDown(index, OptionType.Choice)"
+					@tabbedOut="checkValidOption" />
+			</Draggable>
+		</template>
+
+		<!-- Add multiple options modal -->
+		<OptionInputDialog
+			v-model:open="isOptionDialogShown"
+			@multipleAnswers="handleMultipleOptions" />
+	</Question>
+</template>
+
+<script>
+import { VueDraggable as Draggable } from 'vue-draggable-plus'
+import NcActionButton from '@nextcloud/vue/components/NcActionButton'
+import NcActionCheckbox from '@nextcloud/vue/components/NcActionCheckbox'
+import NcLoadingIcon from '@nextcloud/vue/components/NcLoadingIcon'
+import IconContentPaste from 'vue-material-design-icons/ContentPaste.vue'
+import IconDragHorizontalVariant from 'vue-material-design-icons/DragHorizontalVariant.vue'
+import OptionInputDialog from '../OptionInputDialog.vue'
+import AnswerInput from './AnswerInput.vue'
+import Question from './Question.vue'
+import QuestionMixin from '../../mixins/QuestionMixin.js'
+import QuestionMultipleMixin from '../../mixins/QuestionMultipleMixin.ts'
+import { OptionType } from '../../models/Constants.ts'
+
+export default {
+	name: 'QuestionRanking',
+
+	components: {
+		AnswerInput,
+		Draggable,
+		IconContentPaste,
+		IconDragHorizontalVariant,
+		NcActionButton,
+		NcActionCheckbox,
+		NcLoadingIcon,
+		OptionInputDialog,
+		Question,
+	},
+
+	mixins: [QuestionMixin, QuestionMultipleMixin],
+	emits: ['update:values'],
+
+	data() {
+		return {
+			isDragging: false,
+			isLoading: false,
+			isOptionDialogShown: false,
+			rankedOptions: [],
+			OptionType,
+		}
+	},
+
+	computed: {
+		contentValid() {
+			return this.answerType.validate(this)
+		},
+
+		shiftDragHandle() {
+			return !this.readOnly && this.options.length !== 0 && !this.isLastEmpty
+		},
+
+		choices: {
+			get() {
+				return this.sortOptionsOfType(this.options, OptionType.Choice)
+			},
+			set(value) {
+				this.updateOptionsOrder(value, OptionType.Choice)
+			},
+		},
+	},
+
+	watch: {
+		options: {
+			immediate: true,
+			handler() {
+				this.initRankedOptions()
+			},
+		},
+	},
+
+	methods: {
+		/**
+		 * Initialize ranked options from existing values or default order
+		 */
+		initRankedOptions() {
+			const sorted = this.sortOptionsOfType(this.options, OptionType.Choice)
+
+			if (this.values && this.values.length > 0) {
+				// Restore order from saved values (array of option IDs)
+				const byId = Object.fromEntries(sorted.map((o) => [o.id, o]))
+				this.rankedOptions = this.values
+					.map((id) => byId[parseInt(id)])
+					.filter(Boolean)
+			} else {
+				this.rankedOptions = [...sorted]
+			}
+		},
+
+		/**
+		 * Emit the new ranking after a drag ends
+		 */
+		onRankingEnd() {
+			this.$emit(
+				'update:values',
+				this.rankedOptions.map((o) => o.id),
+			)
+		},
+	},
+}
+</script>
+
+<style lang="scss" scoped>
+.question__content {
+	display: flex;
+	flex-direction: column;
+	gap: var(--default-grid-baseline);
+}
+
+.ranking-item {
+	display: flex;
+	align-items: center;
+	gap: 12px;
+	padding: 12px 16px;
+	min-height: 44px;
+	margin-block-end: 8px;
+	background-color: var(--color-background-dark);
+	border-radius: var(--border-radius-large);
+	user-select: none;
+
+	&__position {
+		font-weight: bold;
+		min-width: 1.5em;
+		text-align: end;
+		color: var(--color-text-maxcontrast);
+	}
+
+	&__drag-handle {
+		display: flex;
+		align-items: center;
+		cursor: grab;
+
+		&:active {
+			cursor: grabbing;
+		}
+	}
+
+	&__text {
+		flex: 1;
+	}
+}
+
+.options-list-transition-move,
+.options-list-transition-enter-active,
+.options-list-transition-leave-active {
+	transition: all var(--animation-slow) ease;
+}
+
+.options-list-transition-enter-from,
+.options-list-transition-leave-to {
+	opacity: 0;
+	transform: translateX(44px);
+}
+
+.options-list-transition-leave-active {
+	position: absolute;
+}
+</style>

--- a/src/components/Results/ResultsSummary.vue
+++ b/src/components/Results/ResultsSummary.vue
@@ -13,33 +13,42 @@
 		</p>
 
 		<!-- Ranking questions: Borda count with average rank -->
-		<div
-			v-if="question.type === 'ranking'"
-			class="question-summary__statistic">
+		<div v-if="question.type === 'ranking'" class="question-summary__statistic">
 			<p class="question-summary__ranking-description">
-				{{ t('forms', 'Ranked by Borda count: each 1st place receives {n} points, 2nd place {n1} points, and so on. Higher score means more preferred.', { n: question.options.length, n1: question.options.length - 1 }) }}
+				{{
+					t(
+						'forms',
+						'Ranked by Borda count: each 1st place receives {n} points, 2nd place {n1} points, and so on. Higher score means more preferred.',
+						{
+							n: question.options.length,
+							n1: question.options.length - 1,
+						},
+					)
+				}}
 			</p>
 			<ol>
-			<li v-for="option in rankingStats" :key="option.id">
-				<label>
-					<span class="question-summary__statistic-score">
-						{{ option.bordaTotal }}
-					</span>
-					<span class="question-summary__statistic-percentage">
-						({{ t('forms', 'avg. rank {average}', { average: option.avgRank }) }}):
-					</span>
-					<span
-						:class="{
-							'question-summary__statistic-text--best': option.best,
-						}">
-						{{ option.text }}
-					</span>
-				</label>
-				<meter
-					min="0"
-					:max="maxBordaScore"
-					:value="option.bordaTotal" />
-			</li>
+				<li v-for="option in rankingStats" :key="option.id">
+					<label>
+						<span class="question-summary__statistic-score">
+							{{ option.bordaTotal }}
+						</span>
+						<span class="question-summary__statistic-percentage">
+							({{
+								t('forms', 'avg. rank {average}', {
+									average: option.avgRank,
+								})
+							}}):
+						</span>
+						<span
+							:class="{
+								'question-summary__statistic-text--best':
+									option.best,
+							}">
+							{{ option.text }}
+						</span>
+					</label>
+					<meter min="0" :max="maxBordaScore" :value="option.bordaTotal" />
+				</li>
 			</ol>
 		</div>
 
@@ -362,10 +371,7 @@ export default {
 			const result = Object.values(stats)
 				.map((s) => ({
 					...s,
-					avgRank:
-						s.count > 0
-							? (s.rankSum / s.count).toFixed(1)
-							: '-',
+					avgRank: s.count > 0 ? (s.rankSum / s.count).toFixed(1) : '-',
 				}))
 				.sort((a, b) => b.bordaTotal - a.bordaTotal)
 

--- a/src/components/Results/ResultsSummary.vue
+++ b/src/components/Results/ResultsSummary.vue
@@ -12,9 +12,40 @@
 			{{ questionTypeLabel }}
 		</p>
 
+		<!-- Ranking questions: Borda count with average rank -->
+		<div
+			v-if="question.type === 'ranking'"
+			class="question-summary__statistic">
+			<p class="question-summary__ranking-description">
+				{{ t('forms', 'Ranked by Borda count: each 1st place receives {n} points, 2nd place {n1} points, and so on. Higher score means more preferred.', { n: question.options.length, n1: question.options.length - 1 }) }}
+			</p>
+			<ol>
+			<li v-for="option in rankingStats" :key="option.id">
+				<label>
+					<span class="question-summary__statistic-score">
+						{{ option.bordaTotal }}
+					</span>
+					<span class="question-summary__statistic-percentage">
+						({{ t('forms', 'avg. rank {average}', { average: option.avgRank }) }}):
+					</span>
+					<span
+						:class="{
+							'question-summary__statistic-text--best': option.best,
+						}">
+						{{ option.text }}
+					</span>
+				</label>
+				<meter
+					min="0"
+					:max="maxBordaScore"
+					:value="option.bordaTotal" />
+			</li>
+			</ol>
+		</div>
+
 		<!-- Answers with countable results for visualization -->
 		<ol
-			v-if="answerTypes[question.type].predefined"
+			v-else-if="answerTypes[question.type].predefined"
 			class="question-summary__statistic">
 			<li v-for="option in questionOptions" :key="option.id">
 				<label :for="`option-${option.questionId}-${option.id}`">
@@ -296,6 +327,64 @@ export default {
 			return questionOptionsStats
 		},
 
+		/**
+		 * Borda count ranking statistics
+		 */
+		rankingStats() {
+			const n = this.question.options.length
+			const stats = {}
+
+			for (const opt of this.question.options) {
+				stats[opt.id] = {
+					id: opt.id,
+					text: opt.text,
+					bordaTotal: 0,
+					rankSum: 0,
+					count: 0,
+				}
+			}
+
+			for (const submission of this.submissions) {
+				const answer = submission.answers.find(
+					(a) => a.questionId === this.question.id,
+				)
+				if (!answer) continue
+				const ranked = JSON.parse(answer.text)
+				ranked.forEach((optionId, index) => {
+					if (stats[optionId]) {
+						stats[optionId].bordaTotal += n - index
+						stats[optionId].rankSum += index + 1
+						stats[optionId].count++
+					}
+				})
+			}
+
+			const result = Object.values(stats)
+				.map((s) => ({
+					...s,
+					avgRank:
+						s.count > 0
+							? (s.rankSum / s.count).toFixed(1)
+							: '-',
+				}))
+				.sort((a, b) => b.bordaTotal - a.bordaTotal)
+
+			// Mark best (highest Borda score)
+			if (result.length > 0 && result[0].bordaTotal > 0) {
+				const best = result[0].bordaTotal
+				result.forEach((o) => {
+					o.best = o.bordaTotal === best
+				})
+			}
+
+			return result
+		},
+
+		maxBordaScore() {
+			const n = this.question.options.length
+			return n * this.submissions.length
+		},
+
 		gridColumns() {
 			return this.question.options.filter(
 				(option) => option.optionType === OptionType.Column,
@@ -535,6 +624,12 @@ export default {
 
 			label {
 				cursor: default;
+			}
+
+			.question-summary__ranking-description {
+				color: var(--color-text-maxcontrast);
+				font-style: italic;
+				margin-block-end: 8px;
 			}
 
 			.question-summary__statistic-text--best {

--- a/src/components/Results/Submission.vue
+++ b/src/components/Results/Submission.vue
@@ -224,6 +224,29 @@ export default {
 						type: question.type,
 						squashedAnswers,
 					})
+				} else if (question.type === 'ranking') {
+					const optionsPerId = {}
+					question.options.forEach((option) => {
+						optionsPerId[option.id] = option
+					})
+					const rankedIds = answers[0]?.text
+						? JSON.parse(answers[0].text)
+						: []
+					const squashedAnswers = rankedIds
+						.map((id, index) => {
+							const option = optionsPerId[id]
+							return option
+								? `${index + 1}. ${option.text}`
+								: `${index + 1}. ?`
+						})
+						.join('\n')
+
+					answeredQuestionsArray.push({
+						id: question.id,
+						text: question.text,
+						type: question.type,
+						squashedAnswers,
+					})
 				} else {
 					const squashedAnswers = answers
 						.map((answer) => answer.text)

--- a/src/models/AnswerTypes.js
+++ b/src/models/AnswerTypes.js
@@ -12,6 +12,7 @@ import IconFile from 'vue-material-design-icons/FileOutline.vue'
 import IconGrid from 'vue-material-design-icons/Grid.vue'
 import IconNumeric from 'vue-material-design-icons/Numeric.vue'
 import IconRadioboxMarked from 'vue-material-design-icons/RadioboxMarked.vue'
+import IconReorderHorizontal from 'vue-material-design-icons/ReorderHorizontal.vue'
 import IconTextLong from 'vue-material-design-icons/TextLong.vue'
 import IconTextShort from 'vue-material-design-icons/TextShort.vue'
 import IconLinearScale from '../components/Icons/IconLinearScale.vue'
@@ -24,6 +25,7 @@ import QuestionGrid from '../components/Questions/QuestionGrid.vue'
 import QuestionLinearScale from '../components/Questions/QuestionLinearScale.vue'
 import QuestionLong from '../components/Questions/QuestionLong.vue'
 import QuestionMultiple from '../components/Questions/QuestionMultiple.vue'
+import QuestionRanking from '../components/Questions/QuestionRanking.vue'
 import QuestionShort from '../components/Questions/QuestionShort.vue'
 import { OptionType } from './Constants.ts'
 
@@ -263,5 +265,21 @@ export default {
 		createPlaceholder: t('forms', 'People can pick a color'),
 		submitPlaceholder: t('forms', 'Pick a color'),
 		warningInvalid: t('forms', 'This question needs a title!'),
+	},
+
+	ranking: {
+		component: markRaw(QuestionRanking),
+		icon: markRaw(IconReorderHorizontal),
+		label: t('forms', 'Ranking'),
+		predefined: true,
+		validate: (question) => question.options.length > 0,
+
+		titlePlaceholder: t('forms', 'Ranking question title'),
+		createPlaceholder: t('forms', 'People can rank options'),
+		submitPlaceholder: t('forms', 'Drag to rank'),
+		warningInvalid: t(
+			'forms',
+			'This question needs a title and at least one answer!',
+		),
 	},
 }

--- a/tests/Unit/Service/SubmissionServiceTest.php
+++ b/tests/Unit/Service/SubmissionServiceTest.php
@@ -573,6 +573,32 @@ file2.txt"
 				"","Anonymous user","1973-11-29T22:33:09+01:00"
 				'
 			],
+			'ranking-submission' => [
+				// Questions
+				[
+					['id' => 1, 'type' => 'ranking', 'text' => 'Rank these', 'options' => [
+						['id' => 10, 'text' => 'Option A'],
+						['id' => 11, 'text' => 'Option B'],
+						['id' => 12, 'text' => 'Option C'],
+					]]
+				],
+				// Array of Submissions incl. Answers
+				[
+					[
+						'id' => 1,
+						'userId' => 'user1',
+						'timestamp' => 123456789,
+						'answers' => [
+							['questionId' => 1, 'text' => '[11,10,12]'],
+						]
+					],
+				],
+				// Expected CSV-Result: one column per option with rank position
+				'
+				"User ID","User display name","Timestamp","Rank these (Option A)","Rank these (Option B)","Rank these (Option C)"
+				"user1","User 1","1973-11-29T22:33:09+01:00","2","1","3"
+				'
+			],
 		];
 	}
 	/**
@@ -1121,6 +1147,11 @@ file2.txt"
 					// time range
 					['id' => 18, 'type' => 'time', 'text' => 'q1', 'isRequired' => true, 'extraSettings' => ['timeRange' => true]],
 					['id' => 19, 'type' => 'color', 'isRequired' => false],
+					['id' => 20, 'type' => 'ranking', 'text' => 'Rank these', 'isRequired' => false, 'options' => [
+						['id' => 30],
+						['id' => 31],
+						['id' => 32]
+					]],
 				],
 				// Answers
 				[
@@ -1144,10 +1175,73 @@ file2.txt"
 					// valid time range
 					'18' => ['12:33', '12:34'],
 					'19' => ['#FF0000'],
+					'20' => [31, 30, 32],
 				],
 				// Expected Result
 				null,
-			]
+			],
+			'valid-ranking-submission' => [
+				// Questions
+				[
+					['id' => 1, 'type' => 'ranking', 'text' => 'Rank these', 'isRequired' => false, 'options' => [
+						['id' => 10],
+						['id' => 11],
+						['id' => 12]
+					]]
+				],
+				// Answers
+				[
+					'1' => [12, 10, 11]
+				],
+				// Expected Result
+				null,
+			],
+			'invalid-ranking-missing-option' => [
+				// Questions
+				[
+					['id' => 1, 'type' => 'ranking', 'text' => 'Rank these', 'isRequired' => false, 'options' => [
+						['id' => 10],
+						['id' => 11],
+						['id' => 12]
+					]]
+				],
+				// Answers
+				[
+					'1' => [10, 11]
+				],
+				// Expected Result
+				'Ranking for question "Rank these" must include all options exactly once.',
+			],
+			'invalid-ranking-unknown-option' => [
+				// Questions
+				[
+					['id' => 1, 'type' => 'ranking', 'text' => 'Rank these', 'isRequired' => false, 'options' => [
+						['id' => 10],
+						['id' => 11]
+					]]
+				],
+				// Answers
+				[
+					'1' => [10, 99]
+				],
+				// Expected Result – caught by generic predefined-options check before ranking check
+				'Answer "99" for question "Rank these" is not a valid option.',
+			],
+			'invalid-ranking-duplicate-option' => [
+				// Questions
+				[
+					['id' => 1, 'type' => 'ranking', 'text' => 'Rank these', 'isRequired' => false, 'options' => [
+						['id' => 10],
+						['id' => 11]
+					]]
+				],
+				// Answers
+				[
+					'1' => [10, 10]
+				],
+				// Expected Result
+				'Ranking for question "Rank these" must include all options exactly once.',
+			],
 		];
 	}
 

--- a/tests/Unit/Service/SubmissionServiceTest.php
+++ b/tests/Unit/Service/SubmissionServiceTest.php
@@ -599,6 +599,29 @@ file2.txt"
 				"user1","User 1","1973-11-29T22:33:09+01:00","2","1","3"
 				'
 			],
+			'ranking-unanswered' => [
+				// Questions
+				[
+					['id' => 1, 'type' => 'ranking', 'text' => 'Rank these', 'options' => [
+						['id' => 10, 'text' => 'Option A'],
+						['id' => 11, 'text' => 'Option B'],
+					]]
+				],
+				// Submission with no ranking answer
+				[
+					[
+						'id' => 1,
+						'userId' => 'user1',
+						'timestamp' => 123456789,
+						'answers' => [],
+					],
+				],
+				// Expected CSV-Result: columns exist but values are empty
+				'
+				"User ID","User display name","Timestamp","Rank these (Option A)","Rank these (Option B)"
+				"user1","User 1","1973-11-29T22:33:09+01:00","",""
+				'
+			],
 		];
 	}
 	/**
@@ -1241,6 +1264,34 @@ file2.txt"
 				],
 				// Expected Result
 				'Ranking for question "Rank these" must include all options exactly once.',
+			],
+			'valid-ranking-not-required-unanswered' => [
+				// Questions
+				[
+					['id' => 1, 'type' => 'ranking', 'text' => 'Rank these', 'isRequired' => false, 'options' => [
+						['id' => 10],
+						['id' => 11],
+						['id' => 12]
+					]]
+				],
+				// Answers – user did not rank anything
+				[],
+				// Expected Result – no error
+				null,
+			],
+			'invalid-ranking-required-unanswered' => [
+				// Questions
+				[
+					['id' => 1, 'type' => 'ranking', 'text' => 'Rank these', 'isRequired' => true, 'options' => [
+						['id' => 10],
+						['id' => 11],
+						['id' => 12]
+					]]
+				],
+				// Answers – user did not rank anything
+				[],
+				// Expected Result – required question must be answered
+				'Question "Rank these" is required.',
 			],
 		];
 	}


### PR DESCRIPTION
As proposed in #1278: Add Ranking question type

Refactored to Vue3, after closing: #3247

This adds a new question type that lets respondents rank options by dragging them into order.

Results are scored using Borda count — first place gets the most points, last place gets the least. The summary shows each option's total score and average rank with a visual bar, along with a short explanation of how scoring works.

For export, ranking questions get one column per option (like grid questions do), with the rank number as the value. Answers are stored as a JSON array of option IDs, which keeps things consistent with how grid answers are stored.

There's also an optional shuffle setting. 

Again disclaimer: heavy use of genAI, I did try to check the code to the best of my abilities and ran it on nextcloud-docker-dev to actually interact with it and export data. 