### PR TITLE
feat(forms): add submission notification emails with external recipients and PDF attachments

### DIFF
--- a/docs/API_v3.md
+++ b/docs/API_v3.md
@@ -170,6 +170,7 @@ Returns the full-depth object of the requested form (without submissions).
   "isAnonymous": false,
   "submitMultiple": true,
   "allowEditSubmissions": false,
+  "notifyOwnerOnSubmission": false,
   "showExpiration": false,
   "canSubmit": true,
   "state": 0,
@@ -275,6 +276,7 @@ Update a single or multiple properties of a form-object. Concerns **only** the F
     - To transfer the ownership of a form to another user, you must only send a single _keyValuePair_ containing the key `ownerId` and the user id of the new owner.
     - To link a file for submissions, the _keyValuePairs_ need to contain the keys `path` and `fileFormat`
     - To unlink a file for submissions, the _keyValuePairs_ need to contain the keys `fileId` and `fileFormat` need to contain the value `null`
+    - `notifyOwnerOnSubmission` must be a boolean.
 - Response: **Status-Code OK**, as well as the id of the updated form.
 
 ```

--- a/docs/API_v3.md
+++ b/docs/API_v3.md
@@ -171,6 +171,7 @@ Returns the full-depth object of the requested form (without submissions).
   "submitMultiple": true,
   "allowEditSubmissions": false,
   "notifyOwnerOnSubmission": false,
+  "attachSubmissionPdf": false,
   "notificationRecipients": ["team@example.com"],
   "showExpiration": false,
   "canSubmit": true,
@@ -278,6 +279,7 @@ Update a single or multiple properties of a form-object. Concerns **only** the F
     - To link a file for submissions, the _keyValuePairs_ need to contain the keys `path` and `fileFormat`
     - To unlink a file for submissions, the _keyValuePairs_ need to contain the keys `fileId` and `fileFormat` need to contain the value `null`
     - `notifyOwnerOnSubmission` must be a boolean.
+    - `attachSubmissionPdf` must be a boolean.
     - `notificationRecipients` must be an array of valid email addresses.
 - Response: **Status-Code OK**, as well as the id of the updated form.
 

--- a/docs/API_v3.md
+++ b/docs/API_v3.md
@@ -171,6 +171,7 @@ Returns the full-depth object of the requested form (without submissions).
   "submitMultiple": true,
   "allowEditSubmissions": false,
   "notifyOwnerOnSubmission": false,
+  "notificationRecipients": ["team@example.com"],
   "showExpiration": false,
   "canSubmit": true,
   "state": 0,
@@ -277,6 +278,7 @@ Update a single or multiple properties of a form-object. Concerns **only** the F
     - To link a file for submissions, the _keyValuePairs_ need to contain the keys `path` and `fileFormat`
     - To unlink a file for submissions, the _keyValuePairs_ need to contain the keys `fileId` and `fileFormat` need to contain the value `null`
     - `notifyOwnerOnSubmission` must be a boolean.
+    - `notificationRecipients` must be an array of valid email addresses.
 - Response: **Status-Code OK**, as well as the id of the updated form.
 
 ```

--- a/docs/DataStructure.md
+++ b/docs/DataStructure.md
@@ -22,6 +22,7 @@ This document describes the Object-Structure, that is used within the Forms App 
 | ownerId              | String                               |                                         | The nextcloud userId of the form owner                                                                                           |
 | submissionMessage    | String                               | max. 2048 ch.                           | Optional custom message, with Markdown support, to be shown to users when the form is submitted (default is used if set to null) |
 | notifyOwnerOnSubmission | Boolean                           |                                         | If the form owner should receive an email notification with a response summary for each new submission                           |
+| notificationRecipients | Array of Strings                   |                                         | Additional email recipients to notify for each new submission, independent of `notifyOwnerOnSubmission`                         |
 | created              | unix timestamp                       |                                         | When the form has been created                                                                                                   |
 | access               | [Access-Object](#access-object)      |                                         | Describing access-settings of the form                                                                                           |
 | expires              | unix-timestamp                       |                                         | When the form should expire. Timestamp `0` indicates _never_                                                                     |
@@ -68,7 +69,8 @@ This document describes the Object-Structure, that is used within the Forms App 
   "submissions": [],
   "submissionCount": 0,
   "submissionMessage": "string",
-  "notifyOwnerOnSubmission": false
+  "notifyOwnerOnSubmission": false,
+  "notificationRecipients": ["team@example.com"]
 }
 ```
 

--- a/docs/DataStructure.md
+++ b/docs/DataStructure.md
@@ -21,6 +21,7 @@ This document describes the Object-Structure, that is used within the Forms App 
 | description          | String                               | max. 8192 ch.                           | The Form description                                                                                                             |
 | ownerId              | String                               |                                         | The nextcloud userId of the form owner                                                                                           |
 | submissionMessage    | String                               | max. 2048 ch.                           | Optional custom message, with Markdown support, to be shown to users when the form is submitted (default is used if set to null) |
+| notifyOwnerOnSubmission | Boolean                           |                                         | If the form owner should receive an email notification with a response summary for each new submission                           |
 | created              | unix timestamp                       |                                         | When the form has been created                                                                                                   |
 | access               | [Access-Object](#access-object)      |                                         | Describing access-settings of the form                                                                                           |
 | expires              | unix-timestamp                       |                                         | When the form should expire. Timestamp `0` indicates _never_                                                                     |
@@ -66,7 +67,8 @@ This document describes the Object-Structure, that is used within the Forms App 
   "shares": []
   "submissions": [],
   "submissionCount": 0,
-  "submissionMessage": "string"
+  "submissionMessage": "string",
+  "notifyOwnerOnSubmission": false
 }
 ```
 

--- a/docs/DataStructure.md
+++ b/docs/DataStructure.md
@@ -22,6 +22,7 @@ This document describes the Object-Structure, that is used within the Forms App 
 | ownerId              | String                               |                                         | The nextcloud userId of the form owner                                                                                           |
 | submissionMessage    | String                               | max. 2048 ch.                           | Optional custom message, with Markdown support, to be shown to users when the form is submitted (default is used if set to null) |
 | notifyOwnerOnSubmission | Boolean                           |                                         | If the form owner should receive an email notification with a response summary for each new submission                           |
+| attachSubmissionPdf  | Boolean                              |                                         | If notification emails should include a PDF attachment with the submitted responses                                              |
 | notificationRecipients | Array of Strings                   |                                         | Additional email recipients to notify for each new submission, independent of `notifyOwnerOnSubmission`                         |
 | created              | unix timestamp                       |                                         | When the form has been created                                                                                                   |
 | access               | [Access-Object](#access-object)      |                                         | Describing access-settings of the form                                                                                           |
@@ -70,6 +71,7 @@ This document describes the Object-Structure, that is used within the Forms App 
   "submissionCount": 0,
   "submissionMessage": "string",
   "notifyOwnerOnSubmission": false,
+  "attachSubmissionPdf": false,
   "notificationRecipients": ["team@example.com"]
 }
 ```

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -11,8 +11,10 @@ namespace OCA\Forms\AppInfo;
 
 use OCA\Analytics\Datasource\DatasourceEvent;
 use OCA\Forms\Capabilities;
+use OCA\Forms\Events\FormSubmittedEvent;
 use OCA\Forms\FormsMigrator;
 use OCA\Forms\Listener\AnalyticsDatasourceListener;
+use OCA\Forms\Listener\OwnerNotificationListener;
 use OCA\Forms\Listener\UserDeletedListener;
 use OCA\Forms\Middleware\ThrottleFormAccessMiddleware;
 use OCA\Forms\Search\SearchProvider;
@@ -43,6 +45,7 @@ class Application extends App implements IBootstrap {
 
 		$context->registerCapability(Capabilities::class);
 		$context->registerEventListener(UserDeletedEvent::class, UserDeletedListener::class);
+		$context->registerEventListener(FormSubmittedEvent::class, OwnerNotificationListener::class);
 		$context->registerEventListener(DatasourceEvent::class, AnalyticsDatasourceListener::class);
 		$context->registerMiddleware(ThrottleFormAccessMiddleware::class);
 		$context->registerSearchProvider(SearchProvider::class);

--- a/lib/Controller/ApiController.php
+++ b/lib/Controller/ApiController.php
@@ -22,6 +22,7 @@ use OCA\Forms\Db\Submission;
 use OCA\Forms\Db\SubmissionMapper;
 use OCA\Forms\Db\UploadedFile;
 use OCA\Forms\Db\UploadedFileMapper;
+use OCA\Forms\Events\FormSubmittedEvent;
 use OCA\Forms\Exception\NoSuchFormException;
 use OCA\Forms\ResponseDefinitions;
 use OCA\Forms\Service\ConfigService;
@@ -178,6 +179,8 @@ class ApiController extends OCSController {
 			$form->setShowExpiration(false);
 			$form->setExpires(0);
 			$form->setIsAnonymous(false);
+			$form->setNotifyOwnerOnSubmission(false);
+			$form->setState(Constants::FORM_STATE_ACTIVE);
 
 			$this->formMapper->insert($form);
 		} else {
@@ -206,6 +209,8 @@ class ApiController extends OCSController {
 			$formData['showExpiration'] = false;
 			$formData['expires'] = 0;
 			$formData['isAnonymous'] = false;
+			$formData['notifyOwnerOnSubmission'] = false;
+			$formData['state'] = Constants::FORM_STATE_ACTIVE;
 
 			$form = Form::fromParams($formData);
 			$this->formMapper->insert($form);
@@ -315,6 +320,10 @@ class ApiController extends OCSController {
 
 		// Do not allow changing showToAllUsers or permitAllUsers if disabled
 		$this->checkAccessUpdate($keyValuePairs);
+
+		if (isset($keyValuePairs['notifyOwnerOnSubmission']) && !is_bool($keyValuePairs['notifyOwnerOnSubmission'])) {
+			throw new OCSBadRequestException('notifyOwnerOnSubmission must be a boolean');
+		}
 
 		// Process file linking
 		if (isset($keyValuePairs['path']) && isset($keyValuePairs['fileFormat'])) {
@@ -1405,7 +1414,7 @@ class ApiController extends OCSController {
 		$this->formMapper->update($form);
 
 		//Create Activity
-		$this->formsService->notifyNewSubmission($form, $submission);
+		$this->formsService->notifyNewSubmission($form, $submission, FormSubmittedEvent::TRIGGER_CREATED);
 
 		if ($form->getFileId() !== null) {
 			$this->jobList->add(SyncSubmissionsWithLinkedFileJob::class, ['form_id' => $form->getId()]);
@@ -1487,7 +1496,7 @@ class ApiController extends OCSController {
 		}
 
 		//Create Activity
-		$this->formsService->notifyNewSubmission($form, $submission);
+		$this->formsService->notifyNewSubmission($form, $submission, FormSubmittedEvent::TRIGGER_UPDATED);
 
 		return new DataResponse($submissionId);
 	}

--- a/lib/Controller/ApiController.php
+++ b/lib/Controller/ApiController.php
@@ -53,6 +53,7 @@ use OCP\IRequest;
 use OCP\IUser;
 use OCP\IUserManager;
 use OCP\IUserSession;
+use OCP\Mail\IMailer;
 
 use Psr\Log\LoggerInterface;
 
@@ -69,6 +70,8 @@ use Psr\Log\LoggerInterface;
  * @psalm-import-type FormsUploadedFile from ResponseDefinitions
  */
 class ApiController extends OCSController {
+	private const MAX_NOTIFICATION_RECIPIENTS = 20;
+
 	private ?IUser $currentUser;
 
 	public function __construct(
@@ -91,6 +94,7 @@ class ApiController extends OCSController {
 		private UploadedFileMapper $uploadedFileMapper,
 		private IMimeTypeDetector $mimeTypeDetector,
 		private IJobList $jobList,
+		private IMailer $mailer,
 	) {
 		parent::__construct($appName, $request);
 		$this->currentUser = $userSession->getUser();
@@ -181,6 +185,7 @@ class ApiController extends OCSController {
 			$form->setIsAnonymous(false);
 			$form->setNotifyOwnerOnSubmission(false);
 			$form->setState(Constants::FORM_STATE_ACTIVE);
+			$form->setNotificationRecipients([]);
 
 			$this->formMapper->insert($form);
 		} else {
@@ -211,6 +216,7 @@ class ApiController extends OCSController {
 			$formData['isAnonymous'] = false;
 			$formData['notifyOwnerOnSubmission'] = false;
 			$formData['state'] = Constants::FORM_STATE_ACTIVE;
+			$formData['notificationRecipients'] = [];
 
 			$form = Form::fromParams($formData);
 			$this->formMapper->insert($form);
@@ -323,6 +329,10 @@ class ApiController extends OCSController {
 
 		if (isset($keyValuePairs['notifyOwnerOnSubmission']) && !is_bool($keyValuePairs['notifyOwnerOnSubmission'])) {
 			throw new OCSBadRequestException('notifyOwnerOnSubmission must be a boolean');
+		}
+
+		if (array_key_exists('notificationRecipients', $keyValuePairs)) {
+			$keyValuePairs['notificationRecipients'] = $this->normalizeNotificationRecipients($keyValuePairs['notificationRecipients']);
 		}
 
 		// Process file linking
@@ -1836,6 +1846,42 @@ class ApiController extends OCSController {
 		}
 	}
 
+	/**
+	 * @param mixed $notificationRecipients
+	 * @return list<string>
+	 */
+	private function normalizeNotificationRecipients(mixed $notificationRecipients): array {
+		if (!is_array($notificationRecipients)) {
+			throw new OCSBadRequestException('notificationRecipients must be an array');
+		}
+
+		$normalizedRecipients = [];
+		foreach ($notificationRecipients as $recipient) {
+			if (!is_string($recipient)) {
+				throw new OCSBadRequestException('notificationRecipients must be an array of strings');
+			}
+
+			$trimmedRecipient = trim($recipient);
+			if ($trimmedRecipient === '') {
+				continue;
+			}
+
+			if (!$this->mailer->validateMailAddress($trimmedRecipient)) {
+				throw new OCSBadRequestException('notificationRecipients contains an invalid email address');
+			}
+
+			$recipientKey = strtolower($trimmedRecipient);
+			if (!isset($normalizedRecipients[$recipientKey])) {
+				$normalizedRecipients[$recipientKey] = $trimmedRecipient;
+			}
+		}
+
+		if (count($normalizedRecipients) > self::MAX_NOTIFICATION_RECIPIENTS) {
+			throw new OCSBadRequestException('Too many notificationRecipients');
+		}
+
+		return array_values($normalizedRecipients);
+	}
 	/**
 	 * Checks if the current user is allowed to archive/unarchive the form
 	 */

--- a/lib/Controller/ApiController.php
+++ b/lib/Controller/ApiController.php
@@ -185,6 +185,7 @@ class ApiController extends OCSController {
 			$form->setIsAnonymous(false);
 			$form->setNotifyOwnerOnSubmission(false);
 			$form->setState(Constants::FORM_STATE_ACTIVE);
+			$form->setAttachSubmissionPdf(false);
 			$form->setNotificationRecipients([]);
 
 			$this->formMapper->insert($form);
@@ -216,6 +217,7 @@ class ApiController extends OCSController {
 			$formData['isAnonymous'] = false;
 			$formData['notifyOwnerOnSubmission'] = false;
 			$formData['state'] = Constants::FORM_STATE_ACTIVE;
+			$formData['attachSubmissionPdf'] = false;
 			$formData['notificationRecipients'] = [];
 
 			$form = Form::fromParams($formData);
@@ -329,6 +331,10 @@ class ApiController extends OCSController {
 
 		if (isset($keyValuePairs['notifyOwnerOnSubmission']) && !is_bool($keyValuePairs['notifyOwnerOnSubmission'])) {
 			throw new OCSBadRequestException('notifyOwnerOnSubmission must be a boolean');
+		}
+
+		if (isset($keyValuePairs['attachSubmissionPdf']) && !is_bool($keyValuePairs['attachSubmissionPdf'])) {
+			throw new OCSBadRequestException('attachSubmissionPdf must be a boolean');
 		}
 
 		if (array_key_exists('notificationRecipients', $keyValuePairs)) {

--- a/lib/Db/Form.php
+++ b/lib/Db/Form.php
@@ -43,6 +43,8 @@ use OCP\AppFramework\Db\Entity;
  * @method void setLastUpdated(int $value)
  * @method string|null getSubmissionMessage()
  * @method void setSubmissionMessage(string|null $value)
+ * @method bool getNotifyOwnerOnSubmission()
+ * @method void setNotifyOwnerOnSubmission(bool $value)
  * @method int getState()
  * @psalm-method 0|1|2 getState()
  * @method void setState(int|null $value)
@@ -69,6 +71,7 @@ class Form extends Entity {
 	protected $allowEditSubmissions;
 	protected $showExpiration;
 	protected $submissionMessage;
+	protected $notifyOwnerOnSubmission;
 	protected $lastUpdated;
 	protected $state;
 	protected $lockedBy;
@@ -85,6 +88,7 @@ class Form extends Entity {
 		$this->addType('submitMultiple', 'boolean');
 		$this->addType('allowEditSubmissions', 'boolean');
 		$this->addType('showExpiration', 'boolean');
+		$this->addType('notifyOwnerOnSubmission', 'boolean');
 		$this->addType('lastUpdated', 'integer');
 		$this->addType('state', 'integer');
 		$this->addType('lockedBy', 'string');
@@ -160,6 +164,7 @@ class Form extends Entity {
 	 *   showExpiration: bool,
 	 *   lastUpdated: int,
 	 *   submissionMessage: ?string,
+	 *   notifyOwnerOnSubmission: bool,
 	 *   state: 0|1|2,
 	 *   lockedBy: ?string,
 	 *   lockedUntil: ?int,
@@ -184,6 +189,7 @@ class Form extends Entity {
 			'showExpiration' => (bool)$this->getShowExpiration(),
 			'lastUpdated' => (int)$this->getLastUpdated(),
 			'submissionMessage' => $this->getSubmissionMessage(),
+			'notifyOwnerOnSubmission' => (bool)$this->getNotifyOwnerOnSubmission(),
 			'state' => $this->getState(),
 			'lockedBy' => $this->getLockedBy(),
 			'lockedUntil' => $this->getLockedUntil(),

--- a/lib/Db/Form.php
+++ b/lib/Db/Form.php
@@ -45,6 +45,8 @@ use OCP\AppFramework\Db\Entity;
  * @method void setSubmissionMessage(string|null $value)
  * @method bool getNotifyOwnerOnSubmission()
  * @method void setNotifyOwnerOnSubmission(bool $value)
+ * @method string|null getNotificationRecipientsJson()
+ * @method void setNotificationRecipientsJson(?string $value)
  * @method int getState()
  * @psalm-method 0|1|2 getState()
  * @method void setState(int|null $value)
@@ -72,6 +74,7 @@ class Form extends Entity {
 	protected $showExpiration;
 	protected $submissionMessage;
 	protected $notifyOwnerOnSubmission;
+	protected $notificationRecipientsJson;
 	protected $lastUpdated;
 	protected $state;
 	protected $lockedBy;
@@ -147,6 +150,37 @@ class Form extends Entity {
 	}
 
 	/**
+	 * @return list<string>
+	 */
+	public function getNotificationRecipients(): array {
+		$encodedRecipients = $this->getNotificationRecipientsJson();
+		if ($encodedRecipients === null || $encodedRecipients === '') {
+			return [];
+		}
+
+		$decodedRecipients = json_decode($encodedRecipients, true, 512, JSON_THROW_ON_ERROR);
+		if (!is_array($decodedRecipients)) {
+			return [];
+		}
+
+		return array_values(array_filter(array_map(static fn (mixed $recipient): string => trim((string)$recipient), $decodedRecipients), static fn (string $recipient): bool => $recipient !== ''));
+	}
+
+	/**
+	 * @param list<string> $recipients
+	 */
+	public function setNotificationRecipients(array $recipients): void {
+		$normalizedRecipients = array_values(array_filter(array_map(static fn (string $recipient): string => trim($recipient), $recipients), static fn (string $recipient): bool => $recipient !== ''));
+
+		if ($normalizedRecipients === []) {
+			$this->setNotificationRecipientsJson(null);
+			return;
+		}
+
+		$this->setNotificationRecipientsJson(json_encode($normalizedRecipients, JSON_THROW_ON_ERROR));
+	}
+
+	/**
 	 * @return array{
 	 *   id: int,
 	 *   hash: string,
@@ -165,6 +199,7 @@ class Form extends Entity {
 	 *   lastUpdated: int,
 	 *   submissionMessage: ?string,
 	 *   notifyOwnerOnSubmission: bool,
+	 *   notificationRecipients: list<string>,
 	 *   state: 0|1|2,
 	 *   lockedBy: ?string,
 	 *   lockedUntil: ?int,
@@ -190,6 +225,7 @@ class Form extends Entity {
 			'lastUpdated' => (int)$this->getLastUpdated(),
 			'submissionMessage' => $this->getSubmissionMessage(),
 			'notifyOwnerOnSubmission' => (bool)$this->getNotifyOwnerOnSubmission(),
+			'notificationRecipients' => $this->getNotificationRecipients(),
 			'state' => $this->getState(),
 			'lockedBy' => $this->getLockedBy(),
 			'lockedUntil' => $this->getLockedUntil(),

--- a/lib/Db/Form.php
+++ b/lib/Db/Form.php
@@ -45,6 +45,8 @@ use OCP\AppFramework\Db\Entity;
  * @method void setSubmissionMessage(string|null $value)
  * @method bool getNotifyOwnerOnSubmission()
  * @method void setNotifyOwnerOnSubmission(bool $value)
+ * @method bool getAttachSubmissionPdf()
+ * @method void setAttachSubmissionPdf(bool $value)
  * @method string|null getNotificationRecipientsJson()
  * @method void setNotificationRecipientsJson(?string $value)
  * @method int getState()
@@ -74,6 +76,7 @@ class Form extends Entity {
 	protected $showExpiration;
 	protected $submissionMessage;
 	protected $notifyOwnerOnSubmission;
+	protected $attachSubmissionPdf;
 	protected $notificationRecipientsJson;
 	protected $lastUpdated;
 	protected $state;
@@ -92,6 +95,7 @@ class Form extends Entity {
 		$this->addType('allowEditSubmissions', 'boolean');
 		$this->addType('showExpiration', 'boolean');
 		$this->addType('notifyOwnerOnSubmission', 'boolean');
+		$this->addType('attachSubmissionPdf', 'boolean');
 		$this->addType('lastUpdated', 'integer');
 		$this->addType('state', 'integer');
 		$this->addType('lockedBy', 'string');
@@ -199,6 +203,7 @@ class Form extends Entity {
 	 *   lastUpdated: int,
 	 *   submissionMessage: ?string,
 	 *   notifyOwnerOnSubmission: bool,
+	 *   attachSubmissionPdf: bool,
 	 *   notificationRecipients: list<string>,
 	 *   state: 0|1|2,
 	 *   lockedBy: ?string,
@@ -225,6 +230,7 @@ class Form extends Entity {
 			'lastUpdated' => (int)$this->getLastUpdated(),
 			'submissionMessage' => $this->getSubmissionMessage(),
 			'notifyOwnerOnSubmission' => (bool)$this->getNotifyOwnerOnSubmission(),
+			'attachSubmissionPdf' => (bool)$this->getAttachSubmissionPdf(),
 			'notificationRecipients' => $this->getNotificationRecipients(),
 			'state' => $this->getState(),
 			'lockedBy' => $this->getLockedBy(),

--- a/lib/Events/FormSubmittedEvent.php
+++ b/lib/Events/FormSubmittedEvent.php
@@ -11,17 +11,35 @@ use OCA\Forms\Db\Form;
 use OCA\Forms\Db\Submission;
 
 class FormSubmittedEvent extends AbstractFormEvent {
+	public const TRIGGER_CREATED = 'created';
+	public const TRIGGER_UPDATED = 'updated';
+	public const TRIGGER_VERIFIED = 'verified';
+
 	public function __construct(
 		Form $form,
 		private Submission $submission,
+		private string $trigger = self::TRIGGER_CREATED,
 	) {
 		parent::__construct($form);
+	}
+
+	public function getSubmission(): Submission {
+		return $this->submission;
+	}
+
+	public function getTrigger(): string {
+		return $this->trigger;
+	}
+
+	public function isNewSubmission(): bool {
+		return $this->trigger === self::TRIGGER_CREATED;
 	}
 
 	public function getWebhookSerializable(): array {
 		return [
 			'form' => $this->form->read(),
 			'submission' => $this->submission->read(),
+			'trigger' => $this->trigger,
 		];
 	}
 }

--- a/lib/FormsMigrator.php
+++ b/lib/FormsMigrator.php
@@ -149,6 +149,7 @@ class FormsMigrator implements IMigrator {
 				$form->setAllowEditSubmissions($formData['allowEditSubmissions']);
 				$form->setShowExpiration($formData['showExpiration']);
 				$form->setNotifyOwnerOnSubmission($formData['notifyOwnerOnSubmission'] ?? false);
+				$form->setNotificationRecipients($formData['notificationRecipients'] ?? []);
 
 				$this->formMapper->insert($form);
 

--- a/lib/FormsMigrator.php
+++ b/lib/FormsMigrator.php
@@ -149,6 +149,7 @@ class FormsMigrator implements IMigrator {
 				$form->setAllowEditSubmissions($formData['allowEditSubmissions']);
 				$form->setShowExpiration($formData['showExpiration']);
 				$form->setNotifyOwnerOnSubmission($formData['notifyOwnerOnSubmission'] ?? false);
+				$form->setAttachSubmissionPdf($formData['attachSubmissionPdf'] ?? false);
 				$form->setNotificationRecipients($formData['notificationRecipients'] ?? []);
 
 				$this->formMapper->insert($form);

--- a/lib/FormsMigrator.php
+++ b/lib/FormsMigrator.php
@@ -148,7 +148,7 @@ class FormsMigrator implements IMigrator {
 				$form->setSubmitMultiple($formData['submitMultiple']);
 				$form->setAllowEditSubmissions($formData['allowEditSubmissions']);
 				$form->setShowExpiration($formData['showExpiration']);
-				$form->setMaxSubmissions($formData['maxSubmissions'] ?? null);
+				$form->setNotifyOwnerOnSubmission($formData['notifyOwnerOnSubmission'] ?? false);
 
 				$this->formMapper->insert($form);
 

--- a/lib/Listener/OwnerNotificationListener.php
+++ b/lib/Listener/OwnerNotificationListener.php
@@ -68,6 +68,7 @@ class OwnerNotificationListener implements IEventListener {
 		}
 
 		$answerSummaries = [];
+		$pdfAnswerEntries = [];
 		try {
 			$answers = $this->answerMapper->findBySubmission($submission->getId());
 		} catch (DoesNotExistException $e) {
@@ -87,6 +88,12 @@ class OwnerNotificationListener implements IEventListener {
 
 			$questionType = $question->getType();
 			$answerText = trim($answer->getText() ?? '');
+			if ($answerText !== '') {
+				$pdfAnswerEntries[] = [
+					'question' => $question->getText(),
+					'answer' => $answerText,
+				];
+			}
 			if (
 				$answerText !== ''
 				&& in_array($questionType, [Constants::ANSWER_TYPE_SHORT, Constants::ANSWER_TYPE_LONG], true)
@@ -103,6 +110,7 @@ class OwnerNotificationListener implements IEventListener {
 			$submission,
 			array_values($normalizedRecipients),
 			$answerSummaries,
+			$pdfAnswerEntries,
 		);
 	}
 }

--- a/lib/Listener/OwnerNotificationListener.php
+++ b/lib/Listener/OwnerNotificationListener.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Forms\Listener;
+
+use OCA\Forms\Constants;
+use OCA\Forms\Db\AnswerMapper;
+use OCA\Forms\Db\QuestionMapper;
+use OCA\Forms\Events\FormSubmittedEvent;
+use OCA\Forms\Service\OwnerNotificationMailService;
+use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\EventDispatcher\Event;
+use OCP\EventDispatcher\IEventListener;
+use OCP\IUserManager;
+use Psr\Log\LoggerInterface;
+
+/**
+ * @implements IEventListener<FormSubmittedEvent>
+ */
+class OwnerNotificationListener implements IEventListener {
+	public function __construct(
+		private OwnerNotificationMailService $ownerNotificationMailService,
+		private AnswerMapper $answerMapper,
+		private QuestionMapper $questionMapper,
+		private IUserManager $userManager,
+		private LoggerInterface $logger,
+	) {
+	}
+
+	public function handle(Event $event): void {
+		if (!($event instanceof FormSubmittedEvent)) {
+			return;
+		}
+		if (!$event->isNewSubmission()) {
+			return;
+		}
+
+		$form = $event->getForm();
+		if (!$form->getNotifyOwnerOnSubmission()) {
+			return;
+		}
+
+		$submission = $event->getSubmission();
+		$owner = $this->userManager->get($form->getOwnerId());
+		$ownerMail = trim((string)$owner?->getEMailAddress());
+		if ($ownerMail === '') {
+			return;
+		}
+
+		$answerSummaries = [];
+		try {
+			$answers = $this->answerMapper->findBySubmission($submission->getId());
+		} catch (DoesNotExistException $e) {
+			return;
+		}
+		foreach ($answers as $answer) {
+			try {
+				$question = $this->questionMapper->findById($answer->getQuestionId());
+			} catch (DoesNotExistException $e) {
+				$this->logger->warning('Question missing while preparing owner notification mail', [
+					'formId' => $form->getId(),
+					'submissionId' => $submission->getId(),
+					'questionId' => $answer->getQuestionId(),
+				]);
+				continue;
+			}
+
+			$questionType = $question->getType();
+			$answerText = trim($answer->getText() ?? '');
+			if (
+				$answerText !== ''
+				&& in_array($questionType, [Constants::ANSWER_TYPE_SHORT, Constants::ANSWER_TYPE_LONG], true)
+			) {
+				$answerSummaries[] = [
+					'question' => $question->getText(),
+					'answer' => $answerText,
+				];
+			}
+		}
+
+		$this->ownerNotificationMailService->send(
+			$form,
+			$submission,
+			[$ownerMail],
+			$answerSummaries,
+		);
+	}
+}

--- a/lib/Listener/OwnerNotificationListener.php
+++ b/lib/Listener/OwnerNotificationListener.php
@@ -42,14 +42,28 @@ class OwnerNotificationListener implements IEventListener {
 		}
 
 		$form = $event->getForm();
-		if (!$form->getNotifyOwnerOnSubmission()) {
-			return;
+		$submission = $event->getSubmission();
+		$recipients = $form->getNotificationRecipients();
+
+		if ($form->getNotifyOwnerOnSubmission()) {
+			$owner = $this->userManager->get($form->getOwnerId());
+			$ownerMail = $owner?->getEMailAddress();
+			if (is_string($ownerMail) && trim($ownerMail) !== '') {
+				$recipients[] = trim($ownerMail);
+			}
 		}
 
-		$submission = $event->getSubmission();
-		$owner = $this->userManager->get($form->getOwnerId());
-		$ownerMail = trim((string)$owner?->getEMailAddress());
-		if ($ownerMail === '') {
+		$normalizedRecipients = [];
+		foreach ($recipients as $recipient) {
+			$trimmedRecipient = trim($recipient);
+			if ($trimmedRecipient === '') {
+				continue;
+			}
+
+			$normalizedRecipients[strtolower($trimmedRecipient)] = $trimmedRecipient;
+		}
+
+		if ($normalizedRecipients === []) {
 			return;
 		}
 
@@ -87,7 +101,7 @@ class OwnerNotificationListener implements IEventListener {
 		$this->ownerNotificationMailService->send(
 			$form,
 			$submission,
-			[$ownerMail],
+			array_values($normalizedRecipients),
 			$answerSummaries,
 		);
 	}

--- a/lib/Migration/Version050300Date20260228170000.php
+++ b/lib/Migration/Version050300Date20260228170000.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Forms\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\DB\Types;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+class Version050300Date20260228170000 extends SimpleMigrationStep {
+
+	/**
+	 * @param IOutput $output
+	 * @param Closure $schemaClosure The `\Closure` returns a `ISchemaWrapper`
+	 * @param array $options
+	 * @return null|ISchemaWrapper
+	 */
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
+		/** @var ISchemaWrapper $schema */
+		$schema = $schemaClosure();
+
+		$formsTable = $schema->getTable('forms_v2_forms');
+		if (!$formsTable->hasColumn('notify_owner_on_submission')) {
+			$formsTable->addColumn('notify_owner_on_submission', Types::BOOLEAN, [
+				'notnull' => false,
+				'default' => false,
+			]);
+		}
+
+		return $schema;
+	}
+}

--- a/lib/Migration/Version050300Date20260228170000.php
+++ b/lib/Migration/Version050300Date20260228170000.php
@@ -35,6 +35,13 @@ class Version050300Date20260228170000 extends SimpleMigrationStep {
 			]);
 		}
 
+		if (!$formsTable->hasColumn('notification_recipients_json')) {
+			$formsTable->addColumn('notification_recipients_json', Types::TEXT, [
+				'notnull' => false,
+				'default' => null,
+			]);
+		}
+
 		return $schema;
 	}
 }

--- a/lib/Migration/Version050300Date20260228190000.php
+++ b/lib/Migration/Version050300Date20260228190000.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Forms\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\DB\Types;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+class Version050300Date20260228190000 extends SimpleMigrationStep {
+
+	/**
+	 * @param IOutput $output
+	 * @param Closure $schemaClosure The `\Closure` returns a `ISchemaWrapper`
+	 * @param array $options
+	 * @return null|ISchemaWrapper
+	 */
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
+		/** @var ISchemaWrapper $schema */
+		$schema = $schemaClosure();
+
+		$formsTable = $schema->getTable('forms_v2_forms');
+		if (!$formsTable->hasColumn('attach_submission_pdf')) {
+			$formsTable->addColumn('attach_submission_pdf', Types::BOOLEAN, [
+				'notnull' => false,
+				'default' => false,
+			]);
+		}
+
+		return $schema;
+	}
+}

--- a/lib/ResponseDefinitions.php
+++ b/lib/ResponseDefinitions.php
@@ -142,6 +142,7 @@ namespace OCA\Forms;
  *   submissionCount?: int,
  *   submissionMessage: ?string,
  *   notifyOwnerOnSubmission: bool,
+ *   notificationRecipients: list<string>,
  * }
  *
  * @psalm-type FormsUploadedFile = array{

--- a/lib/ResponseDefinitions.php
+++ b/lib/ResponseDefinitions.php
@@ -141,6 +141,7 @@ namespace OCA\Forms;
  *   shares: list<FormsShare>,
  *   submissionCount?: int,
  *   submissionMessage: ?string,
+ *   notifyOwnerOnSubmission: bool,
  * }
  *
  * @psalm-type FormsUploadedFile = array{

--- a/lib/ResponseDefinitions.php
+++ b/lib/ResponseDefinitions.php
@@ -142,6 +142,7 @@ namespace OCA\Forms;
  *   submissionCount?: int,
  *   submissionMessage: ?string,
  *   notifyOwnerOnSubmission: bool,
+ *   attachSubmissionPdf: bool,
  *   notificationRecipients: list<string>,
  * }
  *

--- a/lib/Service/FormsService.php
+++ b/lib/Service/FormsService.php
@@ -285,6 +285,7 @@ class FormsService {
 		unset($formData['filePath']);
 		unset($formData['fileFormat']);
 		unset($formData['notifyOwnerOnSubmission']);
+		unset($formData['notificationRecipients']);
 
 		return $formData;
 	}

--- a/lib/Service/FormsService.php
+++ b/lib/Service/FormsService.php
@@ -284,6 +284,7 @@ class FormsService {
 		unset($formData['fileId']);
 		unset($formData['filePath']);
 		unset($formData['fileFormat']);
+		unset($formData['notifyOwnerOnSubmission']);
 
 		return $formData;
 	}
@@ -709,7 +710,7 @@ class FormsService {
 	 * @param Form $form Related Form
 	 * @param string $submitter The ID of the user who submitted the form. Can also be our 'anon-user-'-ID
 	 */
-	public function notifyNewSubmission(Form $form, Submission $submission): void {
+	public function notifyNewSubmission(Form $form, Submission $submission, string $trigger = FormSubmittedEvent::TRIGGER_CREATED): void {
 		$shares = $this->getShares($form->getId());
 		try {
 			$this->activityManager->publishNewSubmission($form, $submission->getUserId());
@@ -738,7 +739,7 @@ class FormsService {
 			}
 		}
 
-		$this->eventDispatcher->dispatchTyped(new FormSubmittedEvent($form, $submission));
+		$this->eventDispatcher->dispatchTyped(new FormSubmittedEvent($form, $submission, $trigger));
 	}
 
 	/**

--- a/lib/Service/OwnerNotificationMailService.php
+++ b/lib/Service/OwnerNotificationMailService.php
@@ -22,6 +22,7 @@ class OwnerNotificationMailService {
 		private IMailer $mailer,
 		private IL10N $l10n,
 		private IURLGenerator $urlGenerator,
+		private SubmissionPdfService $submissionPdfService,
 		private LoggerInterface $logger,
 	) {
 	}
@@ -29,8 +30,9 @@ class OwnerNotificationMailService {
 	/**
 	 * @param list<string> $recipients
 	 * @param array<int, array{question: string, answer: string}> $answerSummaries
+	 * @param array<int, array{question: string, answer: string}> $pdfAnswerEntries
 	 */
-	public function send(Form $form, Submission $submission, array $recipients, array $answerSummaries = []): void {
+	public function send(Form $form, Submission $submission, array $recipients, array $answerSummaries = [], array $pdfAnswerEntries = []): void {
 		$validRecipients = array_values(array_unique(array_filter($recipients, fn (string $recipient): bool => $this->mailer->validateMailAddress($recipient))));
 		if ($validRecipients === []) {
 			return;
@@ -77,6 +79,16 @@ class OwnerNotificationMailService {
 			$message->setSubject($subject);
 			$message->setTo($validRecipients);
 			$message->useTemplate($emailTemplate);
+			if ($form->getAttachSubmissionPdf()) {
+				$entriesForPdf = $pdfAnswerEntries !== [] ? $pdfAnswerEntries : $answerSummaries;
+				$message->attach(
+					$this->mailer->createAttachment(
+						$this->submissionPdfService->createPdf($form, $submission, $entriesForPdf),
+						$this->submissionPdfService->createFilename($form, $submission),
+						'application/pdf',
+					),
+				);
+			}
 
 			$this->mailer->send($message);
 		} catch (\Throwable $e) {

--- a/lib/Service/OwnerNotificationMailService.php
+++ b/lib/Service/OwnerNotificationMailService.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Forms\Service;
+
+use OCA\Forms\Db\Form;
+use OCA\Forms\Db\Submission;
+use OCP\IL10N;
+use OCP\IURLGenerator;
+use OCP\Mail\Headers\AutoSubmitted;
+use OCP\Mail\IMailer;
+use Psr\Log\LoggerInterface;
+
+class OwnerNotificationMailService {
+	public function __construct(
+		private IMailer $mailer,
+		private IL10N $l10n,
+		private IURLGenerator $urlGenerator,
+		private LoggerInterface $logger,
+	) {
+	}
+
+	/**
+	 * @param list<string> $recipients
+	 * @param array<int, array{question: string, answer: string}> $answerSummaries
+	 */
+	public function send(Form $form, Submission $submission, array $recipients, array $answerSummaries = []): void {
+		$validRecipients = array_values(array_unique(array_filter($recipients, fn (string $recipient): bool => $this->mailer->validateMailAddress($recipient))));
+		if ($validRecipients === []) {
+			return;
+		}
+
+		$formTitle = $form->getTitle();
+		$subject = $this->l10n->t('New response to %s', [$formTitle]);
+		$resultsUrl = $this->urlGenerator->linkToRouteAbsolute('forms.page.views', [
+			'hash' => $form->getHash(),
+			'view' => 'results',
+		]);
+
+		try {
+			$emailTemplate = $this->mailer->createEMailTemplate('forms.OwnerNotificationEmail', [
+				'formTitle' => $formTitle,
+			]);
+			$emailTemplate->setSubject($subject);
+			$emailTemplate->addHeader();
+			$emailTemplate->addHeading($this->l10n->t('New form response received'));
+			$emailTemplate->addBodyText(
+				$this->l10n->t('A new response was submitted to the form %s.', [$formTitle])
+			);
+
+			if ($answerSummaries !== []) {
+				$emailTemplate->addBodyText($this->l10n->t('Submission summary:'));
+				foreach ($answerSummaries as $summary) {
+					$emailTemplate->addBodyListItem(
+						$summary['answer'],
+						$summary['question'],
+						'',
+						'',
+						''
+					);
+				}
+			}
+
+			$emailTemplate->addBodyButton($this->l10n->t('Open form results'), $resultsUrl);
+			$emailTemplate->addFooter(
+				$this->l10n->t('This message was sent automatically by %s.', [$this->l10n->t('Forms')])
+			);
+
+			$message = $this->mailer->createMessage();
+			$message->setAutoSubmitted(AutoSubmitted::VALUE_AUTO_GENERATED);
+			$message->setSubject($subject);
+			$message->setTo($validRecipients);
+			$message->useTemplate($emailTemplate);
+
+			$this->mailer->send($message);
+		} catch (\Throwable $e) {
+			$this->logger->error('Failed to send owner notification email for submission', [
+				'formId' => $form->getId(),
+				'submissionId' => $submission->getId(),
+				'exception' => $e,
+			]);
+		}
+	}
+}

--- a/lib/Service/SubmissionPdfService.php
+++ b/lib/Service/SubmissionPdfService.php
@@ -1,0 +1,217 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Forms\Service;
+
+use OCA\Forms\Db\Form;
+use OCA\Forms\Db\Submission;
+use OCP\IL10N;
+
+class SubmissionPdfService {
+	private const MAX_LINES_PER_PAGE = 48;
+
+	public function __construct(
+		private IL10N $l10n,
+	) {
+	}
+
+	/**
+	 * @param array<int, array{question: string, answer: string}> $answerEntries
+	 */
+	public function createPdf(Form $form, Submission $submission, array $answerEntries = []): string {
+		$submissionTimestamp = max(0, $submission->getTimestamp());
+		$headerLines = [
+			$this->l10n->t('Nextcloud Forms submission'),
+			$this->l10n->t('Form: %s', [$form->getTitle()]),
+			$this->l10n->t('Submission ID: %s', [(string)$submission->getId()]),
+			$this->l10n->t('Submitted at (UTC): %s', [gmdate('Y-m-d H:i:s', $submissionTimestamp)]),
+			'',
+			$this->l10n->t('Responses:'),
+		];
+
+		$responseLines = [];
+		if ($answerEntries === []) {
+			$responseLines[] = '- ' . $this->l10n->t('No responses captured');
+		} else {
+			foreach ($answerEntries as $entry) {
+				$responseLines[] = '- ' . $entry['question'] . ':';
+
+				$normalizedAnswer = str_replace(["\r\n", "\r"], "\n", $entry['answer']);
+				foreach (explode("\n", $normalizedAnswer) as $answerLine) {
+					$responseLines[] = '  ' . ($answerLine === '' ? '[empty line]' : $answerLine);
+				}
+			}
+		}
+
+		$lines = array_merge($headerLines, $responseLines);
+		$pdfLines = $this->normalizePdfLines($lines);
+		$contentStreams = array_map(
+			fn (array $pageLines): string => $this->createContentStream($pageLines),
+			$this->paginatePdfLines($pdfLines),
+		);
+
+		return $this->assemblePdf($contentStreams);
+	}
+
+	public function createFilename(Form $form, Submission $submission): string {
+		$title = trim($form->getTitle());
+		$base = $title === '' ? 'form' : $title;
+		$base = preg_replace('/[^\p{L}\p{N}\-_. ]+/u', '_', $base) ?? 'form';
+		$base = preg_replace('/\s+/', '_', trim($base)) ?? 'form';
+		$base = trim($base, '._-');
+
+		if ($base === '') {
+			$base = 'form';
+		}
+
+		return sprintf('%s-submission-%d.pdf', $base, $submission->getId());
+	}
+
+	/**
+	 * @param list<string> $lines
+	 * @return list<string>
+	 */
+	private function normalizePdfLines(array $lines): array {
+		$normalizedLines = [];
+		foreach ($lines as $line) {
+			$encodedLine = $this->encodeLine($line);
+			foreach ($this->wrapLine($encodedLine, 96) as $wrappedLine) {
+				$normalizedLines[] = $wrappedLine;
+			}
+		}
+
+		return $normalizedLines;
+	}
+
+	private function encodeLine(string $line): string {
+		$encoded = iconv('UTF-8', 'Windows-1252//TRANSLIT//IGNORE', $line);
+		if ($encoded === false) {
+			return '';
+		}
+
+		return $encoded;
+	}
+
+	/**
+	 * @return list<string>
+	 */
+	private function wrapLine(string $line, int $limit): array {
+		if ($line === '') {
+			return [''];
+		}
+
+		$words = preg_split('/\s+/', $line) ?: [];
+		$current = '';
+		$result = [];
+
+		foreach ($words as $word) {
+			if ($word === '') {
+				continue;
+			}
+
+			$candidate = $current === '' ? $word : $current . ' ' . $word;
+			if (strlen($candidate) <= $limit) {
+				$current = $candidate;
+				continue;
+			}
+
+			if ($current !== '') {
+				$result[] = $current;
+				$current = '';
+			}
+
+			while (strlen($word) > $limit) {
+				$result[] = substr($word, 0, $limit);
+				$word = substr($word, $limit);
+			}
+
+			$current = $word;
+		}
+
+		if ($current !== '') {
+			$result[] = $current;
+		}
+
+		return $result === [] ? [''] : $result;
+	}
+
+	/**
+	 * @param list<string> $pdfLines
+	 * @return list<list<string>>
+	 */
+	private function paginatePdfLines(array $pdfLines): array {
+		$pages = array_chunk($pdfLines, self::MAX_LINES_PER_PAGE);
+		return $pages === [] ? [['']] : $pages;
+	}
+
+	/**
+	 * @param list<string> $pdfLines
+	 */
+	private function createContentStream(array $pdfLines): string {
+		$content = "BT\n/F1 11 Tf\n14 TL\n50 792 Td\n";
+		foreach ($pdfLines as $line) {
+			$escapedLine = str_replace(['\\', '(', ')'], ['\\\\', '\\(', '\\)'], $line);
+			$content .= '(' . $escapedLine . ") Tj\nT*\n";
+		}
+		$content .= 'ET';
+
+		return $content;
+	}
+
+	/**
+	 * @param list<string> $contentStreams
+	 */
+	private function assemblePdf(array $contentStreams): string {
+		$pageCount = count($contentStreams);
+		$fontObjectId = 3 + ($pageCount * 2);
+		$pageObjectIds = [];
+
+		$objects = [
+			1 => '<< /Type /Catalog /Pages 2 0 R >>',
+			2 => '',
+		];
+		foreach ($contentStreams as $index => $contentStream) {
+			$pageObjectId = 3 + ($index * 2);
+			$contentObjectId = $pageObjectId + 1;
+			$pageObjectIds[] = $pageObjectId;
+
+			$objects[$pageObjectId] = '<< /Type /Page /Parent 2 0 R /MediaBox [0 0 595 842] /Resources << /Font << /F1 '
+				. $fontObjectId . ' 0 R >> >> /Contents ' . $contentObjectId . ' 0 R >>';
+			$objects[$contentObjectId] = '<< /Length ' . strlen($contentStream) . " >>\nstream\n" . $contentStream . "\nendstream";
+		}
+		$objects[2] = '<< /Type /Pages /Kids [' . implode(' ', array_map(
+			static fn (int $pageObjectId): string => $pageObjectId . ' 0 R',
+			$pageObjectIds,
+		)) . '] /Count ' . $pageCount . ' >>';
+		$objects[$fontObjectId] = '<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>';
+
+		ksort($objects);
+
+		$pdf = "%PDF-1.4\n";
+		$offsets = [0 => 0];
+
+		foreach ($objects as $id => $object) {
+			$offsets[$id] = strlen($pdf);
+			$pdf .= $id . " 0 obj\n" . $object . "\nendobj\n";
+		}
+
+		$startXref = strlen($pdf);
+		$objectCount = max(array_keys($objects)) + 1;
+		$pdf .= "xref\n0 " . $objectCount . "\n";
+		$pdf .= sprintf("%010d 65535 f \n", 0);
+		for ($i = 1; $i < $objectCount; $i++) {
+			$pdf .= sprintf("%010d 00000 n \n", $offsets[$i]);
+		}
+
+		$pdf .= "trailer\n<< /Size " . $objectCount . " /Root 1 0 R >>\n";
+		$pdf .= "startxref\n" . $startXref . "\n%%EOF";
+
+		return $pdf;
+	}
+}

--- a/openapi.json
+++ b/openapi.json
@@ -119,7 +119,8 @@
                     "lockedUntil",
                     "maxSubmissions",
                     "shares",
-                    "submissionMessage"
+                    "submissionMessage",
+                    "notifyOwnerOnSubmission"
                 ],
                 "properties": {
                     "id": {
@@ -232,6 +233,9 @@
                     "submissionMessage": {
                         "type": "string",
                         "nullable": true
+                    },
+                    "notifyOwnerOnSubmission": {
+                        "type": "boolean"
                     }
                 }
             },

--- a/openapi.json
+++ b/openapi.json
@@ -120,7 +120,8 @@
                     "maxSubmissions",
                     "shares",
                     "submissionMessage",
-                    "notifyOwnerOnSubmission"
+                    "notifyOwnerOnSubmission",
+                    "notificationRecipients"
                 ],
                 "properties": {
                     "id": {
@@ -236,6 +237,12 @@
                     },
                     "notifyOwnerOnSubmission": {
                         "type": "boolean"
+                    },
+                    "notificationRecipients": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     }
                 }
             },

--- a/openapi.json
+++ b/openapi.json
@@ -121,6 +121,7 @@
                     "shares",
                     "submissionMessage",
                     "notifyOwnerOnSubmission",
+                    "attachSubmissionPdf",
                     "notificationRecipients"
                 ],
                 "properties": {
@@ -236,6 +237,9 @@
                         "nullable": true
                     },
                     "notifyOwnerOnSubmission": {
+                        "type": "boolean"
+                    },
+                    "attachSubmissionPdf": {
                         "type": "boolean"
                     },
                     "notificationRecipients": {

--- a/src/components/SidebarTabs/SettingsSidebarTab.vue
+++ b/src/components/SidebarTabs/SettingsSidebarTab.vue
@@ -61,6 +61,13 @@
 				)
 			}}
 		</NcCheckboxRadioSwitch>
+		<NcCheckboxRadioSwitch
+			:model-value="form.attachSubmissionPdf"
+			:disabled="formArchived || locked"
+			type="switch"
+			@update:model-value="onAttachSubmissionPdfChange">
+			{{ t('forms', 'Attach each submission as PDF to notification emails') }}
+		</NcCheckboxRadioSwitch>
 		<div class="settings-div--separate">
 			<NcTextArea
 				v-model="notificationRecipientsInput"
@@ -390,6 +397,10 @@ export default {
 
 		onNotifyOwnerOnSubmissionChange(checked) {
 			this.$emit('update:form-prop', 'notifyOwnerOnSubmission', checked)
+		},
+
+		onAttachSubmissionPdfChange(checked) {
+			this.$emit('update:form-prop', 'attachSubmissionPdf', checked)
 		},
 
 		onNotificationRecipientsChange(payload) {

--- a/src/components/SidebarTabs/SettingsSidebarTab.vue
+++ b/src/components/SidebarTabs/SettingsSidebarTab.vue
@@ -50,6 +50,18 @@
 			{{ t('forms', 'Allow editing own responses') }}
 		</NcCheckboxRadioSwitch>
 		<NcCheckboxRadioSwitch
+			:model-value="form.notifyOwnerOnSubmission"
+			:disabled="formArchived || locked"
+			type="switch"
+			@update:model-value="onNotifyOwnerOnSubmissionChange">
+			{{
+				t(
+					'forms',
+					'Send email notifications for new responses to the form owner',
+				)
+			}}
+		</NcCheckboxRadioSwitch>
+		<NcCheckboxRadioSwitch
 			:model-value="formExpires"
 			:disabled="formArchived || locked"
 			type="switch"
@@ -79,32 +91,6 @@
 			</NcCheckboxRadioSwitch>
 		</div>
 		<NcCheckboxRadioSwitch
-			:model-value="hasMaxSubmissions"
-			:disabled="formArchived || locked"
-			type="switch"
-			@update:model-value="onMaxSubmissionsChange">
-			{{ t('forms', 'Limit number of responses') }}
-		</NcCheckboxRadioSwitch>
-		<div
-			v-show="hasMaxSubmissions && !formArchived"
-			class="settings-div--indent">
-			<NcInputField
-				v-model="maxSubmissionsValue"
-				type="number"
-				:min="1"
-				:disabled="locked"
-				:label="t('forms', 'Maximum number of responses')"
-				@update:model-value="onMaxSubmissionsValueChange" />
-			<p class="settings-hint">
-				{{
-					t(
-						'forms',
-						'Form will be closed automatically when the limit is reached.',
-					)
-				}}
-			</p>
-		</div>
-		<NcCheckboxRadioSwitch
 			:model-value="formClosed"
 			:disabled="formArchived || locked"
 			aria-describedby="forms-settings__close-form"
@@ -113,7 +99,7 @@
 			{{ t('forms', 'Close form') }}
 		</NcCheckboxRadioSwitch>
 		<p id="forms-settings__close-form" class="settings-hint">
-			{{ t('forms', 'Closed forms do not accept new responses.') }}
+			{{ t('forms', 'Closed forms do not accept new submissions.') }}
 		</p>
 		<NcCheckboxRadioSwitch
 			:model-value="isFormLockedPermanently"
@@ -138,7 +124,7 @@
 			{{
 				t(
 					'forms',
-					'Archived forms do not accept new responses and cannot be modified.',
+					'Archived forms do not accept new submissions and can not be modified.',
 				)
 			}}
 		</p>
@@ -210,7 +196,6 @@ import NcButton from '@nextcloud/vue/components/NcButton'
 import NcCheckboxRadioSwitch from '@nextcloud/vue/components/NcCheckboxRadioSwitch'
 import NcDateTimePicker from '@nextcloud/vue/components/NcDateTimePicker'
 import NcIconSvgWrapper from '@nextcloud/vue/components/NcIconSvgWrapper'
-import NcInputField from '@nextcloud/vue/components/NcInputField'
 import NcNoteCard from '@nextcloud/vue/components/NcNoteCard'
 import TransferOwnership from './TransferOwnership.vue'
 import svgLockOpen from '../../../img/lock_open.svg?raw'
@@ -220,7 +205,6 @@ import { FormState } from '../../models/Constants.ts'
 export default {
 	components: {
 		NcButton,
-		NcInputField,
 		NcCheckboxRadioSwitch,
 		NcDateTimePicker,
 		NcIconSvgWrapper,
@@ -330,23 +314,6 @@ export default {
 			return this.form.state !== FormState.FormActive
 		},
 
-		hasMaxSubmissions() {
-			return (
-				this.form.maxSubmissions !== null
-				&& this.form.maxSubmissions !== undefined
-			)
-		},
-
-		maxSubmissionsValue: {
-			get() {
-				return this.form.maxSubmissions ?? 1
-			},
-
-			set(value) {
-				this.$emit('update:form-prop', 'maxSubmissions', value)
-			},
-		},
-
 		isExpired() {
 			return this.form.expires && moment().unix() > this.form.expires
 		},
@@ -381,6 +348,10 @@ export default {
 			this.$emit('update:form-prop', 'allowEditSubmissions', checked)
 		},
 
+		onNotifyOwnerOnSubmissionChange(checked) {
+			this.$emit('update:form-prop', 'notifyOwnerOnSubmission', checked)
+		},
+
 		onFormExpiresChange(checked) {
 			if (checked) {
 				this.$emit(
@@ -408,16 +379,6 @@ export default {
 				'expires',
 				parseInt(moment(datetime).format('X')),
 			)
-		},
-
-		onMaxSubmissionsChange(checked) {
-			this.$emit('update:form-prop', 'maxSubmissions', checked ? 1 : null)
-		},
-
-		onMaxSubmissionsValueChange(value) {
-			if (value > 0) {
-				this.$emit('update:form-prop', 'maxSubmissions', value)
-			}
 		},
 
 		onFormClosedChange(isClosed) {
@@ -511,6 +472,10 @@ export default {
 
 .settings-div--indent {
 	margin-inline-start: 40px;
+}
+
+.settings-div--separate {
+	margin-block: 4px;
 }
 
 .settings-hint {

--- a/src/components/SidebarTabs/SettingsSidebarTab.vue
+++ b/src/components/SidebarTabs/SettingsSidebarTab.vue
@@ -61,6 +61,29 @@
 				)
 			}}
 		</NcCheckboxRadioSwitch>
+		<div class="settings-div--separate">
+			<NcTextArea
+				v-model="notificationRecipientsInput"
+				:disabled="formArchived || locked"
+				:label="t('forms', 'Additional notification recipients')"
+				:placeholder="
+					t(
+						'forms',
+						'One email address per line (for example: team@example.com)',
+					)
+				"
+				resize="vertical"
+				rows="4"
+				@blur="onNotificationRecipientsChange" />
+			<p class="settings-hint">
+				{{
+					t(
+						'forms',
+						'Additional recipients are notified for each new response, independent of the owner notification switch.',
+					)
+				}}
+			</p>
+		</div>
 		<NcCheckboxRadioSwitch
 			:model-value="formExpires"
 			:disabled="formArchived || locked"
@@ -197,6 +220,7 @@ import NcCheckboxRadioSwitch from '@nextcloud/vue/components/NcCheckboxRadioSwit
 import NcDateTimePicker from '@nextcloud/vue/components/NcDateTimePicker'
 import NcIconSvgWrapper from '@nextcloud/vue/components/NcIconSvgWrapper'
 import NcNoteCard from '@nextcloud/vue/components/NcNoteCard'
+import NcTextArea from '@nextcloud/vue/components/NcTextArea'
 import TransferOwnership from './TransferOwnership.vue'
 import svgLockOpen from '../../../img/lock_open.svg?raw'
 import ShareTypes from '../../mixins/ShareTypes.js'
@@ -209,6 +233,7 @@ export default {
 		NcDateTimePicker,
 		NcIconSvgWrapper,
 		NcNoteCard,
+		NcTextArea,
 		TransferOwnership,
 	},
 
@@ -249,6 +274,7 @@ export default {
 			maxStringLengths: loadState('forms', 'maxStringLengths'),
 			/** If custom submission message is shown as input or rendered markdown */
 			editMessage: false,
+			notificationRecipientsInput: '',
 			svgLockOpen,
 		}
 	},
@@ -330,6 +356,20 @@ export default {
 		},
 	},
 
+	watch: {
+		'form.notificationRecipients': {
+			handler(value) {
+				this.updateNotificationRecipientsInput(value)
+			},
+
+			deep: true,
+		},
+	},
+
+	created() {
+		this.updateNotificationRecipientsInput(this.form.notificationRecipients)
+	},
+
 	methods: {
 		/**
 		 * Save Form-Properties
@@ -350,6 +390,21 @@ export default {
 
 		onNotifyOwnerOnSubmissionChange(checked) {
 			this.$emit('update:form-prop', 'notifyOwnerOnSubmission', checked)
+		},
+
+		onNotificationRecipientsChange(payload) {
+			const value =
+				typeof payload === 'string'
+					? payload
+					: (payload?.target?.value ?? this.notificationRecipientsInput)
+
+			const recipients = value
+				.split(/[\r\n,]+/g)
+				.map((recipient) => recipient.trim())
+				.filter((recipient) => recipient.length > 0)
+
+			this.notificationRecipientsInput = recipients.join('\n')
+			this.$emit('update:form-prop', 'notificationRecipients', recipients)
 		},
 
 		onFormExpiresChange(checked) {
@@ -460,6 +515,15 @@ export default {
 		 */
 		notBeforeNow(datetime) {
 			return datetime < moment().toDate()
+		},
+
+		updateNotificationRecipientsInput(notificationRecipients) {
+			if (!Array.isArray(notificationRecipients)) {
+				this.notificationRecipientsInput = ''
+				return
+			}
+
+			this.notificationRecipientsInput = notificationRecipients.join('\n')
 		},
 	},
 }

--- a/tests/Integration/Api/ApiV3Test.php
+++ b/tests/Integration/Api/ApiV3Test.php
@@ -397,6 +397,7 @@ class ApiV3Test extends IntegrationBase {
 					'maxSubmissions' => null,
 					'isMaxSubmissionsReached' => false,
 					'notifyOwnerOnSubmission' => false,
+					'notificationRecipients' => [],
 				]
 			]
 		];
@@ -531,6 +532,7 @@ class ApiV3Test extends IntegrationBase {
 					'maxSubmissions' => null,
 					'isMaxSubmissionsReached' => false,
 					'notifyOwnerOnSubmission' => false,
+					'notificationRecipients' => [],
 				]
 			]
 		];

--- a/tests/Integration/Api/ApiV3Test.php
+++ b/tests/Integration/Api/ApiV3Test.php
@@ -255,7 +255,7 @@ class ApiV3Test extends IntegrationBase {
 		// Set up http Client
 		$this->http = new Client([
 			'base_uri' => 'http://localhost:8080/ocs/v2.php/apps/forms/',
-			'auth' => ['test', 'test'],
+			'auth' => ['test', self::TEST_USER_PASSWORD],
 			'headers' => [
 				'OCS-ApiRequest' => 'true',
 				'Accept' => 'application/json'
@@ -396,6 +396,7 @@ class ApiV3Test extends IntegrationBase {
 					'fileFormat' => null,
 					'maxSubmissions' => null,
 					'isMaxSubmissionsReached' => false,
+					'notifyOwnerOnSubmission' => false,
 				]
 			]
 		];
@@ -529,6 +530,7 @@ class ApiV3Test extends IntegrationBase {
 					'fileFormat' => null,
 					'maxSubmissions' => null,
 					'isMaxSubmissionsReached' => false,
+					'notifyOwnerOnSubmission' => false,
 				]
 			]
 		];

--- a/tests/Integration/Api/ApiV3Test.php
+++ b/tests/Integration/Api/ApiV3Test.php
@@ -397,6 +397,7 @@ class ApiV3Test extends IntegrationBase {
 					'maxSubmissions' => null,
 					'isMaxSubmissionsReached' => false,
 					'notifyOwnerOnSubmission' => false,
+					'attachSubmissionPdf' => false,
 					'notificationRecipients' => [],
 				]
 			]
@@ -532,6 +533,7 @@ class ApiV3Test extends IntegrationBase {
 					'maxSubmissions' => null,
 					'isMaxSubmissionsReached' => false,
 					'notifyOwnerOnSubmission' => false,
+					'attachSubmissionPdf' => false,
 					'notificationRecipients' => [],
 				]
 			]

--- a/tests/Integration/Api/RespectAdminSettingsTest.php
+++ b/tests/Integration/Api/RespectAdminSettingsTest.php
@@ -135,6 +135,7 @@ class RespectAdminSettingsTest extends IntegrationBase {
 				'showExpiration' => false,
 				'submissionMessage' => '',
 				'notifyOwnerOnSubmission' => false,
+				'attachSubmissionPdf' => false,
 				'notificationRecipients' => [],
 				'permissions' => [
 					'edit',

--- a/tests/Integration/Api/RespectAdminSettingsTest.php
+++ b/tests/Integration/Api/RespectAdminSettingsTest.php
@@ -135,6 +135,7 @@ class RespectAdminSettingsTest extends IntegrationBase {
 				'showExpiration' => false,
 				'submissionMessage' => '',
 				'notifyOwnerOnSubmission' => false,
+				'notificationRecipients' => [],
 				'permissions' => [
 					'edit',
 					'embed',

--- a/tests/Integration/Api/RespectAdminSettingsTest.php
+++ b/tests/Integration/Api/RespectAdminSettingsTest.php
@@ -134,6 +134,7 @@ class RespectAdminSettingsTest extends IntegrationBase {
 				'allowEditSubmissions' => false,
 				'showExpiration' => false,
 				'submissionMessage' => '',
+				'notifyOwnerOnSubmission' => false,
 				'permissions' => [
 					'edit',
 					'embed',
@@ -165,7 +166,7 @@ class RespectAdminSettingsTest extends IntegrationBase {
 		// Set up http Client
 		$this->http = new Client([
 			'base_uri' => 'http://localhost:8080/ocs/v2.php/apps/forms/',
-			'auth' => ['test', 'test'],
+			'auth' => ['test', self::TEST_USER_PASSWORD],
 			'headers' => [
 				'OCS-ApiRequest' => 'true',
 				'Accept' => 'application/json'

--- a/tests/Integration/IntegrationBase.php
+++ b/tests/Integration/IntegrationBase.php
@@ -19,6 +19,7 @@ use Test\TestCase;
  * @group DB
  */
 class IntegrationBase extends TestCase {
+	protected const TEST_USER_PASSWORD = 'Forms-Test-Password-2026!';
 	/** @var Array */
 	protected $testForms;
 
@@ -44,7 +45,7 @@ class IntegrationBase extends TestCase {
 		foreach ($this->users as $userId => $displayName) {
 			$user = $userManager->get($userId);
 			if ($user === null) {
-				$user = $userManager->createUser($userId, $userId);
+				$user = $userManager->createUser($userId, self::TEST_USER_PASSWORD);
 			}
 			$user->setDisplayName($displayName);
 		}

--- a/tests/Unit/Controller/ApiControllerTest.php
+++ b/tests/Unit/Controller/ApiControllerTest.php
@@ -186,6 +186,7 @@ class ApiControllerTest extends TestCase {
 			$read = $form->read();
 			unset($read['created']);
 			unset($read['notifyOwnerOnSubmission']);
+			unset($read['attachSubmissionPdf']);
 			unset($read['notificationRecipients']);
 			self::assertEquals($expected, $read);
 			return true;
@@ -1107,6 +1108,27 @@ class ApiControllerTest extends TestCase {
 
 		$this->expectException(OCSBadRequestException::class);
 		$this->apiController->updateForm(1, ['notifyOwnerOnSubmission' => 'yes']);
+	}
+
+	public function testUpdateFormRejectsNonBooleanAttachSubmissionPdf(): void {
+		$form = new Form();
+		$form->setId(1);
+		$form->setOwnerId('currentUser');
+		$form->setState(Constants::FORM_STATE_ACTIVE);
+		$form->setLockedBy(null);
+		$form->setLockedUntil(null);
+
+		$this->formsService->expects($this->once())
+			->method('getFormIfAllowed')
+			->with(1, Constants::PERMISSION_EDIT)
+			->willReturn($form);
+
+		$this->formsService->expects($this->once())
+			->method('obtainFormLock')
+			->with($form);
+
+		$this->expectException(OCSBadRequestException::class);
+		$this->apiController->updateForm(1, ['attachSubmissionPdf' => 'yes']);
 	}
 
 	public function testGetSubmission_invalidForm() {

--- a/tests/Unit/Controller/ApiControllerTest.php
+++ b/tests/Unit/Controller/ApiControllerTest.php
@@ -66,6 +66,7 @@ use OCP\IRequest;
 use OCP\IUser;
 use OCP\IUserManager;
 use OCP\IUserSession;
+use OCP\Mail\IMailer;
 
 use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Log\LoggerInterface;
@@ -108,6 +109,8 @@ class ApiControllerTest extends TestCase {
 	private $mimeTypeDetector;
 	/** @var IJobList|MockObject */
 	private $jobList;
+	/** @var IMailer|MockObject */
+	private $mailer;
 
 	public function setUp(): void {
 		$this->answerMapper = $this->createMock(AnswerMapper::class);
@@ -132,6 +135,7 @@ class ApiControllerTest extends TestCase {
 		$this->uploadedFileMapper = $this->createMock(UploadedFileMapper::class);
 		$this->mimeTypeDetector = $this->createMock(IMimeTypeDetector::class);
 		$this->jobList = $this->createMock(IJobList::class);
+		$this->mailer = $this->createMock(IMailer::class);
 
 		$this->apiController = new ApiController(
 			'forms',
@@ -153,6 +157,7 @@ class ApiControllerTest extends TestCase {
 			$this->uploadedFileMapper,
 			$this->mimeTypeDetector,
 			$this->jobList,
+			$this->mailer,
 		);
 	}
 
@@ -181,6 +186,7 @@ class ApiControllerTest extends TestCase {
 			$read = $form->read();
 			unset($read['created']);
 			unset($read['notifyOwnerOnSubmission']);
+			unset($read['notificationRecipients']);
 			self::assertEquals($expected, $read);
 			return true;
 		};
@@ -993,6 +999,93 @@ class ApiControllerTest extends TestCase {
 
 		$this->assertEquals(new DataResponse('newOwner'), $this->apiController->updateForm(1, ['ownerId' => 'newOwner']));
 		$this->assertEquals('newOwner', $form->getOwnerId());
+	}
+
+	public function testUpdateFormNormalizesNotificationRecipients(): void {
+		$form = new Form();
+		$form->setId(1);
+		$form->setOwnerId('currentUser');
+		$form->setState(Constants::FORM_STATE_ACTIVE);
+		$form->setLockedBy(null);
+		$form->setLockedUntil(null);
+		$form->setNotificationRecipients([]);
+
+		$this->formsService->expects($this->once())
+			->method('getFormIfAllowed')
+			->with(1, Constants::PERMISSION_EDIT)
+			->willReturn($form);
+
+		$this->formsService->expects($this->once())
+			->method('obtainFormLock')
+			->with($form);
+
+		$this->mailer->expects($this->exactly(3))
+			->method('validateMailAddress')
+			->willReturn(true);
+
+		$this->formMapper->expects($this->once())
+			->method('update')
+			->with($this->callback(function (Form $updated): bool {
+				return $updated->getNotificationRecipients() === ['ext@example.com', 'owner@example.com'];
+			}));
+
+		$response = $this->apiController->updateForm(1, [
+			'notificationRecipients' => [
+				' ext@example.com ',
+				'EXT@example.com',
+				'owner@example.com',
+				'',
+			],
+		]);
+
+		$this->assertEquals(new DataResponse(1), $response);
+	}
+
+	public function testUpdateFormRejectsInvalidNotificationRecipientsType(): void {
+		$form = new Form();
+		$form->setId(1);
+		$form->setOwnerId('currentUser');
+		$form->setState(Constants::FORM_STATE_ACTIVE);
+		$form->setLockedBy(null);
+		$form->setLockedUntil(null);
+
+		$this->formsService->expects($this->once())
+			->method('getFormIfAllowed')
+			->with(1, Constants::PERMISSION_EDIT)
+			->willReturn($form);
+
+		$this->formsService->expects($this->once())
+			->method('obtainFormLock')
+			->with($form);
+
+		$this->expectException(OCSBadRequestException::class);
+		$this->apiController->updateForm(1, ['notificationRecipients' => 'user@example.com']);
+	}
+
+	public function testUpdateFormRejectsInvalidNotificationRecipientAddress(): void {
+		$form = new Form();
+		$form->setId(1);
+		$form->setOwnerId('currentUser');
+		$form->setState(Constants::FORM_STATE_ACTIVE);
+		$form->setLockedBy(null);
+		$form->setLockedUntil(null);
+
+		$this->formsService->expects($this->once())
+			->method('getFormIfAllowed')
+			->with(1, Constants::PERMISSION_EDIT)
+			->willReturn($form);
+
+		$this->formsService->expects($this->once())
+			->method('obtainFormLock')
+			->with($form);
+
+		$this->mailer->expects($this->once())
+			->method('validateMailAddress')
+			->with('invalid')
+			->willReturn(false);
+
+		$this->expectException(OCSBadRequestException::class);
+		$this->apiController->updateForm(1, ['notificationRecipients' => ['invalid']]);
 	}
 
 	public function testUpdateFormRejectsNonBooleanNotifyOwnerOnSubmission(): void {

--- a/tests/Unit/Controller/ApiControllerTest.php
+++ b/tests/Unit/Controller/ApiControllerTest.php
@@ -43,6 +43,7 @@ use OCA\Forms\Db\ShareMapper;
 use OCA\Forms\Db\Submission;
 use OCA\Forms\Db\SubmissionMapper;
 use OCA\Forms\Db\UploadedFileMapper;
+use OCA\Forms\Events\FormSubmittedEvent;
 use OCA\Forms\Exception\NoSuchFormException;
 use OCA\Forms\Service\ConfigService;
 use OCA\Forms\Service\FormsService;
@@ -179,6 +180,7 @@ class ApiControllerTest extends TestCase {
 			self::assertInstanceOf(Form::class, $form);
 			$read = $form->read();
 			unset($read['created']);
+			unset($read['notifyOwnerOnSubmission']);
 			self::assertEquals($expected, $read);
 			return true;
 		};
@@ -430,9 +432,7 @@ class ApiControllerTest extends TestCase {
 			->willReturn('formHash');
 		$expected = $expectedForm;
 		$expected['id'] = null;
-		// TODO fix test, currently unset because behaviour has changed
-		$expected['state'] = null;
-		$expected['lastUpdated'] = null;
+		$expected['lastUpdated'] = 0;
 		$this->formMapper->expects($this->once())
 			->method('insert')
 			->with(self::callback(self::createFormValidator($expected)))
@@ -995,6 +995,27 @@ class ApiControllerTest extends TestCase {
 		$this->assertEquals('newOwner', $form->getOwnerId());
 	}
 
+	public function testUpdateFormRejectsNonBooleanNotifyOwnerOnSubmission(): void {
+		$form = new Form();
+		$form->setId(1);
+		$form->setOwnerId('currentUser');
+		$form->setState(Constants::FORM_STATE_ACTIVE);
+		$form->setLockedBy(null);
+		$form->setLockedUntil(null);
+
+		$this->formsService->expects($this->once())
+			->method('getFormIfAllowed')
+			->with(1, Constants::PERMISSION_EDIT)
+			->willReturn($form);
+
+		$this->formsService->expects($this->once())
+			->method('obtainFormLock')
+			->with($form);
+
+		$this->expectException(OCSBadRequestException::class);
+		$this->apiController->updateForm(1, ['notifyOwnerOnSubmission' => 'yes']);
+	}
+
 	public function testGetSubmission_invalidForm() {
 		$exception = $this->createMock(NoSuchFormException::class);
 		$this->formsService->expects($this->once())
@@ -1217,7 +1238,7 @@ class ApiControllerTest extends TestCase {
 
 		$this->formsService->expects($this->once())
 			->method('notifyNewSubmission')
-			->with($form, $submission);
+			->with($form, $submission, FormSubmittedEvent::TRIGGER_UPDATED);
 
 		$response = $this->apiController->updateSubmission($formId, $submissionId, $answers);
 		$this->assertEquals(new DataResponse($submissionId), $response);

--- a/tests/Unit/FormsMigratorTest.php
+++ b/tests/Unit/FormsMigratorTest.php
@@ -111,6 +111,7 @@ class FormsMigratorTest extends TestCase {
     "showExpiration": false,
     "lastUpdated": 123456789,
     "submissionMessage": "Back to website",
+    "notifyOwnerOnSubmission": false,
     "questions": [
       {
         "id": 14,
@@ -254,7 +255,7 @@ JSON
 	public function dataImport() {
 		return [
 			'exactlyOneOfEach' => [
-				'$inputJson' => '[{"title":"Link","description":"","created":1646251830,"access":{"permitAllUsers":false,"showToAllUsers":false},"expires":0,"state":0,"lockedBy":null,"lockedUntil":null,"maxSubmissions":null,"isAnonymous":false,"submitMultiple":false,"allowEditSubmissions":false,"showExpiration":false,"lastUpdated":123456789,"questions":[{"id":14,"order":2,"type":"multiple","isRequired":false,"text":"checkbox","description":"huhu","extraSettings":{},"options":[{"text":"ans1"}]}],"submissions":[{"userId":"anyUser@localhost","timestamp":1651354059,"answers":[{"questionId":14,"text":"ans1"}]}]}]'
+				'$inputJson' => '[{"title":"Link","description":"","created":1646251830,"access":{"permitAllUsers":false,"showToAllUsers":false},"expires":0,"state":0,"lockedBy":null,"lockedUntil":null,"isAnonymous":false,"submitMultiple":false,"allowEditSubmissions":false,"showExpiration":false,"lastUpdated":123456789,"questions":[{"id":14,"order":2,"type":"multiple","isRequired":false,"text":"checkbox","description":"huhu","extraSettings":{},"options":[{"text":"ans1"}]}],"submissions":[{"userId":"anyUser@localhost","timestamp":1651354059,"answers":[{"questionId":14,"text":"ans1"}]}]}]'
 			]
 		];
 	}

--- a/tests/Unit/FormsMigratorTest.php
+++ b/tests/Unit/FormsMigratorTest.php
@@ -112,6 +112,7 @@ class FormsMigratorTest extends TestCase {
     "lastUpdated": 123456789,
     "submissionMessage": "Back to website",
     "notifyOwnerOnSubmission": false,
+    "notificationRecipients": [],
     "questions": [
       {
         "id": 14,

--- a/tests/Unit/FormsMigratorTest.php
+++ b/tests/Unit/FormsMigratorTest.php
@@ -112,6 +112,7 @@ class FormsMigratorTest extends TestCase {
     "lastUpdated": 123456789,
     "submissionMessage": "Back to website",
     "notifyOwnerOnSubmission": false,
+    "attachSubmissionPdf": false,
     "notificationRecipients": [],
     "questions": [
       {

--- a/tests/Unit/Listener/OwnerNotificationListenerTest.php
+++ b/tests/Unit/Listener/OwnerNotificationListenerTest.php
@@ -114,6 +114,11 @@ class OwnerNotificationListenerTest extends TestCase {
 					return count($summaries) === 1
 						&& $summaries[0]['question'] === 'Question text'
 						&& $summaries[0]['answer'] === 'Short text answer';
+				}),
+				$this->callback(function (array $pdfEntries): bool {
+					return count($pdfEntries) === 1
+						&& $pdfEntries[0]['question'] === 'Question text'
+						&& $pdfEntries[0]['answer'] === 'Short text answer';
 				})
 			);
 
@@ -179,6 +184,11 @@ class OwnerNotificationListenerTest extends TestCase {
 					return count($summaries) === 1
 						&& $summaries[0]['question'] === 'Question text'
 						&& $summaries[0]['answer'] === 'Short text answer';
+				}),
+				$this->callback(function (array $pdfEntries): bool {
+					return count($pdfEntries) === 1
+						&& $pdfEntries[0]['question'] === 'Question text'
+						&& $pdfEntries[0]['answer'] === 'Short text answer';
 				})
 			);
 
@@ -230,6 +240,7 @@ class OwnerNotificationListenerTest extends TestCase {
 		$form->setLockedUntil(null);
 		$form->setSubmissionMessage(null);
 		$form->setNotifyOwnerOnSubmission(false);
+		$form->setAttachSubmissionPdf(false);
 		$form->setNotificationRecipients([]);
 
 		return $form;

--- a/tests/Unit/Listener/OwnerNotificationListenerTest.php
+++ b/tests/Unit/Listener/OwnerNotificationListenerTest.php
@@ -1,0 +1,192 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Forms\Tests\Unit\Listener;
+
+use OCA\Forms\Constants;
+use OCA\Forms\Db\Answer;
+use OCA\Forms\Db\AnswerMapper;
+use OCA\Forms\Db\Form;
+use OCA\Forms\Db\Question;
+use OCA\Forms\Db\QuestionMapper;
+use OCA\Forms\Db\Submission;
+use OCA\Forms\Events\FormSubmittedEvent;
+use OCA\Forms\Listener\OwnerNotificationListener;
+use OCA\Forms\Service\OwnerNotificationMailService;
+use OCP\IUser;
+use OCP\IUserManager;
+use PHPUnit\Framework\MockObject\MockObject;
+use Psr\Log\LoggerInterface;
+use Test\TestCase;
+
+class OwnerNotificationListenerTest extends TestCase {
+	/** @var OwnerNotificationMailService|MockObject */
+	private $mailService;
+	/** @var AnswerMapper|MockObject */
+	private $answerMapper;
+	/** @var QuestionMapper|MockObject */
+	private $questionMapper;
+	/** @var IUserManager|MockObject */
+	private $userManager;
+	/** @var LoggerInterface|MockObject */
+	private $logger;
+
+	private OwnerNotificationListener $listener;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->mailService = $this->createMock(OwnerNotificationMailService::class);
+		$this->answerMapper = $this->createMock(AnswerMapper::class);
+		$this->questionMapper = $this->createMock(QuestionMapper::class);
+		$this->userManager = $this->createMock(IUserManager::class);
+		$this->logger = $this->createMock(LoggerInterface::class);
+
+		$this->listener = new OwnerNotificationListener(
+			$this->mailService,
+			$this->answerMapper,
+			$this->questionMapper,
+			$this->userManager,
+			$this->logger,
+		);
+	}
+
+	public function testHandleSendsOwnerNotification(): void {
+		$form = $this->createForm();
+		$form->setNotifyOwnerOnSubmission(true);
+
+		$submission = $this->createSubmission(11, $form->getId());
+		$event = new FormSubmittedEvent($form, $submission);
+
+		$owner = $this->createMock(IUser::class);
+		$owner->expects($this->once())
+			->method('getEMailAddress')
+			->willReturn('owner@example.com');
+
+		$this->userManager->expects($this->once())
+			->method('get')
+			->with('owner')
+			->willReturn($owner);
+
+		$answer = new Answer();
+		$answer->setQuestionId(22);
+		$answer->setSubmissionId(11);
+		$answer->setText('Short text answer');
+
+		$question = new Question();
+		$question->setId(22);
+		$question->setFormId($form->getId());
+		$question->setType(Constants::ANSWER_TYPE_SHORT);
+		$question->setText('Question text');
+		$question->setDescription('');
+		$question->setName('');
+		$question->setOrder(1);
+		$question->setIsRequired(false);
+		$question->setExtraSettings([]);
+
+		$this->answerMapper->expects($this->once())
+			->method('findBySubmission')
+			->with(11)
+			->willReturn([$answer]);
+
+		$this->questionMapper->expects($this->once())
+			->method('findById')
+			->with(22)
+			->willReturn($question);
+
+		$this->mailService->expects($this->once())
+			->method('send')
+			->with(
+				$this->identicalTo($form),
+				$this->identicalTo($submission),
+				$this->callback(function (array $recipients): bool {
+					return $recipients === ['owner@example.com'];
+				}),
+				$this->callback(function (array $summaries): bool {
+					return count($summaries) === 1
+						&& $summaries[0]['question'] === 'Question text'
+						&& $summaries[0]['answer'] === 'Short text answer';
+				})
+			);
+
+		$this->listener->handle($event);
+	}
+
+	public function testHandleSkipsUpdatedSubmissions(): void {
+		$form = $this->createForm();
+		$submission = $this->createSubmission(11, $form->getId());
+		$event = new FormSubmittedEvent($form, $submission, FormSubmittedEvent::TRIGGER_UPDATED);
+
+		$this->answerMapper->expects($this->never())
+			->method('findBySubmission');
+		$this->mailService->expects($this->never())
+			->method('send');
+
+		$this->listener->handle($event);
+	}
+
+	public function testHandleSkipsWhenOwnerHasNoMailAddress(): void {
+		$form = $this->createForm();
+		$form->setNotifyOwnerOnSubmission(true);
+
+		$submission = $this->createSubmission(11, $form->getId());
+		$event = new FormSubmittedEvent($form, $submission);
+
+		$owner = $this->createMock(IUser::class);
+		$owner->expects($this->once())
+			->method('getEMailAddress')
+			->willReturn('');
+
+		$this->userManager->expects($this->once())
+			->method('get')
+			->with('owner')
+			->willReturn($owner);
+
+		$this->answerMapper->expects($this->never())
+			->method('findBySubmission');
+		$this->mailService->expects($this->never())
+			->method('send');
+
+		$this->listener->handle($event);
+	}
+
+	private function createForm(): Form {
+		$form = new Form();
+		$form->setId(1);
+		$form->setTitle('Test form');
+		$form->setOwnerId('owner');
+		$form->setDescription('');
+		$form->setFileId(null);
+		$form->setFileFormat(null);
+		$form->setCreated(0);
+		$form->setExpires(0);
+		$form->setIsAnonymous(false);
+		$form->setSubmitMultiple(false);
+		$form->setAllowEditSubmissions(false);
+		$form->setShowExpiration(false);
+		$form->setLastUpdated(0);
+		$form->setState(Constants::FORM_STATE_ACTIVE);
+		$form->setLockedBy(null);
+		$form->setLockedUntil(null);
+		$form->setSubmissionMessage(null);
+		$form->setNotifyOwnerOnSubmission(false);
+
+		return $form;
+	}
+
+	private function createSubmission(int $id, int $formId): Submission {
+		$submission = new Submission();
+		$submission->setId($id);
+		$submission->setFormId($formId);
+		$submission->setUserId('submitter');
+		$submission->setTimestamp(time());
+
+		return $submission;
+	}
+}

--- a/tests/Unit/Listener/OwnerNotificationListenerTest.php
+++ b/tests/Unit/Listener/OwnerNotificationListenerTest.php
@@ -57,9 +57,10 @@ class OwnerNotificationListenerTest extends TestCase {
 		);
 	}
 
-	public function testHandleSendsOwnerNotification(): void {
+	public function testHandleSendsOwnerAndExternalNotifications(): void {
 		$form = $this->createForm();
 		$form->setNotifyOwnerOnSubmission(true);
+		$form->setNotificationRecipients(['external@example.com']);
 
 		$submission = $this->createSubmission(11, $form->getId());
 		$event = new FormSubmittedEvent($form, $submission);
@@ -106,7 +107,8 @@ class OwnerNotificationListenerTest extends TestCase {
 				$this->identicalTo($form),
 				$this->identicalTo($submission),
 				$this->callback(function (array $recipients): bool {
-					return $recipients === ['owner@example.com'];
+					sort($recipients);
+					return $recipients === ['external@example.com', 'owner@example.com'];
 				}),
 				$this->callback(function (array $summaries): bool {
 					return count($summaries) === 1
@@ -131,7 +133,59 @@ class OwnerNotificationListenerTest extends TestCase {
 		$this->listener->handle($event);
 	}
 
-	public function testHandleSkipsWhenOwnerHasNoMailAddress(): void {
+	public function testHandleSendsExternalNotificationsWithoutOwnerNotification(): void {
+		$form = $this->createForm();
+		$form->setNotificationRecipients(['external@example.com']);
+
+		$submission = $this->createSubmission(11, $form->getId());
+		$event = new FormSubmittedEvent($form, $submission);
+
+		$this->userManager->expects($this->never())
+			->method('get');
+
+		$answer = new Answer();
+		$answer->setQuestionId(22);
+		$answer->setSubmissionId(11);
+		$answer->setText('Short text answer');
+
+		$question = new Question();
+		$question->setId(22);
+		$question->setFormId($form->getId());
+		$question->setType(Constants::ANSWER_TYPE_SHORT);
+		$question->setText('Question text');
+		$question->setDescription('');
+		$question->setName('');
+		$question->setOrder(1);
+		$question->setIsRequired(false);
+		$question->setExtraSettings([]);
+
+		$this->answerMapper->expects($this->once())
+			->method('findBySubmission')
+			->with(11)
+			->willReturn([$answer]);
+
+		$this->questionMapper->expects($this->once())
+			->method('findById')
+			->with(22)
+			->willReturn($question);
+
+		$this->mailService->expects($this->once())
+			->method('send')
+			->with(
+				$this->identicalTo($form),
+				$this->identicalTo($submission),
+				['external@example.com'],
+				$this->callback(function (array $summaries): bool {
+					return count($summaries) === 1
+						&& $summaries[0]['question'] === 'Question text'
+						&& $summaries[0]['answer'] === 'Short text answer';
+				})
+			);
+
+		$this->listener->handle($event);
+	}
+
+	public function testHandleSkipsWhenOwnerHasNoMailAddressAndNoExternalRecipients(): void {
 		$form = $this->createForm();
 		$form->setNotifyOwnerOnSubmission(true);
 
@@ -176,6 +230,7 @@ class OwnerNotificationListenerTest extends TestCase {
 		$form->setLockedUntil(null);
 		$form->setSubmissionMessage(null);
 		$form->setNotifyOwnerOnSubmission(false);
+		$form->setNotificationRecipients([]);
 
 		return $form;
 	}

--- a/tests/Unit/Service/FormsServiceTest.php
+++ b/tests/Unit/Service/FormsServiceTest.php
@@ -257,6 +257,7 @@ class FormsServiceTest extends TestCase {
 				'lockedUntil' => null,
 				'maxSubmissions' => null,
 				'isMaxSubmissionsReached' => false,
+				'notifyOwnerOnSubmission' => false,
 			]]
 		];
 	}

--- a/tests/Unit/Service/FormsServiceTest.php
+++ b/tests/Unit/Service/FormsServiceTest.php
@@ -258,6 +258,7 @@ class FormsServiceTest extends TestCase {
 				'maxSubmissions' => null,
 				'isMaxSubmissionsReached' => false,
 				'notifyOwnerOnSubmission' => false,
+				'attachSubmissionPdf' => false,
 				'notificationRecipients' => [],
 			]]
 		];
@@ -480,6 +481,7 @@ class FormsServiceTest extends TestCase {
 				'lockedUntil' => null,
 				'maxSubmissions' => null,
 				'isMaxSubmissionsReached' => false,
+				'attachSubmissionPdf' => false,
 			]]
 		];
 	}

--- a/tests/Unit/Service/FormsServiceTest.php
+++ b/tests/Unit/Service/FormsServiceTest.php
@@ -258,6 +258,7 @@ class FormsServiceTest extends TestCase {
 				'maxSubmissions' => null,
 				'isMaxSubmissionsReached' => false,
 				'notifyOwnerOnSubmission' => false,
+				'notificationRecipients' => [],
 			]]
 		];
 	}

--- a/tests/Unit/Service/SubmissionPdfServiceTest.php
+++ b/tests/Unit/Service/SubmissionPdfServiceTest.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Forms\Tests\Unit\Service;
+
+use OCA\Forms\Db\Form;
+use OCA\Forms\Db\Submission;
+use OCA\Forms\Service\SubmissionPdfService;
+use OCP\IL10N;
+use Test\TestCase;
+
+class SubmissionPdfServiceTest extends TestCase {
+	public function testCreatePdfIncludesSubmissionMetadataAndResponses(): void {
+		$service = $this->createService();
+		$form = new Form();
+		$form->setTitle('Customer Survey');
+		$submission = new Submission();
+		$submission->setId(99);
+		$submission->setTimestamp(1700000000);
+
+		$pdf = $service->createPdf($form, $submission, [
+			[
+				'question' => 'Email',
+				'answer' => 'user@example.com',
+			],
+		]);
+
+		$this->assertTrue(str_starts_with($pdf, '%PDF-1.4'));
+		$this->assertStringContainsString('Nextcloud Forms submission', $pdf);
+		$this->assertStringContainsString('Form: Customer Survey', $pdf);
+		$this->assertStringContainsString('Submission ID: 99', $pdf);
+		$this->assertStringContainsString('Email', $pdf);
+		$this->assertStringContainsString('user@example.com', $pdf);
+	}
+
+	public function testCreatePdfUsesFallbackTextForMissingResponses(): void {
+		$service = $this->createService();
+		$form = new Form();
+		$form->setTitle('Customer Survey');
+		$submission = new Submission();
+		$submission->setId(100);
+		$submission->setTimestamp(1700000000);
+
+		$pdf = $service->createPdf($form, $submission);
+
+		$this->assertStringContainsString('- No responses captured', $pdf);
+	}
+
+	public function testCreatePdfSpansMultiplePagesWithoutTruncation(): void {
+		$service = $this->createService();
+		$form = new Form();
+		$form->setTitle('Customer Survey');
+		$submission = new Submission();
+		$submission->setId(101);
+		$submission->setTimestamp(1700000000);
+
+		$entries = [];
+		for ($i = 1; $i <= 30; $i++) {
+			$entries[] = [
+				'question' => 'Question ' . $i,
+				'answer' => 'answer-' . $i,
+			];
+		}
+
+		$pdf = $service->createPdf($form, $submission, $entries);
+
+		$this->assertStringContainsString('/Count 2', $pdf);
+		$this->assertStringContainsString('answer-30', $pdf);
+	}
+
+	public function testCreateFilenameSanitizesFormTitle(): void {
+		$service = $this->createService();
+		$form = new Form();
+		$form->setTitle('  Customer Survey: 2026 / Berlin?  ');
+		$submission = new Submission();
+		$submission->setId(123);
+
+		$filename = $service->createFilename($form, $submission);
+
+		$this->assertSame('Customer_Survey__2026___Berlin-submission-123.pdf', $filename);
+	}
+
+	public function testCreateFilenameUsesDefaultForEmptyTitle(): void {
+		$service = $this->createService();
+		$form = new Form();
+		$form->setTitle('   ');
+		$submission = new Submission();
+		$submission->setId(7);
+
+		$filename = $service->createFilename($form, $submission);
+
+		$this->assertSame('form-submission-7.pdf', $filename);
+	}
+
+	private function createService(): SubmissionPdfService {
+		$l10n = $this->createMock(IL10N::class);
+		$l10n->expects($this->any())
+			->method('t')
+			->willReturnCallback(static function (string $text, ...$params): string {
+				$replace = (isset($params[0]) && is_array($params[0])) ? $params[0] : [];
+				return $replace === [] ? $text : vsprintf($text, $replace);
+			});
+
+		return new SubmissionPdfService($l10n);
+	}
+}


### PR DESCRIPTION
## What this changes

- Adds submission notification mails for new responses using the configured system mail account.
- Lets form owners opt into owner notifications and configure additional external notification recipients per form.
- Lets forms attach a generated PDF copy of the submission to those notification mails.
- Validates and normalizes configured recipient addresses in the API and settings UI, and covers the notification / attachment flow with unit and integration tests.

## Related issues

- #1233
- #1810
- #883

## Notes

- Additional recipients are independent of the owner-notification switch, so a form can notify external addresses without mailing the owner.
- The mail body keeps the inline summary focused on short and long text answers; enabling the PDF attachment adds a portable copy of the captured submission data for forwarding and archiving.
- Leaves generated locale catalogs out of the PR because Nextcloud translations are handled through Transifex.

## Validation

- Nextcloud 33: unit and integration suites passed.
- Nextcloud 31: unit and integration suites passed.
