### PR TITLE
feat(forms): add respondent confirmation emails with optional email verification

### DIFF
--- a/docs/API_v3.md
+++ b/docs/API_v3.md
@@ -439,6 +439,7 @@ Update a single or multiple properties of a question-object.
 - Restrictions:
     - It is **not allowed** to update one of the following key-value pairs: _id, formId, order_.
     - `extraSettings.confirmationRecipient` can only be enabled for short questions with `extraSettings.validationType` set to `email`.
+    - `extraSettings.requireEmailVerification` can only be enabled for short questions with `extraSettings.validationType` set to `email` and `extraSettings.confirmationRecipient` set to `true`.
 - Response: **Status-Code OK**, as well as the id of the updated question.
 
 ```
@@ -904,6 +905,7 @@ Store Submission to Database
     - For Question-Types with pre-defined answers (`multiple`, `multiple_unique`, `dropdown`), the array contains the corresponding option-IDs.
     - For File-Uploads, the array contains the objects with key `uploadedFileId` (value from Upload a file endpoint).
     - To send a respondent confirmation email, set the corresponding short question to `validationType = email` and `confirmationRecipient = true`.
+    - If the same question also sets `requireEmailVerification = true`, the submission stays pending until the recipient visits the verification link, and the confirmation email is only sent after verification succeeds.
 
 ```
   {

--- a/docs/API_v3.md
+++ b/docs/API_v3.md
@@ -436,7 +436,9 @@ Update a single or multiple properties of a question-object.
   | Parameter | Type | Description |
   |-----------|---------|-------------|
   | _keyValuePairs_ | Array | Array of key-value pairs to update |
-- Restrictions: It is **not allowed** to update one of the following key-value pairs: _id, formId, order_.
+- Restrictions:
+    - It is **not allowed** to update one of the following key-value pairs: _id, formId, order_.
+    - `extraSettings.confirmationRecipient` can only be enabled for short questions with `extraSettings.validationType` set to `email`.
 - Response: **Status-Code OK**, as well as the id of the updated question.
 
 ```
@@ -901,6 +903,7 @@ Store Submission to Database
     - An **array** of values as value --> Even for short Text Answers, wrapped into Array.
     - For Question-Types with pre-defined answers (`multiple`, `multiple_unique`, `dropdown`), the array contains the corresponding option-IDs.
     - For File-Uploads, the array contains the objects with key `uploadedFileId` (value from Upload a file endpoint).
+    - To send a respondent confirmation email, set the corresponding short question to `validationType = email` and `confirmationRecipient = true`.
 
 ```
   {

--- a/docs/DataStructure.md
+++ b/docs/DataStructure.md
@@ -148,6 +148,7 @@ A submission-object describes a single submission by a user to a form.
 | formId | Integer | | The id of the form, the submission belongs to |
 | userId | String | | The nextcloud userId of the submitting user. If submission is anonymous, this contains `anon-user-<hash>` |
 | timestamp | unix timestamp | | When the user submitted |
+| isVerified | Boolean | | Whether the submission has completed email-address verification, if required |
 | answers | Array of [Answers](#answer) | | Array of the actual user answers, belonging to this submission.
 | userDisplayName | String | | Display name of the nextcloud-user, derived from `userId`. Contains `Anonymous user` if submitted anonymously. Not stored in DB.
 
@@ -157,6 +158,7 @@ A submission-object describes a single submission by a user to a form.
   "formId": 3,
   "userId": "jonas",
   "timestamp": 1611274433,
+  "isVerified": true,
   "answers": [],
   "userDisplayName": "jonas"
 }
@@ -241,6 +243,7 @@ Optional extra settings for some [Question Types](#question-types)
 | `validationType`        | `short`                               | string           | `null, 'phone', 'email', 'regex', 'number'` | Custom validation for checking a submission                                 |
 | `validationRegex`       | `short`                               | string           | regular expression                          | if `validationType` is 'regex' this defines the regular expression to apply |
 | `confirmationRecipient` | `short`                               | Boolean          | `true/false`                                | Marks an email question as recipient for respondent confirmation emails      |
+| `requireEmailVerification` | `short`                            | Boolean          | `true/false`                                | Requires respondents to verify the confirmation-recipient email before the submission is treated as verified                    |
 | `allowedFileTypes`      | `file`                                | Array of strings | `'image', 'x-office/document'`              | Allowed file types for file upload                                          |
 | `allowedFileExtensions` | `file`                                | Array of strings | `'jpg', 'png'`                              | Allowed file extensions for file upload                                     |
 | `maxAllowedFilesCount`  | `file`                                | Integer          | -                                           | Maximum number of files that can be uploaded, 0 means no limit              |

--- a/docs/DataStructure.md
+++ b/docs/DataStructure.md
@@ -240,6 +240,7 @@ Optional extra settings for some [Question Types](#question-types)
 | `optionsLimitMin`       | `multiple`                            | Integer          | -                                           | Minimum number of options that must be selected                             |
 | `validationType`        | `short`                               | string           | `null, 'phone', 'email', 'regex', 'number'` | Custom validation for checking a submission                                 |
 | `validationRegex`       | `short`                               | string           | regular expression                          | if `validationType` is 'regex' this defines the regular expression to apply |
+| `confirmationRecipient` | `short`                               | Boolean          | `true/false`                                | Marks an email question as recipient for respondent confirmation emails      |
 | `allowedFileTypes`      | `file`                                | Array of strings | `'image', 'x-office/document'`              | Allowed file types for file upload                                          |
 | `allowedFileExtensions` | `file`                                | Array of strings | `'jpg', 'png'`                              | Allowed file extensions for file upload                                     |
 | `maxAllowedFilesCount`  | `file`                                | Integer          | -                                           | Maximum number of files that can be uploaded, 0 means no limit              |

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -11,8 +11,10 @@ namespace OCA\Forms\AppInfo;
 
 use OCA\Analytics\Datasource\DatasourceEvent;
 use OCA\Forms\Capabilities;
+use OCA\Forms\Events\FormSubmittedEvent;
 use OCA\Forms\FormsMigrator;
 use OCA\Forms\Listener\AnalyticsDatasourceListener;
+use OCA\Forms\Listener\ConfirmationEmailListener;
 use OCA\Forms\Listener\UserDeletedListener;
 use OCA\Forms\Middleware\ThrottleFormAccessMiddleware;
 use OCA\Forms\Search\SearchProvider;
@@ -43,6 +45,7 @@ class Application extends App implements IBootstrap {
 
 		$context->registerCapability(Capabilities::class);
 		$context->registerEventListener(UserDeletedEvent::class, UserDeletedListener::class);
+		$context->registerEventListener(FormSubmittedEvent::class, ConfirmationEmailListener::class);
 		$context->registerEventListener(DatasourceEvent::class, AnalyticsDatasourceListener::class);
 		$context->registerMiddleware(ThrottleFormAccessMiddleware::class);
 		$context->registerSearchProvider(SearchProvider::class);

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -15,6 +15,7 @@ use OCA\Forms\Events\FormSubmittedEvent;
 use OCA\Forms\FormsMigrator;
 use OCA\Forms\Listener\AnalyticsDatasourceListener;
 use OCA\Forms\Listener\ConfirmationEmailListener;
+use OCA\Forms\Listener\SubmissionVerificationListener;
 use OCA\Forms\Listener\UserDeletedListener;
 use OCA\Forms\Middleware\ThrottleFormAccessMiddleware;
 use OCA\Forms\Search\SearchProvider;
@@ -45,6 +46,7 @@ class Application extends App implements IBootstrap {
 
 		$context->registerCapability(Capabilities::class);
 		$context->registerEventListener(UserDeletedEvent::class, UserDeletedListener::class);
+		$context->registerEventListener(FormSubmittedEvent::class, SubmissionVerificationListener::class);
 		$context->registerEventListener(FormSubmittedEvent::class, ConfirmationEmailListener::class);
 		$context->registerEventListener(DatasourceEvent::class, AnalyticsDatasourceListener::class);
 		$context->registerMiddleware(ThrottleFormAccessMiddleware::class);

--- a/lib/Constants.php
+++ b/lib/Constants.php
@@ -150,6 +150,7 @@ class Constants {
 		'validationType' => ['string'],
 		'validationRegex' => ['string'],
 		'confirmationRecipient' => ['boolean'],
+		'requireEmailVerification' => ['boolean'],
 	];
 
 	public const EXTRA_SETTINGS_FILE = [

--- a/lib/Constants.php
+++ b/lib/Constants.php
@@ -149,6 +149,7 @@ class Constants {
 	public const EXTRA_SETTINGS_SHORT = [
 		'validationType' => ['string'],
 		'validationRegex' => ['string'],
+		'confirmationRecipient' => ['boolean'],
 	];
 
 	public const EXTRA_SETTINGS_FILE = [

--- a/lib/Controller/ApiController.php
+++ b/lib/Controller/ApiController.php
@@ -22,6 +22,7 @@ use OCA\Forms\Db\Submission;
 use OCA\Forms\Db\SubmissionMapper;
 use OCA\Forms\Db\UploadedFile;
 use OCA\Forms\Db\UploadedFileMapper;
+use OCA\Forms\Events\FormSubmittedEvent;
 use OCA\Forms\Exception\NoSuchFormException;
 use OCA\Forms\ResponseDefinitions;
 use OCA\Forms\Service\ConfigService;
@@ -546,6 +547,10 @@ class ApiController extends OCSController {
 			$questionData = $sourceQuestion->read();
 			unset($questionData['id']);
 			$questionData['order'] = end($allQuestions)->getOrder() + 1;
+			if (is_array($questionData['extraSettings'] ?? null)
+				&& ($questionData['extraSettings']['confirmationRecipient'] ?? false) === true) {
+				$questionData['extraSettings']['confirmationRecipient'] = false;
+			}
 
 			$newQuestion = Question::fromParams($questionData);
 			$this->questionMapper->insert($newQuestion);
@@ -648,6 +653,12 @@ class ApiController extends OCSController {
 		if (key_exists('extraSettings', $keyValuePairs) && !$this->formsService->areExtraSettingsValid($keyValuePairs['extraSettings'], $question->getType())) {
 			throw new OCSBadRequestException('Invalid extraSettings, will not update.');
 		}
+		$this->assertSingleConfirmationRecipientQuestion(
+			$formId,
+			$questionId,
+			$question->getType(),
+			is_array($keyValuePairs['extraSettings'] ?? null) ? $keyValuePairs['extraSettings'] : null,
+		);
 
 		// Create QuestionEntity with given Params & Id.
 		$question = Question::fromParams($keyValuePairs);
@@ -1405,7 +1416,7 @@ class ApiController extends OCSController {
 		$this->formMapper->update($form);
 
 		//Create Activity
-		$this->formsService->notifyNewSubmission($form, $submission);
+		$this->formsService->notifyNewSubmission($form, $submission, FormSubmittedEvent::TRIGGER_CREATED);
 
 		if ($form->getFileId() !== null) {
 			$this->jobList->add(SyncSubmissionsWithLinkedFileJob::class, ['form_id' => $form->getId()]);
@@ -1487,7 +1498,7 @@ class ApiController extends OCSController {
 		}
 
 		//Create Activity
-		$this->formsService->notifyNewSubmission($form, $submission);
+		$this->formsService->notifyNewSubmission($form, $submission, FormSubmittedEvent::TRIGGER_UPDATED);
 
 		return new DataResponse($submissionId);
 	}
@@ -1823,6 +1834,32 @@ class ApiController extends OCSController {
 				|| ($permitAll && !$this->configService->getAllowPermitAll())) {
 				$this->logger->info('Not allowed to update showToAllUsers or permitAllUsers');
 				throw new OCSForbiddenException();
+			}
+		}
+	}
+
+	/**
+	 * Ensure only one short-email question can be used as confirmation recipient in a form.
+	 *
+	 * @param array<string, mixed>|null $extraSettings
+	 */
+	private function assertSingleConfirmationRecipientQuestion(int $formId, int $questionId, string $questionType, ?array $extraSettings): void {
+		if ($questionType !== Constants::ANSWER_TYPE_SHORT || !is_array($extraSettings) || ($extraSettings['confirmationRecipient'] ?? false) !== true) {
+			return;
+		}
+
+		$formQuestions = $this->questionMapper->findByForm($formId);
+		foreach ($formQuestions as $formQuestion) {
+			if ($formQuestion->getId() === $questionId) {
+				continue;
+			}
+
+			$existingSettings = $formQuestion->getExtraSettings();
+			$isExistingConfirmationRecipient = $formQuestion->getType() === Constants::ANSWER_TYPE_SHORT
+				&& ($existingSettings['validationType'] ?? null) === 'email'
+				&& ($existingSettings['confirmationRecipient'] ?? false) === true;
+			if ($isExistingConfirmationRecipient) {
+				throw new OCSBadRequestException('Only one confirmation recipient question is allowed per form');
 			}
 		}
 	}

--- a/lib/Controller/ApiController.php
+++ b/lib/Controller/ApiController.php
@@ -550,6 +550,9 @@ class ApiController extends OCSController {
 			if (is_array($questionData['extraSettings'] ?? null)
 				&& ($questionData['extraSettings']['confirmationRecipient'] ?? false) === true) {
 				$questionData['extraSettings']['confirmationRecipient'] = false;
+				if (($questionData['extraSettings']['requireEmailVerification'] ?? false) === true) {
+					$questionData['extraSettings']['requireEmailVerification'] = false;
+				}
 			}
 
 			$newQuestion = Question::fromParams($questionData);
@@ -1371,6 +1374,7 @@ class ApiController extends OCSController {
 		$submission = new Submission();
 		$submission->setFormId($formId);
 		$submission->setTimestamp(time());
+		$submission->setIsVerified(true);
 
 		// If not logged in, anonymous, or embedded use anonID
 		if (!$this->currentUser || $form->getIsAnonymous()) {

--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -14,6 +14,7 @@ use OCA\Forms\Db\ShareMapper;
 use OCA\Forms\Db\SubmissionMapper;
 use OCA\Forms\Service\ConfigService;
 use OCA\Forms\Service\FormsService;
+use OCA\Forms\Service\SubmissionVerificationService;
 
 use OCP\Accounts\IAccountManager;
 use OCP\AppFramework\Controller;
@@ -49,6 +50,7 @@ class PageController extends Controller {
 		private SubmissionMapper $submissionMapper,
 		private ConfigService $configService,
 		private FormsService $formsService,
+		private SubmissionVerificationService $submissionVerificationService,
 		private IAccountManager $accountManager,
 		private IInitialState $initialState,
 		private IL10N $l10n,
@@ -116,6 +118,27 @@ class PageController extends Controller {
 	#[FrontpageRoute(verb: 'GET', url: '/{hash}/submit/{submissionId}', requirements: ['hash' => '[a-zA-Z0-9]{16,}', 'submissionId' => '\d+'])]
 	public function submitViewWithSubmission(string $hash, int $submissionId): TemplateResponse {
 		return $this->formMapper->findByHash($hash)->getAllowEditSubmissions() ? $this->index($hash, $submissionId) : $this->index($hash);
+	}
+
+	#[NoAdminRequired()]
+	#[NoCSRFRequired()]
+	#[PublicPage()]
+	#[FrontpageRoute(verb: 'GET', url: '/verify/{token}', requirements: ['token' => '[a-f0-9]{48}'])]
+	public function verifySubmissionEmail(string $token): PublicTemplateResponse {
+		$isVerified = $this->submissionVerificationService->verifyToken($token);
+
+		$response = new PublicTemplateResponse($this->appName, 'verify', [
+			'verified' => $isVerified,
+			'headline' => $isVerified
+				? $this->l10n->t('Email address verified')
+				: $this->l10n->t('Email verification failed'),
+			'message' => $isVerified
+				? $this->l10n->t('Your email address has been verified successfully. You can close this page now.')
+				: $this->l10n->t('The verification link is invalid or expired.'),
+		]);
+		$response->setHeaderTitle($this->l10n->t('Forms'));
+
+		return $response;
 	}
 
 	/**

--- a/lib/Db/Submission.php
+++ b/lib/Db/Submission.php
@@ -18,11 +18,14 @@ use OCP\AppFramework\Db\Entity;
  * @method void setUserId(string $value)
  * @method int getTimestamp()
  * @method void setTimestamp(integer $value)
+ * @method bool getIsVerified()
+ * @method void setIsVerified(bool $value)
  */
 class Submission extends Entity {
 	protected $formId;
 	protected $userId;
 	protected $timestamp;
+	protected $isVerified;
 
 	/**
 	 * Submission constructor.
@@ -30,6 +33,7 @@ class Submission extends Entity {
 	public function __construct() {
 		$this->addType('formId', 'integer');
 		$this->addType('timestamp', 'integer');
+		$this->addType('isVerified', 'boolean');
 	}
 
 	/**
@@ -38,6 +42,7 @@ class Submission extends Entity {
 	 *     formId: int,
 	 *     userId: string,
 	 *     timestamp: int,
+	 *     isVerified: bool,
 	 * }
 	 */
 	public function read(): array {
@@ -46,6 +51,7 @@ class Submission extends Entity {
 			'formId' => $this->getFormId(),
 			'userId' => $this->getUserId(),
 			'timestamp' => $this->getTimestamp(),
+			'isVerified' => (bool)$this->getIsVerified(),
 		];
 	}
 }

--- a/lib/Db/SubmissionVerification.php
+++ b/lib/Db/SubmissionVerification.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Forms\Db;
+
+use OCP\AppFramework\Db\Entity;
+
+/**
+ * @method int getSubmissionId()
+ * @method void setSubmissionId(int $value)
+ * @method string getRecipientEmailHash()
+ * @method void setRecipientEmailHash(string $value)
+ * @method string getTokenHash()
+ * @method void setTokenHash(string $value)
+ * @method int getExpires()
+ * @method void setExpires(int $value)
+ * @method int|null getUsed()
+ * @method void setUsed(?int $value)
+ */
+class SubmissionVerification extends Entity {
+	protected $submissionId;
+	protected $recipientEmailHash;
+	protected $tokenHash;
+	protected $expires;
+	protected $used;
+
+	public function __construct() {
+		$this->addType('submissionId', 'integer');
+		$this->addType('expires', 'integer');
+		$this->addType('used', 'integer');
+	}
+
+	/**
+	 * @return array{
+	 *   id: int,
+	 *   submissionId: int,
+	 *   recipientEmailHash: string,
+	 *   tokenHash: string,
+	 *   expires: int,
+	 *   used: int|null,
+	 * }
+	 */
+	public function read(): array {
+		return [
+			'id' => $this->getId(),
+			'submissionId' => $this->getSubmissionId(),
+			'recipientEmailHash' => $this->getRecipientEmailHash(),
+			'tokenHash' => $this->getTokenHash(),
+			'expires' => $this->getExpires(),
+			'used' => $this->getUsed(),
+		];
+	}
+}

--- a/lib/Db/SubmissionVerificationMapper.php
+++ b/lib/Db/SubmissionVerificationMapper.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Forms\Db;
+
+use OCP\AppFramework\Db\QBMapper;
+use OCP\DB\QueryBuilder\IQueryBuilder;
+use OCP\IDBConnection;
+
+/**
+ * @extends QBMapper<SubmissionVerification>
+ */
+class SubmissionVerificationMapper extends QBMapper {
+	public function __construct(IDBConnection $db) {
+		parent::__construct($db, 'forms_v2_submission_verify', SubmissionVerification::class);
+	}
+
+	/**
+	 * @throws \OCP\AppFramework\Db\DoesNotExistException
+	 * @throws \OCP\AppFramework\Db\MultipleObjectsReturnedException
+	 */
+	public function findBySubmissionId(int $submissionId): SubmissionVerification {
+		$qb = $this->db->getQueryBuilder();
+
+		$qb->select('*')
+			->from($this->getTableName())
+			->where(
+				$qb->expr()->eq('submission_id', $qb->createNamedParameter($submissionId, IQueryBuilder::PARAM_INT))
+			);
+
+		return $this->findEntity($qb);
+	}
+
+	/**
+	 * @throws \OCP\AppFramework\Db\DoesNotExistException
+	 * @throws \OCP\AppFramework\Db\MultipleObjectsReturnedException
+	 */
+	public function findByTokenHash(string $tokenHash): SubmissionVerification {
+		$qb = $this->db->getQueryBuilder();
+
+		$qb->select('*')
+			->from($this->getTableName())
+			->where(
+				$qb->expr()->eq('token_hash', $qb->createNamedParameter($tokenHash, IQueryBuilder::PARAM_STR))
+			);
+
+		return $this->findEntity($qb);
+	}
+}

--- a/lib/Events/FormSubmittedEvent.php
+++ b/lib/Events/FormSubmittedEvent.php
@@ -11,17 +11,34 @@ use OCA\Forms\Db\Form;
 use OCA\Forms\Db\Submission;
 
 class FormSubmittedEvent extends AbstractFormEvent {
+	public const TRIGGER_CREATED = 'created';
+	public const TRIGGER_UPDATED = 'updated';
+
 	public function __construct(
 		Form $form,
 		private Submission $submission,
+		private string $trigger = self::TRIGGER_CREATED,
 	) {
 		parent::__construct($form);
+	}
+
+	public function getSubmission(): Submission {
+		return $this->submission;
+	}
+
+	public function getTrigger(): string {
+		return $this->trigger;
+	}
+
+	public function isNewSubmission(): bool {
+		return $this->trigger === self::TRIGGER_CREATED;
 	}
 
 	public function getWebhookSerializable(): array {
 		return [
 			'form' => $this->form->read(),
 			'submission' => $this->submission->read(),
+			'trigger' => $this->trigger,
 		];
 	}
 }

--- a/lib/Events/FormSubmittedEvent.php
+++ b/lib/Events/FormSubmittedEvent.php
@@ -13,6 +13,7 @@ use OCA\Forms\Db\Submission;
 class FormSubmittedEvent extends AbstractFormEvent {
 	public const TRIGGER_CREATED = 'created';
 	public const TRIGGER_UPDATED = 'updated';
+	public const TRIGGER_VERIFIED = 'verified';
 
 	public function __construct(
 		Form $form,

--- a/lib/FormsMigrator.php
+++ b/lib/FormsMigrator.php
@@ -182,6 +182,7 @@ class FormsMigrator implements IMigrator {
 					$submission->setFormId($form->getId());
 					$submission->setUserId($submissionData['userId']);
 					$submission->setTimestamp($submissionData['timestamp']);
+					$submission->setIsVerified($submissionData['isVerified'] ?? true);
 
 					$this->submissionMapper->insert($submission);
 

--- a/lib/Listener/ConfirmationEmailListener.php
+++ b/lib/Listener/ConfirmationEmailListener.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Forms\Listener;
+
+use OCA\Forms\Constants;
+use OCA\Forms\Db\AnswerMapper;
+use OCA\Forms\Db\QuestionMapper;
+use OCA\Forms\Events\FormSubmittedEvent;
+use OCA\Forms\Service\ConfirmationMailService;
+use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\EventDispatcher\Event;
+use OCP\EventDispatcher\IEventListener;
+use Psr\Log\LoggerInterface;
+
+/**
+ * @implements IEventListener<FormSubmittedEvent>
+ */
+class ConfirmationEmailListener implements IEventListener {
+	public function __construct(
+		private ConfirmationMailService $confirmationMailService,
+		private AnswerMapper $answerMapper,
+		private QuestionMapper $questionMapper,
+		private LoggerInterface $logger,
+	) {
+	}
+
+	public function handle(Event $event): void {
+		if (!($event instanceof FormSubmittedEvent)) {
+			return;
+		}
+		if (!$event->isNewSubmission()) {
+			return;
+		}
+
+		$submission = $event->getSubmission();
+		$form = $event->getForm();
+
+		$emailAddress = null;
+		$answerSummaries = [];
+		try {
+			$answers = $this->answerMapper->findBySubmission($submission->getId());
+		} catch (DoesNotExistException $e) {
+			return;
+		}
+		$hasAmbiguousRecipients = false;
+
+		foreach ($answers as $answer) {
+			try {
+				$question = $this->questionMapper->findById($answer->getQuestionId());
+			} catch (DoesNotExistException $e) {
+				$this->logger->warning('Question missing while preparing confirmation mail', [
+					'formId' => $form->getId(),
+					'submissionId' => $submission->getId(),
+					'questionId' => $answer->getQuestionId(),
+				]);
+				continue;
+			}
+
+			$questionType = $question->getType();
+			$answerText = trim($answer->getText() ?? '');
+
+			$extraSettings = $question->getExtraSettings();
+			$isEmailQuestion = $questionType === Constants::ANSWER_TYPE_SHORT
+				&& (($extraSettings['validationType'] ?? null) === 'email');
+			$isConfirmationRecipient = ($extraSettings['confirmationRecipient'] ?? false) === true;
+
+			if ($answerText !== '' && $isEmailQuestion && $isConfirmationRecipient) {
+				if ($emailAddress !== null && !hash_equals($emailAddress, $answerText)) {
+					$hasAmbiguousRecipients = true;
+					break;
+				}
+				$emailAddress = $answerText;
+			}
+
+			if (
+				$answerText !== ''
+				&& in_array($questionType, [Constants::ANSWER_TYPE_SHORT, Constants::ANSWER_TYPE_LONG], true)
+			) {
+				$answerSummaries[] = [
+					'question' => $question->getText(),
+					'answer' => $answerText,
+				];
+			}
+		}
+		if ($hasAmbiguousRecipients) {
+			$this->logger->warning('Skipping confirmation mail because multiple confirmation recipient questions were answered', [
+				'formId' => $form->getId(),
+				'submissionId' => $submission->getId(),
+			]);
+			return;
+		}
+
+		if ($emailAddress === null) {
+			return;
+		}
+
+		$this->confirmationMailService->send($form, $submission, $emailAddress, $answerSummaries);
+	}
+}

--- a/lib/Listener/ConfirmationEmailListener.php
+++ b/lib/Listener/ConfirmationEmailListener.php
@@ -35,12 +35,15 @@ class ConfirmationEmailListener implements IEventListener {
 		if (!($event instanceof FormSubmittedEvent)) {
 			return;
 		}
-		if (!$event->isNewSubmission()) {
+		if (!in_array($event->getTrigger(), [FormSubmittedEvent::TRIGGER_CREATED, FormSubmittedEvent::TRIGGER_VERIFIED], true)) {
 			return;
 		}
 
 		$submission = $event->getSubmission();
 		$form = $event->getForm();
+		if ($event->getTrigger() === FormSubmittedEvent::TRIGGER_CREATED && $submission->getIsVerified() === false) {
+			return;
+		}
 
 		$emailAddress = null;
 		$answerSummaries = [];

--- a/lib/Listener/SubmissionVerificationListener.php
+++ b/lib/Listener/SubmissionVerificationListener.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Forms\Listener;
+
+use OCA\Forms\Constants;
+use OCA\Forms\Db\AnswerMapper;
+use OCA\Forms\Db\QuestionMapper;
+use OCA\Forms\Events\FormSubmittedEvent;
+use OCA\Forms\Service\SubmissionVerificationMailService;
+use OCA\Forms\Service\SubmissionVerificationService;
+use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\EventDispatcher\Event;
+use OCP\EventDispatcher\IEventListener;
+use OCP\Mail\IMailer;
+use Psr\Log\LoggerInterface;
+
+/**
+ * @implements IEventListener<FormSubmittedEvent>
+ */
+class SubmissionVerificationListener implements IEventListener {
+	public function __construct(
+		private AnswerMapper $answerMapper,
+		private QuestionMapper $questionMapper,
+		private SubmissionVerificationService $submissionVerificationService,
+		private SubmissionVerificationMailService $submissionVerificationMailService,
+		private IMailer $mailer,
+		private LoggerInterface $logger,
+	) {
+	}
+
+	public function handle(Event $event): void {
+		if (!($event instanceof FormSubmittedEvent)) {
+			return;
+		}
+		if ($event->getTrigger() !== FormSubmittedEvent::TRIGGER_CREATED) {
+			return;
+		}
+
+		$form = $event->getForm();
+		$submission = $event->getSubmission();
+		$emailForVerification = null;
+		try {
+			$answers = $this->answerMapper->findBySubmission($submission->getId());
+		} catch (DoesNotExistException $e) {
+			$this->submissionVerificationService->markVerified($submission);
+			return;
+		}
+
+		foreach ($answers as $answer) {
+			try {
+				$question = $this->questionMapper->findById($answer->getQuestionId());
+			} catch (DoesNotExistException $e) {
+				$this->logger->warning('Question missing while preparing submission verification mail', [
+					'formId' => $form->getId(),
+					'submissionId' => $submission->getId(),
+					'questionId' => $answer->getQuestionId(),
+				]);
+				continue;
+			}
+
+			$extraSettings = $question->getExtraSettings();
+			$isVerificationQuestion = $question->getType() === Constants::ANSWER_TYPE_SHORT
+				&& ($extraSettings['validationType'] ?? null) === 'email'
+				&& ($extraSettings['confirmationRecipient'] ?? false) === true
+				&& ($extraSettings['requireEmailVerification'] ?? false) === true;
+
+			if (!$isVerificationQuestion) {
+				continue;
+			}
+
+			$answerText = trim($answer->getText() ?? '');
+			if ($answerText !== '') {
+				$emailForVerification = $answerText;
+				break;
+			}
+		}
+
+		if ($emailForVerification === null) {
+			$this->submissionVerificationService->markVerified($submission);
+			return;
+		}
+
+		if (!$this->mailer->validateMailAddress($emailForVerification)) {
+			$this->logger->warning('Skipping submission verification for invalid email address', [
+				'formId' => $form->getId(),
+				'submissionId' => $submission->getId(),
+			]);
+			return;
+		}
+
+		try {
+			$this->submissionVerificationService->markPendingVerification($submission);
+			$token = $this->submissionVerificationService->createVerificationToken($submission, $emailForVerification);
+			if ($token === null) {
+				return;
+			}
+
+			$verificationLink = $this->submissionVerificationService->createVerificationLink($token);
+			$this->submissionVerificationMailService->send($form, $submission, $emailForVerification, $verificationLink);
+		} catch (\Throwable $e) {
+			$this->logger->error('Failed to process submission verification', [
+				'formId' => $form->getId(),
+				'submissionId' => $submission->getId(),
+				'exception' => $e,
+			]);
+		}
+	}
+}

--- a/lib/Migration/Version050300Date20260228171000.php
+++ b/lib/Migration/Version050300Date20260228171000.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Forms\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\DB\QueryBuilder\IQueryBuilder;
+use OCP\DB\Types;
+use OCP\IDBConnection;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+class Version050300Date20260228171000 extends SimpleMigrationStep {
+
+	public function __construct(
+		protected IDBConnection $db,
+	) {
+	}
+
+	/**
+	 * @param IOutput $output
+	 * @param Closure $schemaClosure The `\Closure` returns a `ISchemaWrapper`
+	 * @param array $options
+	 * @return null|ISchemaWrapper
+	 */
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
+		/** @var ISchemaWrapper $schema */
+		$schema = $schemaClosure();
+
+		$submissionsTable = $schema->getTable('forms_v2_submissions');
+		if (!$submissionsTable->hasColumn('is_verified')) {
+			$submissionsTable->addColumn('is_verified', Types::BOOLEAN, [
+				'notnull' => false,
+				'default' => true,
+			]);
+		}
+
+		if (!$schema->hasTable('forms_v2_submission_verify')) {
+			$verificationTable = $schema->createTable('forms_v2_submission_verify');
+			$verificationTable->addColumn('id', Types::INTEGER, [
+				'autoincrement' => true,
+				'notnull' => true,
+			]);
+			$verificationTable->addColumn('submission_id', Types::INTEGER, [
+				'notnull' => true,
+			]);
+			$verificationTable->addColumn('recipient_email_hash', Types::STRING, [
+				'notnull' => true,
+				'length' => 64,
+			]);
+			$verificationTable->addColumn('token_hash', Types::STRING, [
+				'notnull' => true,
+				'length' => 64,
+			]);
+			$verificationTable->addColumn('expires', Types::INTEGER, [
+				'notnull' => true,
+				'comment' => 'unix-timestamp',
+			]);
+			$verificationTable->addColumn('used', Types::INTEGER, [
+				'notnull' => false,
+				'default' => null,
+				'comment' => 'unix-timestamp',
+			]);
+
+			$verificationTable->setPrimaryKey(['id'], 'forms_subv_id');
+			$verificationTable->addUniqueIndex(['submission_id'], 'forms_subv_sub_id');
+			$verificationTable->addUniqueIndex(['token_hash'], 'forms_subv_token_hash');
+		}
+
+		return $schema;
+	}
+
+	/**
+	 * @param IOutput $output
+	 * @param Closure(): ISchemaWrapper $schemaClosure
+	 * @param array $options
+	 */
+	public function postSchemaChange(IOutput $output, Closure $schemaClosure, array $options): void {
+		$qb = $this->db->getQueryBuilder();
+		$qb->update('forms_v2_submissions')
+			->set('is_verified', $qb->createNamedParameter(true, IQueryBuilder::PARAM_BOOL))
+			->where($qb->expr()->isNull('is_verified'))
+			->executeStatement();
+	}
+}

--- a/lib/ResponseDefinitions.php
+++ b/lib/ResponseDefinitions.php
@@ -40,6 +40,7 @@ namespace OCA\Forms;
  *   timeRange?: bool,
  *   validationRegex?: string,
  *   validationType?: string,
+ *   confirmationRecipient?: bool,
  *   questionType?: string,
  * }
  *
@@ -110,7 +111,6 @@ namespace OCA\Forms;
  *   state: int,
  *   lockedBy: ?string,
  *   lockedUntil: ?int,
- *   maxSubmissions: ?int,
  * }
  *
  * @psalm-type FormsForm = array{
@@ -126,7 +126,6 @@ namespace OCA\Forms;
  *   fileId: ?int,
  *   filePath?: ?string,
  *   isAnonymous: bool,
- *   isMaxSubmissionsReached: bool,
  *   lastUpdated: int,
  *   submitMultiple: bool,
  *   allowEditSubmissions: bool,
@@ -137,7 +136,6 @@ namespace OCA\Forms;
  *   state: 0|1|2,
  *   lockedBy: ?string,
  *   lockedUntil: ?int,
- *   maxSubmissions: ?int,
  *   shares: list<FormsShare>,
  *   submissionCount?: int,
  *   submissionMessage: ?string,

--- a/lib/ResponseDefinitions.php
+++ b/lib/ResponseDefinitions.php
@@ -41,6 +41,7 @@ namespace OCA\Forms;
  *   validationRegex?: string,
  *   validationType?: string,
  *   confirmationRecipient?: bool,
+ *   requireEmailVerification?: bool,
  *   questionType?: string,
  * }
  *
@@ -75,6 +76,7 @@ namespace OCA\Forms;
  *   formId: int,
  *   userId: string,
  *   timestamp: int,
+ *   isVerified: bool,
  *   answers: list<FormsAnswer>,
  *   userDisplayName: string
  * }

--- a/lib/Service/ConfirmationMailService.php
+++ b/lib/Service/ConfirmationMailService.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Forms\Service;
+
+use OCA\Forms\Db\Form;
+use OCA\Forms\Db\Submission;
+use OCP\IL10N;
+use OCP\Mail\Headers\AutoSubmitted;
+use OCP\Mail\IMailer;
+use Psr\Log\LoggerInterface;
+
+class ConfirmationMailService {
+	public function __construct(
+		private IMailer $mailer,
+		private IL10N $l10n,
+		private LoggerInterface $logger,
+	) {
+	}
+
+	/**
+	 * @param array<int, array{question: string, answer: string}> $answerSummaries
+	 */
+	public function send(Form $form, Submission $submission, string $recipient, array $answerSummaries = []): void {
+		if (!$this->mailer->validateMailAddress($recipient)) {
+			$this->logger->debug('Skipping confirmation mail, invalid recipient address', [
+				'formId' => $form->getId(),
+				'submissionId' => $submission->getId(),
+			]);
+			return;
+		}
+
+		$formTitle = $form->getTitle();
+		$subject = $this->l10n->t('Confirmation for your response to %s', [$formTitle]);
+
+		try {
+			// Create styled email template with Nextcloud branding
+			$emailTemplate = $this->mailer->createEMailTemplate('forms.ConfirmationEmail', [
+				'formTitle' => $formTitle,
+			]);
+
+			$emailTemplate->setSubject($subject);
+
+			// Add header with Nextcloud logo
+			$emailTemplate->addHeader();
+
+			// Add heading
+			$emailTemplate->addHeading($this->l10n->t('Form Submission Confirmed'));
+
+			// Add body text
+			$emailTemplate->addBodyText(
+				$this->l10n->t('Thank you for submitting the form %s. We have successfully received your response.', [$formTitle])
+			);
+
+			// Add submission summary if available
+			if ($answerSummaries !== []) {
+				$emailTemplate->addBodyText($this->l10n->t('Your responses:'));
+
+				foreach ($answerSummaries as $summary) {
+					$emailTemplate->addBodyListItem(
+						$summary['answer'],
+						$summary['question'],
+						'',
+						'',
+						''
+					);
+				}
+			}
+
+			// Add footer
+			$emailTemplate->addFooter(
+				$this->l10n->t('This message was sent automatically by %s.', [$this->l10n->t('Forms')])
+			);
+
+			$message = $this->mailer->createMessage();
+			$message->setAutoSubmitted(AutoSubmitted::VALUE_AUTO_GENERATED);
+			$message->setSubject($subject);
+			$message->setTo([$recipient]);
+			$message->useTemplate($emailTemplate);
+
+			$this->mailer->send($message);
+		} catch (\Throwable $e) {
+			$this->logger->error('Failed to send confirmation email for submission', [
+				'formId' => $form->getId(),
+				'submissionId' => $submission->getId(),
+				'exception' => $e,
+			]);
+		}
+	}
+}

--- a/lib/Service/FormsService.php
+++ b/lib/Service/FormsService.php
@@ -882,6 +882,16 @@ class FormsService {
 				}
 			}
 
+			if (($extraSettings['requireEmailVerification'] ?? false) === true) {
+				// Verification is only valid for the selected confirmation-recipient email field
+				if (
+					($extraSettings['validationType'] ?? null) !== 'email'
+					|| ($extraSettings['confirmationRecipient'] ?? false) !== true
+				) {
+					return false;
+				}
+			}
+
 			if (!isset($extraSettings['validationType'])) {
 				return true;
 			}

--- a/lib/Service/FormsService.php
+++ b/lib/Service/FormsService.php
@@ -709,7 +709,7 @@ class FormsService {
 	 * @param Form $form Related Form
 	 * @param string $submitter The ID of the user who submitted the form. Can also be our 'anon-user-'-ID
 	 */
-	public function notifyNewSubmission(Form $form, Submission $submission): void {
+	public function notifyNewSubmission(Form $form, Submission $submission, string $trigger = FormSubmittedEvent::TRIGGER_CREATED): void {
 		$shares = $this->getShares($form->getId());
 		try {
 			$this->activityManager->publishNewSubmission($form, $submission->getUserId());
@@ -738,7 +738,7 @@ class FormsService {
 			}
 		}
 
-		$this->eventDispatcher->dispatchTyped(new FormSubmittedEvent($form, $submission));
+		$this->eventDispatcher->dispatchTyped(new FormSubmittedEvent($form, $submission, $trigger));
 	}
 
 	/**
@@ -874,7 +874,18 @@ class FormsService {
 			}
 
 			// Special handling of short input for validation
-		} elseif ($questionType === Constants::ANSWER_TYPE_SHORT && isset($extraSettings['validationType'])) {
+		} elseif ($questionType === Constants::ANSWER_TYPE_SHORT) {
+			if (isset($extraSettings['confirmationRecipient'])) {
+				// Confirmation recipients must be explicit email fields
+				if (($extraSettings['validationType'] ?? null) !== 'email') {
+					return false;
+				}
+			}
+
+			if (!isset($extraSettings['validationType'])) {
+				return true;
+			}
+
 			// Ensure input validation type is known
 			if (!in_array($extraSettings['validationType'], Constants::SHORT_INPUT_TYPES)) {
 				return false;

--- a/lib/Service/SubmissionVerificationMailService.php
+++ b/lib/Service/SubmissionVerificationMailService.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Forms\Service;
+
+use OCA\Forms\Db\Form;
+use OCA\Forms\Db\Submission;
+use OCP\IL10N;
+use OCP\Mail\Headers\AutoSubmitted;
+use OCP\Mail\IMailer;
+use Psr\Log\LoggerInterface;
+
+class SubmissionVerificationMailService {
+	public function __construct(
+		private IMailer $mailer,
+		private IL10N $l10n,
+		private LoggerInterface $logger,
+	) {
+	}
+
+	public function send(Form $form, Submission $submission, string $recipient, string $verificationLink): void {
+		if (!$this->mailer->validateMailAddress($recipient)) {
+			$this->logger->debug('Skipping submission verification mail, invalid recipient address', [
+				'formId' => $form->getId(),
+				'submissionId' => $submission->getId(),
+			]);
+			return;
+		}
+
+		$formTitle = $form->getTitle();
+		$subject = $this->l10n->t('Verify your email for %s', [$formTitle]);
+
+		try {
+			$emailTemplate = $this->mailer->createEMailTemplate('forms.SubmissionVerificationEmail', [
+				'formTitle' => $formTitle,
+			]);
+
+			$emailTemplate->setSubject($subject);
+			$emailTemplate->addHeader();
+			$emailTemplate->addHeading($this->l10n->t('Verify your email address'));
+			$emailTemplate->addBodyText(
+				$this->l10n->t('A response was submitted to %s using this email address.', [$formTitle])
+			);
+			$emailTemplate->addBodyText(
+				$this->l10n->t('Please verify your email address to confirm ownership of this submission.')
+			);
+			$emailTemplate->addBodyButton($this->l10n->t('Verify email address'), $verificationLink);
+			$emailTemplate->addFooter(
+				$this->l10n->t('This message was sent automatically by %s.', [$this->l10n->t('Forms')])
+			);
+
+			$message = $this->mailer->createMessage();
+			$message->setAutoSubmitted(AutoSubmitted::VALUE_AUTO_GENERATED);
+			$message->setSubject($subject);
+			$message->setTo([$recipient]);
+			$message->useTemplate($emailTemplate);
+
+			$this->mailer->send($message);
+		} catch (\Throwable $e) {
+			$this->logger->error('Failed to send submission verification email', [
+				'formId' => $form->getId(),
+				'submissionId' => $submission->getId(),
+				'exception' => $e,
+			]);
+		}
+	}
+}

--- a/lib/Service/SubmissionVerificationService.php
+++ b/lib/Service/SubmissionVerificationService.php
@@ -1,0 +1,148 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Forms\Service;
+
+use OCA\Forms\Db\FormMapper;
+use OCA\Forms\Db\Submission;
+use OCA\Forms\Db\SubmissionMapper;
+use OCA\Forms\Db\SubmissionVerification;
+use OCA\Forms\Db\SubmissionVerificationMapper;
+use OCA\Forms\Events\FormSubmittedEvent;
+use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\EventDispatcher\IEventDispatcher;
+use OCP\IURLGenerator;
+use Psr\Log\LoggerInterface;
+
+class SubmissionVerificationService {
+	private const TOKEN_VALIDITY_SECONDS = 172800;
+
+	public function __construct(
+		private SubmissionVerificationMapper $submissionVerificationMapper,
+		private SubmissionMapper $submissionMapper,
+		private FormMapper $formMapper,
+		private IEventDispatcher $eventDispatcher,
+		private IURLGenerator $urlGenerator,
+		private LoggerInterface $logger,
+	) {
+	}
+
+	public function markPendingVerification(Submission $submission): void {
+		if ($submission->getIsVerified() === false) {
+			return;
+		}
+
+		$submission->setIsVerified(false);
+		$this->submissionMapper->update($submission);
+	}
+
+	public function markVerified(Submission $submission): void {
+		if ($submission->getIsVerified() === true) {
+			return;
+		}
+
+		$submission->setIsVerified(true);
+		$this->submissionMapper->update($submission);
+	}
+
+	public function createVerificationToken(Submission $submission, string $emailAddress): ?string {
+		$normalizedRecipientHash = $this->hashRecipient($emailAddress);
+		$currentTimestamp = time();
+
+		$verification = null;
+		try {
+			$verification = $this->submissionVerificationMapper->findBySubmissionId($submission->getId());
+		} catch (DoesNotExistException $e) {
+			// Fresh token, no pending verification for this submission yet.
+		}
+
+		if ($verification !== null
+			&& $verification->getUsed() === null
+			&& $verification->getExpires() >= $currentTimestamp
+			&& hash_equals($verification->getRecipientEmailHash(), $normalizedRecipientHash)
+		) {
+			// Avoid duplicate verification mails for unchanged pending verification.
+			return null;
+		}
+
+		$token = bin2hex(random_bytes(24));
+		$tokenHash = hash('sha256', $token);
+
+		if ($verification === null) {
+			$verification = new SubmissionVerification();
+			$verification->setSubmissionId($submission->getId());
+		}
+
+		$verification->setRecipientEmailHash($normalizedRecipientHash);
+		$verification->setTokenHash($tokenHash);
+		$verification->setExpires($currentTimestamp + self::TOKEN_VALIDITY_SECONDS);
+		$verification->setUsed(null);
+
+		if ($verification->getId() === null) {
+			$this->submissionVerificationMapper->insert($verification);
+		} else {
+			$this->submissionVerificationMapper->update($verification);
+		}
+
+		return $token;
+	}
+
+	public function createVerificationLink(string $token): string {
+		return $this->urlGenerator->linkToRouteAbsolute('forms.page.verifySubmissionEmail', [
+			'token' => $token,
+		]);
+	}
+
+	public function verifyToken(string $token): bool {
+		$tokenHash = hash('sha256', $token);
+
+		try {
+			$verification = $this->submissionVerificationMapper->findByTokenHash($tokenHash);
+		} catch (DoesNotExistException $e) {
+			return false;
+		}
+
+		$currentTimestamp = time();
+		if ($verification->getUsed() !== null || $verification->getExpires() < $currentTimestamp) {
+			return false;
+		}
+
+		try {
+			$submission = $this->submissionMapper->findById($verification->getSubmissionId());
+		} catch (DoesNotExistException $e) {
+			$this->logger->warning('Submission missing while verifying submission email', [
+				'submissionId' => $verification->getSubmissionId(),
+			]);
+			return false;
+		}
+
+		if ($submission->getIsVerified() === false) {
+			$submission->setIsVerified(true);
+			$this->submissionMapper->update($submission);
+		}
+
+		$verification->setUsed($currentTimestamp);
+		$this->submissionVerificationMapper->update($verification);
+		try {
+			$form = $this->formMapper->findById($submission->getFormId());
+			$this->eventDispatcher->dispatchTyped(new FormSubmittedEvent($form, $submission, FormSubmittedEvent::TRIGGER_VERIFIED));
+		} catch (DoesNotExistException $e) {
+			$this->logger->warning('Form missing while dispatching verification-completed submission event', [
+				'formId' => $submission->getFormId(),
+				'submissionId' => $submission->getId(),
+			]);
+		}
+
+		return true;
+	}
+
+	private function hashRecipient(string $emailAddress): string {
+		return hash('sha256', strtolower(trim($emailAddress)));
+	}
+}

--- a/openapi.json
+++ b/openapi.json
@@ -526,6 +526,9 @@
                     "confirmationRecipient": {
                         "type": "boolean"
                     },
+                    "requireEmailVerification": {
+                        "type": "boolean"
+                    },
                     "questionType": {
                         "type": "string"
                     }
@@ -598,6 +601,7 @@
                     "formId",
                     "userId",
                     "timestamp",
+                    "isVerified",
                     "answers",
                     "userDisplayName"
                 ],
@@ -616,6 +620,9 @@
                     "timestamp": {
                         "type": "integer",
                         "format": "int64"
+                    },
+                    "isVerified": {
+                        "type": "boolean"
                     },
                     "answers": {
                         "type": "array",

--- a/openapi.json
+++ b/openapi.json
@@ -106,7 +106,6 @@
                     "fileFormat",
                     "fileId",
                     "isAnonymous",
-                    "isMaxSubmissionsReached",
                     "lastUpdated",
                     "submitMultiple",
                     "allowEditSubmissions",
@@ -117,7 +116,6 @@
                     "state",
                     "lockedBy",
                     "lockedUntil",
-                    "maxSubmissions",
                     "shares",
                     "submissionMessage"
                 ],
@@ -165,9 +163,6 @@
                     "isAnonymous": {
                         "type": "boolean"
                     },
-                    "isMaxSubmissionsReached": {
-                        "type": "boolean"
-                    },
                     "lastUpdated": {
                         "type": "integer",
                         "format": "int64"
@@ -210,11 +205,6 @@
                         "nullable": true
                     },
                     "lockedUntil": {
-                        "type": "integer",
-                        "format": "int64",
-                        "nullable": true
-                    },
-                    "maxSubmissions": {
                         "type": "integer",
                         "format": "int64",
                         "nullable": true
@@ -317,8 +307,7 @@
                     "partial",
                     "state",
                     "lockedBy",
-                    "lockedUntil",
-                    "maxSubmissions"
+                    "lockedUntil"
                 ],
                 "properties": {
                     "id": {
@@ -356,11 +345,6 @@
                         "nullable": true
                     },
                     "lockedUntil": {
-                        "type": "integer",
-                        "format": "int64",
-                        "nullable": true
-                    },
-                    "maxSubmissions": {
                         "type": "integer",
                         "format": "int64",
                         "nullable": true
@@ -538,6 +522,9 @@
                     },
                     "validationType": {
                         "type": "string"
+                    },
+                    "confirmationRecipient": {
+                        "type": "boolean"
                     },
                     "questionType": {
                         "type": "string"

--- a/src/components/Questions/QuestionShort.vue
+++ b/src/components/Questions/QuestionShort.vue
@@ -12,8 +12,11 @@
 		<div class="question__content">
 			<input
 				ref="input"
-				:aria-labelledby="titleId"
-				:aria-describedby="description ? descriptionId : undefined"
+				:aria-label="
+					t('forms', 'A short answer for the question “{text}”', {
+						text,
+					})
+				"
 				:placeholder="submissionInputPlaceholder"
 				:disabled="!readOnly"
 				:name="name || undefined"
@@ -61,6 +64,17 @@
 						t(
 							'forms',
 							'Use this question as confirmation email recipient',
+						)
+					}}
+				</NcActionCheckbox>
+				<NcActionCheckbox
+					v-if="validationType === 'email' && confirmationRecipient"
+					:model-value="requireEmailVerification"
+					@update:model-value="onRequireEmailVerificationChange">
+					{{
+						t(
+							'forms',
+							'Require respondents to verify this email address',
 						)
 					}}
 				</NcActionCheckbox>
@@ -160,6 +174,10 @@ export default {
 		confirmationRecipient() {
 			return this.extraSettings?.confirmationRecipient === true
 		},
+
+		requireEmailVerification() {
+			return this.extraSettings?.requireEmailVerification === true
+		},
 	},
 
 	methods: {
@@ -202,16 +220,21 @@ export default {
 					validationType,
 					validationRegex: this.validationRegex,
 					confirmationRecipient: false,
+					requireEmailVerification: false,
 				})
 			} else {
 				// For all other types except regex we close the menu (for regex we keep it open to allow entering a regex)
 				this.isValidationTypeMenuOpen = false
+				const isEmailValidation = validationType === 'email'
 				this.onExtraSettingsChange({
 					validationType:
 						validationType === 'text' ? undefined : validationType,
-					confirmationRecipient:
-						validationType === 'email'
-							? this.confirmationRecipient
+					confirmationRecipient: isEmailValidation
+						? this.confirmationRecipient
+						: false,
+					requireEmailVerification:
+						isEmailValidation && this.confirmationRecipient
+							? this.requireEmailVerification
 							: false,
 				})
 			}
@@ -220,6 +243,14 @@ export default {
 		onConfirmationRecipientChange(value) {
 			this.onExtraSettingsChange({
 				confirmationRecipient: value === true,
+				requireEmailVerification:
+					value === true && this.requireEmailVerification,
+			})
+		},
+
+		onRequireEmailVerificationChange(value) {
+			this.onExtraSettingsChange({
+				requireEmailVerification: value === true,
 			})
 		},
 

--- a/src/components/Questions/QuestionShort.vue
+++ b/src/components/Questions/QuestionShort.vue
@@ -53,6 +53,17 @@
 					@update:model-value="onChangeValidationType(validationTypeName)">
 					{{ validationTypeObject.label }}
 				</NcActionRadio>
+				<NcActionCheckbox
+					v-if="validationType === 'email'"
+					:model-value="confirmationRecipient"
+					@update:model-value="onConfirmationRecipientChange">
+					{{
+						t(
+							'forms',
+							'Use this question as confirmation email recipient',
+						)
+					}}
+				</NcActionCheckbox>
 				<NcActionInput
 					v-if="validationType === 'regex'"
 					ref="regexInput"
@@ -72,6 +83,7 @@
 </template>
 
 <script>
+import NcActionCheckbox from '@nextcloud/vue/components/NcActionCheckbox'
 import NcActionInput from '@nextcloud/vue/components/NcActionInput'
 import NcActionRadio from '@nextcloud/vue/components/NcActionRadio'
 import NcActions from '@nextcloud/vue/components/NcActions'
@@ -88,6 +100,7 @@ export default {
 		IconRegex,
 		NcActions,
 		NcActionInput,
+		NcActionCheckbox,
 		NcActionRadio,
 		Question,
 	},
@@ -143,6 +156,10 @@ export default {
 		validationRegex() {
 			return this.extraSettings?.validationRegex || ''
 		},
+
+		confirmationRecipient() {
+			return this.extraSettings?.confirmationRecipient === true
+		},
 	},
 
 	methods: {
@@ -184,6 +201,7 @@ export default {
 				this.onExtraSettingsChange({
 					validationType,
 					validationRegex: this.validationRegex,
+					confirmationRecipient: false,
 				})
 			} else {
 				// For all other types except regex we close the menu (for regex we keep it open to allow entering a regex)
@@ -191,8 +209,18 @@ export default {
 				this.onExtraSettingsChange({
 					validationType:
 						validationType === 'text' ? undefined : validationType,
+					confirmationRecipient:
+						validationType === 'email'
+							? this.confirmationRecipient
+							: false,
 				})
 			}
+		},
+
+		onConfirmationRecipientChange(value) {
+			this.onExtraSettingsChange({
+				confirmationRecipient: value === true,
+			})
 		},
 
 		/**

--- a/src/components/Results/Submission.vue
+++ b/src/components/Results/Submission.vue
@@ -32,6 +32,20 @@
 		<p class="submission-date">
 			{{ submissionDateTime }}
 		</p>
+		<p
+			v-if="showVerificationStatus"
+			class="submission-verification"
+			:class="[
+				submission.isVerified
+					? 'submission-verification--verified'
+					: 'submission-verification--pending',
+			]">
+			{{
+				submission.isVerified
+					? t('forms', 'Email address verified')
+					: t('forms', 'Email address verification pending')
+			}}
+		</p>
 
 		<Answer
 			v-for="question in answeredQuestions"
@@ -110,6 +124,25 @@ export default {
 		// Format submission-timestamp to DateTime
 		submissionDateTime() {
 			return moment(this.submission.timestamp, 'X').format('LLLL')
+		},
+
+		showVerificationStatus() {
+			if (!Object.hasOwn(this.submission, 'isVerified')) {
+				return false
+			}
+
+			return this.questions.some((question) => {
+				if (question.type !== 'short') {
+					return false
+				}
+
+				const extraSettings = question.extraSettings || {}
+				return (
+					extraSettings.validationType === 'email'
+					&& extraSettings.confirmationRecipient === true
+					&& extraSettings.requireEmailVerification === true
+				)
+			})
 		},
 
 		/**
@@ -259,6 +292,20 @@ export default {
 	&-date {
 		color: var(--color-text-lighter);
 		margin-block-start: -8px;
+	}
+
+	&-verification {
+		margin-block: -4px 12px;
+		font-size: 13px;
+		color: var(--color-text-maxcontrast);
+
+		&--verified {
+			color: var(--color-success-text);
+		}
+
+		&--pending {
+			color: var(--color-warning-text);
+		}
 	}
 }
 </style>

--- a/templates/verify.php
+++ b/templates/verify.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+?>
+
+<div class="forms-verification<?php p($_['verified'] ? ' forms-verification--success' : ' forms-verification--error'); ?>">
+	<h2><?php p($_['headline']); ?></h2>
+	<p><?php p($_['message']); ?></p>
+</div>
+
+<style>
+.forms-verification {
+	max-width: 640px;
+	margin: 40px auto;
+	padding: 24px;
+	border-radius: 12px;
+	background: var(--color-main-background);
+	border: 1px solid var(--color-border);
+	box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.forms-verification--success {
+	border-inline-start: 6px solid var(--color-success);
+}
+
+.forms-verification--error {
+	border-inline-start: 6px solid var(--color-error);
+}
+
+.forms-verification h2 {
+	margin: 0 0 12px;
+}
+
+.forms-verification p {
+	margin: 0;
+	color: var(--color-text-maxcontrast);
+}
+</style>

--- a/tests/Integration/Api/ApiV3Test.php
+++ b/tests/Integration/Api/ApiV3Test.php
@@ -1113,6 +1113,7 @@ class ApiV3Test extends IntegrationBase {
 							'userId' => 'user1',
 							'userDisplayName' => 'User No. 1',
 							'timestamp' => 123456,
+							'isVerified' => true,
 							'answers' => [
 								[
 									// 'submissionId' => Checked dynamically
@@ -1134,6 +1135,7 @@ class ApiV3Test extends IntegrationBase {
 							'userId' => 'user2',
 							'userDisplayName' => 'user2',
 							'timestamp' => 12345,
+							'isVerified' => true,
 							'answers' => [
 								[
 									// 'submissionId' => Checked dynamically
@@ -1155,6 +1157,7 @@ class ApiV3Test extends IntegrationBase {
 							'userId' => 'user3',
 							'userDisplayName' => 'user3',
 							'timestamp' => 1234,
+							'isVerified' => true,
 							'answers' => [
 								[
 									// 'submissionId' => Checked dynamically
@@ -1384,6 +1387,7 @@ CSV
 			'userId' => 'test',
 			'userDisplayName' => 'Test Displayname',
 			'formId' => $this->testForms[0]['id'],
+			'isVerified' => true,
 			'answers' => [
 				[
 					'questionId' => $this->testForms[0]['questions'][0]['id'],

--- a/tests/Integration/Api/ApiV3Test.php
+++ b/tests/Integration/Api/ApiV3Test.php
@@ -255,7 +255,7 @@ class ApiV3Test extends IntegrationBase {
 		// Set up http Client
 		$this->http = new Client([
 			'base_uri' => 'http://localhost:8080/ocs/v2.php/apps/forms/',
-			'auth' => ['test', 'test'],
+			'auth' => ['test', self::TEST_USER_PASSWORD],
 			'headers' => [
 				'OCS-ApiRequest' => 'true',
 				'Accept' => 'application/json'

--- a/tests/Integration/Api/RespectAdminSettingsTest.php
+++ b/tests/Integration/Api/RespectAdminSettingsTest.php
@@ -165,7 +165,7 @@ class RespectAdminSettingsTest extends IntegrationBase {
 		// Set up http Client
 		$this->http = new Client([
 			'base_uri' => 'http://localhost:8080/ocs/v2.php/apps/forms/',
-			'auth' => ['test', 'test'],
+			'auth' => ['test', self::TEST_USER_PASSWORD],
 			'headers' => [
 				'OCS-ApiRequest' => 'true',
 				'Accept' => 'application/json'

--- a/tests/Integration/IntegrationBase.php
+++ b/tests/Integration/IntegrationBase.php
@@ -19,6 +19,8 @@ use Test\TestCase;
  * @group DB
  */
 class IntegrationBase extends TestCase {
+	protected const TEST_USER_PASSWORD = 'Forms-Test-Password-2026!';
+
 	/** @var Array */
 	protected $testForms;
 
@@ -44,7 +46,7 @@ class IntegrationBase extends TestCase {
 		foreach ($this->users as $userId => $displayName) {
 			$user = $userManager->get($userId);
 			if ($user === null) {
-				$user = $userManager->createUser($userId, $userId);
+				$user = $userManager->createUser($userId, self::TEST_USER_PASSWORD);
 			}
 			$user->setDisplayName($displayName);
 		}

--- a/tests/Integration/IntegrationBase.php
+++ b/tests/Integration/IntegrationBase.php
@@ -122,15 +122,18 @@ class IntegrationBase extends TestCase {
 
 			// Insert Submissions into DB
 			foreach (($form['submissions'] ?? []) as $suIndex => $submission) {
+				$isVerified = $submission['isVerified'] ?? true;
 				$qb->insert('forms_v2_submissions')
 					->values([
 						'form_id' => $qb->createNamedParameter($formId, IQueryBuilder::PARAM_INT),
 						'user_id' => $qb->createNamedParameter($submission['userId'], IQueryBuilder::PARAM_STR),
-						'timestamp' => $qb->createNamedParameter($submission['timestamp'], IQueryBuilder::PARAM_INT)
+						'timestamp' => $qb->createNamedParameter($submission['timestamp'], IQueryBuilder::PARAM_INT),
+						'is_verified' => $qb->createNamedParameter($isVerified, IQueryBuilder::PARAM_BOOL),
 					]);
 				$qb->executeStatement();
 				$submissionId = $qb->getLastInsertId();
 				$this->testForms[$index]['submissions'][$suIndex]['id'] = $submissionId;
+				$this->testForms[$index]['submissions'][$suIndex]['isVerified'] = $isVerified;
 
 				foreach ($submission['answers'] as $aIndex => $answer) {
 					$qb->insert('forms_v2_answers')

--- a/tests/Unit/Controller/ApiControllerTest.php
+++ b/tests/Unit/Controller/ApiControllerTest.php
@@ -43,6 +43,7 @@ use OCA\Forms\Db\ShareMapper;
 use OCA\Forms\Db\Submission;
 use OCA\Forms\Db\SubmissionMapper;
 use OCA\Forms\Db\UploadedFileMapper;
+use OCA\Forms\Events\FormSubmittedEvent;
 use OCA\Forms\Exception\NoSuchFormException;
 use OCA\Forms\Service\ConfigService;
 use OCA\Forms\Service\FormsService;
@@ -430,9 +431,8 @@ class ApiControllerTest extends TestCase {
 			->willReturn('formHash');
 		$expected = $expectedForm;
 		$expected['id'] = null;
-		// TODO fix test, currently unset because behaviour has changed
 		$expected['state'] = null;
-		$expected['lastUpdated'] = null;
+		$expected['lastUpdated'] = 0;
 		$this->formMapper->expects($this->once())
 			->method('insert')
 			->with(self::callback(self::createFormValidator($expected)))
@@ -1217,7 +1217,7 @@ class ApiControllerTest extends TestCase {
 
 		$this->formsService->expects($this->once())
 			->method('notifyNewSubmission')
-			->with($form, $submission);
+			->with($form, $submission, FormSubmittedEvent::TRIGGER_UPDATED);
 
 		$response = $this->apiController->updateSubmission($formId, $submissionId, $answers);
 		$this->assertEquals(new DataResponse($submissionId), $response);

--- a/tests/Unit/Controller/PageControllerTest.php
+++ b/tests/Unit/Controller/PageControllerTest.php
@@ -13,8 +13,10 @@ use OCA\Forms\Db\ShareMapper;
 use OCA\Forms\Db\SubmissionMapper;
 use OCA\Forms\Service\ConfigService;
 use OCA\Forms\Service\FormsService;
+use OCA\Forms\Service\SubmissionVerificationService;
 use OCP\Accounts\IAccountManager;
 use OCP\AppFramework\Http\ContentSecurityPolicy;
+use OCP\AppFramework\Http\Template\PublicTemplateResponse;
 use OCP\AppFramework\Http\TemplateResponse;
 use OCP\AppFramework\Services\IInitialState;
 use OCP\IL10N;
@@ -66,6 +68,8 @@ class PageControllerTest extends TestCase {
 
 	/** @var IUserSession|MockObject */
 	private $userSession;
+	/** @var SubmissionVerificationService|MockObject */
+	private $submissionVerificationService;
 
 	public function setUp(): void {
 		parent::setUp();
@@ -82,6 +86,7 @@ class PageControllerTest extends TestCase {
 		$this->urlGenerator = $this->createMock(IURLGenerator::class);
 		$this->userManager = $this->createMock(IUserManager::class);
 		$this->userSession = $this->createMock(IUserSession::class);
+		$this->submissionVerificationService = $this->createMock(SubmissionVerificationService::class);
 
 		$this->pageController = new PageController(
 			'forms',
@@ -91,6 +96,7 @@ class PageControllerTest extends TestCase {
 			$this->submissionMapper,
 			$this->configService,
 			$this->formsService,
+			$this->submissionVerificationService,
 			$this->accountManager,
 			$this->initialState,
 			$this->l10n,
@@ -108,5 +114,55 @@ class PageControllerTest extends TestCase {
 			->method('setContentSecurityPolicy')
 			->with(self::callback(fn (ContentSecurityPolicy $csp): bool => preg_match('/frame-ancestors[^;]* \*[ ;]/', $csp->buildPolicy()) !== false));
 		TestCase::invokePrivate($this->pageController, 'setEmbeddedCSP', [$response]);
+	}
+
+	public function testVerifySubmissionEmailSuccess(): void {
+		$token = '0123456789abcdef0123456789abcdef0123456789abcdef';
+		$this->submissionVerificationService->expects($this->once())
+			->method('verifyToken')
+			->with($token)
+			->willReturn(true);
+
+		$this->l10n->method('t')
+			->willReturnMap([
+				['Email address verified', [], 'Email address verified'],
+				['Your email address has been verified successfully. You can close this page now.', [], 'verified message'],
+				['Forms', [], 'Forms'],
+			]);
+
+		$response = $this->pageController->verifySubmissionEmail($token);
+
+		$this->assertInstanceOf(PublicTemplateResponse::class, $response);
+		$this->assertSame('verify', $response->getTemplateName());
+		$this->assertSame([
+			'verified' => true,
+			'headline' => 'Email address verified',
+			'message' => 'verified message',
+		], $response->getParams());
+	}
+
+	public function testVerifySubmissionEmailFailure(): void {
+		$token = 'fedcba9876543210fedcba9876543210fedcba9876543210';
+		$this->submissionVerificationService->expects($this->once())
+			->method('verifyToken')
+			->with($token)
+			->willReturn(false);
+
+		$this->l10n->method('t')
+			->willReturnMap([
+				['Email verification failed', [], 'Email verification failed'],
+				['The verification link is invalid or expired.', [], 'failed message'],
+				['Forms', [], 'Forms'],
+			]);
+
+		$response = $this->pageController->verifySubmissionEmail($token);
+
+		$this->assertInstanceOf(PublicTemplateResponse::class, $response);
+		$this->assertSame('verify', $response->getTemplateName());
+		$this->assertSame([
+			'verified' => false,
+			'headline' => 'Email verification failed',
+			'message' => 'failed message',
+		], $response->getParams());
 	}
 }

--- a/tests/Unit/Listener/ConfirmationEmailListenerTest.php
+++ b/tests/Unit/Listener/ConfirmationEmailListenerTest.php
@@ -1,0 +1,290 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Forms\Tests\Unit\Listener;
+
+use OCA\Forms\Constants;
+use OCA\Forms\Db\Answer;
+use OCA\Forms\Db\AnswerMapper;
+use OCA\Forms\Db\Form;
+use OCA\Forms\Db\Question;
+use OCA\Forms\Db\QuestionMapper;
+use OCA\Forms\Db\Submission;
+use OCA\Forms\Events\FormSubmittedEvent;
+use OCA\Forms\Listener\ConfirmationEmailListener;
+use OCA\Forms\Service\ConfirmationMailService;
+use OCP\AppFramework\Db\DoesNotExistException;
+use PHPUnit\Framework\MockObject\MockObject;
+use Psr\Log\LoggerInterface;
+use Test\TestCase;
+
+class ConfirmationEmailListenerTest extends TestCase {
+	/** @var ConfirmationMailService|MockObject */
+	private $mailService;
+
+	/** @var AnswerMapper|MockObject */
+	private $answerMapper;
+
+	/** @var QuestionMapper|MockObject */
+	private $questionMapper;
+
+	/** @var LoggerInterface|MockObject */
+	private $logger;
+
+	private ConfirmationEmailListener $listener;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->mailService = $this->createMock(ConfirmationMailService::class);
+		$this->answerMapper = $this->createMock(AnswerMapper::class);
+		$this->questionMapper = $this->createMock(QuestionMapper::class);
+		$this->logger = $this->createMock(LoggerInterface::class);
+
+		$this->listener = new ConfirmationEmailListener(
+			$this->mailService,
+			$this->answerMapper,
+			$this->questionMapper,
+			$this->logger,
+		);
+	}
+
+	public function testHandleSendsConfirmationMail(): void {
+		$form = $this->createForm(7, 'Feedback form');
+		$submission = $this->createSubmission(12, $form->getId());
+		$event = new FormSubmittedEvent($form, $submission);
+
+		$emailAnswer = $this->createAnswer(101, 'user@example.com', $submission->getId());
+		$textAnswer = $this->createAnswer(102, 'Looks great!', $submission->getId());
+
+		$this->answerMapper->expects($this->once())
+			->method('findBySubmission')
+			->with($submission->getId())
+			->willReturn([$emailAnswer, $textAnswer]);
+
+		$emailQuestion = $this->createQuestion(101, Constants::ANSWER_TYPE_SHORT, 'Email address', [
+			'validationType' => 'email',
+			'confirmationRecipient' => true,
+		]);
+		$textQuestion = $this->createQuestion(102, Constants::ANSWER_TYPE_SHORT, 'Comment');
+
+		$this->questionMapper->expects($this->exactly(2))
+			->method('findById')
+			->willReturnCallback(function (int $questionId) use ($emailQuestion, $textQuestion): Question {
+				return match ($questionId) {
+					101 => $emailQuestion,
+					102 => $textQuestion,
+					default => throw new \RuntimeException('Unexpected question id'),
+				};
+			});
+
+		$this->mailService->expects($this->once())
+			->method('send')
+			->with(
+				$this->identicalTo($form),
+				$this->identicalTo($submission),
+				'user@example.com',
+				$this->callback(function (array $summaries): bool {
+					if (count($summaries) !== 2) {
+						return false;
+					}
+
+					$questions = array_column($summaries, 'question');
+					$answers = array_column($summaries, 'answer');
+
+					return in_array('Email address', $questions, true)
+						&& in_array('user@example.com', $answers, true)
+						&& in_array('Comment', $questions, true)
+						&& in_array('Looks great!', $answers, true);
+				})
+			);
+
+		$this->listener->handle($event);
+	}
+
+	public function testHandleWithEmailValidationButWithoutRecipientFlagSkipsMail(): void {
+		$form = $this->createForm(21, 'Survey');
+		$submission = $this->createSubmission(43, $form->getId());
+		$event = new FormSubmittedEvent($form, $submission);
+
+		$emailAnswer = $this->createAnswer(302, 'user@example.com', $submission->getId());
+
+		$this->answerMapper->expects($this->once())
+			->method('findBySubmission')
+			->with($submission->getId())
+			->willReturn([$emailAnswer]);
+
+		$emailQuestion = $this->createQuestion(302, Constants::ANSWER_TYPE_SHORT, 'Email', ['validationType' => 'email']);
+
+		$this->questionMapper->expects($this->once())
+			->method('findById')
+			->with(302)
+			->willReturn($emailQuestion);
+
+		$this->mailService->expects($this->never())
+			->method('send');
+
+		$this->listener->handle($event);
+	}
+
+	public function testHandleWithoutEmailSkipsMail(): void {
+		$form = $this->createForm(20, 'Survey');
+		$submission = $this->createSubmission(42, $form->getId());
+		$event = new FormSubmittedEvent($form, $submission);
+
+		$textAnswer = $this->createAnswer(301, 'No email provided', $submission->getId());
+
+		$this->answerMapper->expects($this->once())
+			->method('findBySubmission')
+			->with($submission->getId())
+			->willReturn([$textAnswer]);
+
+		$shortQuestion = $this->createQuestion(301, Constants::ANSWER_TYPE_SHORT, 'Comment');
+
+		$this->questionMapper->expects($this->once())
+			->method('findById')
+			->with(301)
+			->willReturn($shortQuestion);
+
+		$this->mailService->expects($this->never())
+			->method('send');
+
+		$this->listener->handle($event);
+	}
+
+	public function testHandleSkipsUpdatedSubmissions(): void {
+		$form = $this->createForm(20, 'Survey');
+		$submission = $this->createSubmission(42, $form->getId());
+		$event = new FormSubmittedEvent($form, $submission, FormSubmittedEvent::TRIGGER_UPDATED);
+
+		$this->answerMapper->expects($this->never())
+			->method('findBySubmission');
+
+		$this->mailService->expects($this->never())
+			->method('send');
+
+		$this->listener->handle($event);
+	}
+
+	public function testHandleWithoutStoredAnswersSkipsMail(): void {
+		$form = $this->createForm(20, 'Survey');
+		$submission = $this->createSubmission(42, $form->getId());
+		$event = new FormSubmittedEvent($form, $submission);
+
+		$this->answerMapper->expects($this->once())
+			->method('findBySubmission')
+			->willThrowException(new DoesNotExistException('No answers'));
+
+		$this->mailService->expects($this->never())
+			->method('send');
+
+		$this->listener->handle($event);
+	}
+
+	public function testHandleWithMultipleRecipientQuestionsSkipsMail(): void {
+		$form = $this->createForm(7, 'Feedback form');
+		$submission = $this->createSubmission(12, $form->getId());
+		$event = new FormSubmittedEvent($form, $submission);
+
+		$firstEmailAnswer = $this->createAnswer(101, 'first@example.com', $submission->getId());
+		$secondEmailAnswer = $this->createAnswer(102, 'second@example.com', $submission->getId());
+
+		$this->answerMapper->expects($this->once())
+			->method('findBySubmission')
+			->with($submission->getId())
+			->willReturn([$firstEmailAnswer, $secondEmailAnswer]);
+
+		$firstEmailQuestion = $this->createQuestion(101, Constants::ANSWER_TYPE_SHORT, 'Email address', [
+			'validationType' => 'email',
+			'confirmationRecipient' => true,
+		]);
+		$secondEmailQuestion = $this->createQuestion(102, Constants::ANSWER_TYPE_SHORT, 'Backup email address', [
+			'validationType' => 'email',
+			'confirmationRecipient' => true,
+		]);
+
+		$this->questionMapper->expects($this->exactly(2))
+			->method('findById')
+			->willReturnCallback(function (int $questionId) use ($firstEmailQuestion, $secondEmailQuestion): Question {
+				return match ($questionId) {
+					101 => $firstEmailQuestion,
+					102 => $secondEmailQuestion,
+					default => throw new \RuntimeException('Unexpected question id'),
+				};
+			});
+
+		$this->logger->expects($this->once())
+			->method('warning');
+
+		$this->mailService->expects($this->never())
+			->method('send');
+
+		$this->listener->handle($event);
+	}
+
+	private function createForm(int $id, string $title): Form {
+		$form = new Form();
+		$form->setId($id);
+		$form->setTitle($title);
+		$form->setDescription('');
+		$form->setOwnerId('owner');
+		$form->setFileId(null);
+		$form->setFileFormat(null);
+		$form->setCreated(0);
+		$form->setExpires(0);
+		$form->setIsAnonymous(false);
+		$form->setSubmitMultiple(false);
+		$form->setAllowEditSubmissions(false);
+		$form->setShowExpiration(false);
+		$form->setLastUpdated(0);
+		$form->setState(Constants::FORM_STATE_ACTIVE);
+		$form->setLockedBy(null);
+		$form->setLockedUntil(null);
+		$form->setSubmissionMessage(null);
+
+		return $form;
+	}
+
+	private function createSubmission(int $id, int $formId): Submission {
+		$submission = new Submission();
+		$submission->setId($id);
+		$submission->setFormId($formId);
+		$submission->setUserId('user');
+		$submission->setTimestamp(1);
+
+		return $submission;
+	}
+
+	private function createAnswer(int $questionId, string $text, int $submissionId): Answer {
+		$answer = new Answer();
+		$answer->setQuestionId($questionId);
+		$answer->setSubmissionId($submissionId);
+		$answer->setText($text);
+
+		return $answer;
+	}
+
+	/**
+	 * @param array<string, mixed> $extraSettings
+	 */
+	private function createQuestion(int $id, string $type, string $text, array $extraSettings = []): Question {
+		$question = new Question();
+		$question->setId($id);
+		$question->setFormId(0);
+		$question->setOrder(0);
+		$question->setType($type);
+		$question->setText($text);
+		$question->setDescription('');
+		$question->setIsRequired(false);
+		$question->setExtraSettings($extraSettings);
+		$question->setName('');
+
+		return $question;
+	}
+}

--- a/tests/Unit/Listener/ConfirmationEmailListenerTest.php
+++ b/tests/Unit/Listener/ConfirmationEmailListenerTest.php
@@ -228,6 +228,20 @@ class ConfirmationEmailListenerTest extends TestCase {
 		$this->listener->handle($event);
 	}
 
+	public function testHandleSkipsPendingVerificationOnCreate(): void {
+		$form = $this->createForm(7, 'Feedback form');
+		$submission = $this->createSubmission(12, $form->getId());
+		$submission->setIsVerified(false);
+		$event = new FormSubmittedEvent($form, $submission, FormSubmittedEvent::TRIGGER_CREATED);
+
+		$this->answerMapper->expects($this->never())
+			->method('findBySubmission');
+		$this->mailService->expects($this->never())
+			->method('send');
+
+		$this->listener->handle($event);
+	}
+
 	private function createForm(int $id, string $title): Form {
 		$form = new Form();
 		$form->setId($id);
@@ -257,6 +271,7 @@ class ConfirmationEmailListenerTest extends TestCase {
 		$submission->setFormId($formId);
 		$submission->setUserId('user');
 		$submission->setTimestamp(1);
+		$submission->setIsVerified(true);
 
 		return $submission;
 	}

--- a/tests/Unit/Listener/SubmissionVerificationListenerTest.php
+++ b/tests/Unit/Listener/SubmissionVerificationListenerTest.php
@@ -1,0 +1,219 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Forms\Tests\Unit\Listener;
+
+use OCA\Forms\Constants;
+use OCA\Forms\Db\Answer;
+use OCA\Forms\Db\AnswerMapper;
+use OCA\Forms\Db\Form;
+use OCA\Forms\Db\Question;
+use OCA\Forms\Db\QuestionMapper;
+use OCA\Forms\Db\Submission;
+use OCA\Forms\Events\FormSubmittedEvent;
+use OCA\Forms\Listener\SubmissionVerificationListener;
+use OCA\Forms\Service\SubmissionVerificationMailService;
+use OCA\Forms\Service\SubmissionVerificationService;
+use OCP\Mail\IMailer;
+use PHPUnit\Framework\MockObject\MockObject;
+use Psr\Log\LoggerInterface;
+use Test\TestCase;
+
+class SubmissionVerificationListenerTest extends TestCase {
+	/** @var AnswerMapper|MockObject */
+	private $answerMapper;
+	/** @var QuestionMapper|MockObject */
+	private $questionMapper;
+	/** @var SubmissionVerificationService|MockObject */
+	private $verificationService;
+	/** @var SubmissionVerificationMailService|MockObject */
+	private $mailService;
+	/** @var IMailer|MockObject */
+	private $mailer;
+	/** @var LoggerInterface|MockObject */
+	private $logger;
+
+	private SubmissionVerificationListener $listener;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->answerMapper = $this->createMock(AnswerMapper::class);
+		$this->questionMapper = $this->createMock(QuestionMapper::class);
+		$this->verificationService = $this->createMock(SubmissionVerificationService::class);
+		$this->mailService = $this->createMock(SubmissionVerificationMailService::class);
+		$this->mailer = $this->createMock(IMailer::class);
+		$this->logger = $this->createMock(LoggerInterface::class);
+
+		$this->listener = new SubmissionVerificationListener(
+			$this->answerMapper,
+			$this->questionMapper,
+			$this->verificationService,
+			$this->mailService,
+			$this->mailer,
+			$this->logger,
+		);
+	}
+
+	public function testHandleCreatesAndSendsVerificationToken(): void {
+		$form = $this->createForm();
+		$submission = $this->createSubmission(50, $form->getId());
+		$event = new FormSubmittedEvent($form, $submission);
+
+		$answer = new Answer();
+		$answer->setQuestionId(9);
+		$answer->setSubmissionId($submission->getId());
+		$answer->setText('user@example.com');
+
+		$question = new Question();
+		$question->setId(9);
+		$question->setFormId($form->getId());
+		$question->setType(Constants::ANSWER_TYPE_SHORT);
+		$question->setText('Email');
+		$question->setDescription('');
+		$question->setName('');
+		$question->setOrder(1);
+		$question->setIsRequired(true);
+		$question->setExtraSettings([
+			'validationType' => 'email',
+			'confirmationRecipient' => true,
+			'requireEmailVerification' => true,
+		]);
+
+		$this->answerMapper->expects($this->once())
+			->method('findBySubmission')
+			->with($submission->getId())
+			->willReturn([$answer]);
+
+		$this->questionMapper->expects($this->once())
+			->method('findById')
+			->with(9)
+			->willReturn($question);
+
+		$this->mailer->expects($this->once())
+			->method('validateMailAddress')
+			->with('user@example.com')
+			->willReturn(true);
+
+		$this->verificationService->expects($this->once())
+			->method('markPendingVerification')
+			->with($submission);
+
+		$this->verificationService->expects($this->once())
+			->method('createVerificationToken')
+			->with($submission, 'user@example.com')
+			->willReturn('0123456789abcdef0123456789abcdef0123456789abcdef');
+
+		$this->verificationService->expects($this->once())
+			->method('createVerificationLink')
+			->with('0123456789abcdef0123456789abcdef0123456789abcdef')
+			->willReturn('https://forms.example/verify');
+
+		$this->mailService->expects($this->once())
+			->method('send')
+			->with($form, $submission, 'user@example.com', 'https://forms.example/verify');
+
+		$this->verificationService->expects($this->never())
+			->method('markVerified');
+
+		$this->listener->handle($event);
+	}
+
+	public function testHandleWithoutVerificationQuestionMarksSubmissionVerified(): void {
+		$form = $this->createForm();
+		$submission = $this->createSubmission(51, $form->getId());
+		$event = new FormSubmittedEvent($form, $submission);
+
+		$answer = new Answer();
+		$answer->setQuestionId(10);
+		$answer->setSubmissionId($submission->getId());
+		$answer->setText('just text');
+
+		$question = new Question();
+		$question->setId(10);
+		$question->setFormId($form->getId());
+		$question->setType(Constants::ANSWER_TYPE_SHORT);
+		$question->setText('Comment');
+		$question->setDescription('');
+		$question->setName('');
+		$question->setOrder(1);
+		$question->setIsRequired(false);
+		$question->setExtraSettings([]);
+
+		$this->answerMapper->expects($this->once())
+			->method('findBySubmission')
+			->willReturn([$answer]);
+
+		$this->questionMapper->expects($this->once())
+			->method('findById')
+			->with(10)
+			->willReturn($question);
+
+		$this->verificationService->expects($this->once())
+			->method('markVerified')
+			->with($submission);
+
+		$this->verificationService->expects($this->never())
+			->method('markPendingVerification');
+
+		$this->mailService->expects($this->never())
+			->method('send');
+
+		$this->listener->handle($event);
+	}
+
+	public function testHandleSkipsNonCreatedTrigger(): void {
+		$form = $this->createForm();
+		$submission = $this->createSubmission(52, $form->getId());
+		$event = new FormSubmittedEvent($form, $submission, FormSubmittedEvent::TRIGGER_VERIFIED);
+
+		$this->answerMapper->expects($this->never())
+			->method('findBySubmission');
+		$this->verificationService->expects($this->never())
+			->method('markPendingVerification');
+		$this->mailService->expects($this->never())
+			->method('send');
+
+		$this->listener->handle($event);
+	}
+
+	private function createForm(): Form {
+		$form = new Form();
+		$form->setId(3);
+		$form->setTitle('Survey');
+		$form->setOwnerId('owner');
+		$form->setDescription('');
+		$form->setFileId(null);
+		$form->setFileFormat(null);
+		$form->setCreated(0);
+		$form->setExpires(0);
+		$form->setIsAnonymous(false);
+		$form->setSubmitMultiple(false);
+		$form->setAllowEditSubmissions(false);
+		$form->setShowExpiration(false);
+		$form->setLastUpdated(0);
+		$form->setState(Constants::FORM_STATE_ACTIVE);
+		$form->setLockedBy(null);
+		$form->setLockedUntil(null);
+		$form->setSubmissionMessage(null);
+
+		return $form;
+	}
+
+	private function createSubmission(int $id, int $formId): Submission {
+		$submission = new Submission();
+		$submission->setId($id);
+		$submission->setFormId($formId);
+		$submission->setUserId('user');
+		$submission->setTimestamp(time());
+		$submission->setIsVerified(true);
+
+		return $submission;
+	}
+}

--- a/tests/Unit/Service/FormsServiceTest.php
+++ b/tests/Unit/Service/FormsServiceTest.php
@@ -1347,6 +1347,32 @@ class FormsServiceTest extends TestCase {
 				'questionType' => Constants::ANSWER_TYPE_SHORT,
 				'expected' => true,
 			],
+			'valid-require-email-verification' => [
+				'extraSettings' => [
+					'validationType' => 'email',
+					'confirmationRecipient' => true,
+					'requireEmailVerification' => true,
+				],
+				'questionType' => Constants::ANSWER_TYPE_SHORT,
+				'expected' => true,
+			],
+			'invalid-require-email-verification-without-confirmation-recipient' => [
+				'extraSettings' => [
+					'validationType' => 'email',
+					'requireEmailVerification' => true,
+				],
+				'questionType' => Constants::ANSWER_TYPE_SHORT,
+				'expected' => false,
+			],
+			'invalid-require-email-verification-with-non-email-validation' => [
+				'extraSettings' => [
+					'validationType' => 'number',
+					'confirmationRecipient' => true,
+					'requireEmailVerification' => true,
+				],
+				'questionType' => Constants::ANSWER_TYPE_SHORT,
+				'expected' => false,
+			],
 			'invalid-confirmation-recipient-without-email-validation' => [
 				'extraSettings' => [
 					'confirmationRecipient' => true,

--- a/tests/Unit/Service/FormsServiceTest.php
+++ b/tests/Unit/Service/FormsServiceTest.php
@@ -1339,6 +1339,29 @@ class FormsServiceTest extends TestCase {
 				'questionType' => Constants::ANSWER_TYPE_SHORT,
 				'expected' => false
 			],
+			'valid-confirmation-recipient' => [
+				'extraSettings' => [
+					'validationType' => 'email',
+					'confirmationRecipient' => true,
+				],
+				'questionType' => Constants::ANSWER_TYPE_SHORT,
+				'expected' => true,
+			],
+			'invalid-confirmation-recipient-without-email-validation' => [
+				'extraSettings' => [
+					'confirmationRecipient' => true,
+				],
+				'questionType' => Constants::ANSWER_TYPE_SHORT,
+				'expected' => false,
+			],
+			'invalid-confirmation-recipient-with-non-email-validation' => [
+				'extraSettings' => [
+					'validationType' => 'number',
+					'confirmationRecipient' => true,
+				],
+				'questionType' => Constants::ANSWER_TYPE_SHORT,
+				'expected' => false,
+			],
 			'valid-custom-regex' => [
 				'extraSettings' => [
 					'validationType' => 'regex',

--- a/tests/Unit/Service/SubmissionServiceTest.php
+++ b/tests/Unit/Service/SubmissionServiceTest.php
@@ -149,6 +149,7 @@ class SubmissionServiceTest extends TestCase {
 		$submission_1->setFormId(5);
 		$submission_1->setUserId('someUser');
 		$submission_1->setTimestamp(123456);
+		$submission_1->setIsVerified(true);
 		$answer_1 = new Answer();
 		$answer_1->setId(35);
 		$answer_1->setSubmissionId(42);
@@ -165,6 +166,7 @@ class SubmissionServiceTest extends TestCase {
 		$submission_2->setFormId(5);
 		$submission_2->setUserId('someOtherUser');
 		$submission_2->setTimestamp(1234);
+		$submission_2->setIsVerified(true);
 
 		$this->submissionMapper->expects($this->any())
 			->method('findByForm')
@@ -189,6 +191,7 @@ class SubmissionServiceTest extends TestCase {
 				'formId' => 5,
 				'userId' => 'someUser',
 				'timestamp' => 123456,
+				'isVerified' => true,
 				'answers' => [
 					[
 						'id' => 35,
@@ -211,6 +214,7 @@ class SubmissionServiceTest extends TestCase {
 				'formId' => 5,
 				'userId' => 'someOtherUser',
 				'timestamp' => 1234,
+				'isVerified' => true,
 				'answers' => []
 			]
 		];
@@ -227,6 +231,7 @@ class SubmissionServiceTest extends TestCase {
 		$submission_1->setFormId(5);
 		$submission_1->setUserId('someUser');
 		$submission_1->setTimestamp(123456);
+		$submission_1->setIsVerified(true);
 		$answer_1 = new Answer();
 		$answer_1->setId(35);
 		$answer_1->setSubmissionId(42);
@@ -254,6 +259,7 @@ class SubmissionServiceTest extends TestCase {
 			'formId' => 5,
 			'userId' => 'someUser',
 			'timestamp' => 123456,
+			'isVerified' => true,
 			'answers' => [
 				[
 					'id' => 35,

--- a/tests/Unit/Service/SubmissionVerificationServiceTest.php
+++ b/tests/Unit/Service/SubmissionVerificationServiceTest.php
@@ -1,0 +1,143 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Forms\Tests\Unit\Service;
+
+use OCA\Forms\Db\Form;
+use OCA\Forms\Db\FormMapper;
+use OCA\Forms\Db\Submission;
+use OCA\Forms\Db\SubmissionMapper;
+use OCA\Forms\Db\SubmissionVerification;
+use OCA\Forms\Db\SubmissionVerificationMapper;
+use OCA\Forms\Events\FormSubmittedEvent;
+use OCA\Forms\Service\SubmissionVerificationService;
+use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\EventDispatcher\IEventDispatcher;
+use OCP\IURLGenerator;
+use PHPUnit\Framework\MockObject\MockObject;
+use Psr\Log\LoggerInterface;
+use Test\TestCase;
+
+class SubmissionVerificationServiceTest extends TestCase {
+	/** @var SubmissionVerificationMapper|MockObject */
+	private $verificationMapper;
+	/** @var SubmissionMapper|MockObject */
+	private $submissionMapper;
+	/** @var FormMapper|MockObject */
+	private $formMapper;
+	/** @var IEventDispatcher|MockObject */
+	private $eventDispatcher;
+	/** @var IURLGenerator|MockObject */
+	private $urlGenerator;
+	/** @var LoggerInterface|MockObject */
+	private $logger;
+
+	private SubmissionVerificationService $service;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->verificationMapper = $this->createMock(SubmissionVerificationMapper::class);
+		$this->submissionMapper = $this->createMock(SubmissionMapper::class);
+		$this->formMapper = $this->createMock(FormMapper::class);
+		$this->eventDispatcher = $this->createMock(IEventDispatcher::class);
+		$this->urlGenerator = $this->createMock(IURLGenerator::class);
+		$this->logger = $this->createMock(LoggerInterface::class);
+
+		$this->service = new SubmissionVerificationService(
+			$this->verificationMapper,
+			$this->submissionMapper,
+			$this->formMapper,
+			$this->eventDispatcher,
+			$this->urlGenerator,
+			$this->logger,
+		);
+	}
+
+	public function testCreateVerificationTokenCreatesRecordForNewSubmission(): void {
+		$submission = new Submission();
+		$submission->setId(42);
+		$submission->setIsVerified(false);
+
+		$this->verificationMapper->expects($this->once())
+			->method('findBySubmissionId')
+			->with(42)
+			->willThrowException(new DoesNotExistException('missing'));
+
+		$this->verificationMapper->expects($this->once())
+			->method('insert')
+			->with($this->callback(function (SubmissionVerification $verification): bool {
+				return $verification->getSubmissionId() === 42
+					&& strlen($verification->getTokenHash()) === 64
+					&& strlen($verification->getRecipientEmailHash()) === 64
+					&& $verification->getUsed() === null;
+			}));
+
+		$token = $this->service->createVerificationToken($submission, 'USER@example.com');
+
+		$this->assertNotNull($token);
+		$this->assertEquals(48, strlen((string)$token));
+	}
+
+	public function testVerifyTokenMarksSubmissionAsVerified(): void {
+		$token = '123456789012345678901234567890123456789012345678';
+		$verification = new SubmissionVerification();
+		$verification->setId(7);
+		$verification->setSubmissionId(123);
+		$verification->setRecipientEmailHash(hash('sha256', 'user@example.com'));
+		$verification->setTokenHash(hash('sha256', $token));
+		$verification->setExpires(time() + 3600);
+		$verification->setUsed(null);
+
+		$submission = new Submission();
+		$submission->setId(123);
+		$submission->setFormId(1);
+		$submission->setUserId('user');
+		$submission->setTimestamp(time());
+		$submission->setIsVerified(false);
+
+		$this->verificationMapper->expects($this->once())
+			->method('findByTokenHash')
+			->with(hash('sha256', $token))
+			->willReturn($verification);
+
+		$this->submissionMapper->expects($this->once())
+			->method('findById')
+			->with(123)
+			->willReturn($submission);
+
+		$this->submissionMapper->expects($this->once())
+			->method('update')
+			->with($this->callback(function (Submission $updated): bool {
+				return $updated->getId() === 123 && $updated->getIsVerified() === true;
+			}));
+
+		$form = new Form();
+		$form->setId(1);
+		$this->formMapper->expects($this->once())
+			->method('findById')
+			->with(1)
+			->willReturn($form);
+
+		$this->verificationMapper->expects($this->once())
+			->method('update')
+			->with($this->callback(function (SubmissionVerification $updated): bool {
+				return $updated->getId() === 7 && $updated->getUsed() !== null;
+			}));
+		$this->eventDispatcher->expects($this->once())
+			->method('dispatchTyped')
+			->with($this->callback(function (FormSubmittedEvent $event): bool {
+				return $event->getTrigger() === FormSubmittedEvent::TRIGGER_VERIFIED
+					&& $event->getSubmission()->getId() === 123
+					&& $event->getForm()->getId() === 1;
+			}));
+
+		$this->assertTrue($this->service->verifyToken($token));
+	}
+}


### PR DESCRIPTION
## What this changes

- Adds respondent confirmation mails for short questions that use email validation and are explicitly marked as the confirmation recipient in `extraSettings`.
- Adds an optional email verification flow for that recipient question. When verification is enabled, submissions stay unverified until the recipient uses the mailed verification link.
- Sends the confirmation mail only after the submission is verified, so verified flows do not acknowledge unverified addresses.
- Adds the public verification route, token persistence, and unit/integration coverage for the full submit -> verify -> confirm path.

## Related issues

- #1418
- #525

## Upstream context

- #3098 already proposes confirmation mails. This branch intentionally follows the review direction there by using an explicit recipient flag on the question instead of auto-picking an email field, and then extends that flow with email verification.
- `forms` currently supports Nextcloud 31-33. `OCP\\Mail\\IEmailValidator` is only available from Nextcloud 32 onward, so this implementation keeps `IMailer::validateMailAddress()` for 31 compatibility.

## Scope / non-goals

- Uses the configured system mail account and a fixed branded template.
- Does not add per-form sender selection or custom subject/body templating yet.
- Leaves generated locale catalogs out of the PR because Nextcloud translations are handled through Transifex.

## Validation

- Nextcloud 33: unit and integration suites passed.
- Nextcloud 31: unit and integration suites passed.
