### PR TITLE
feat: ranking question type

### DIFF
--- a/docs/DataStructure.md
+++ b/docs/DataStructure.md
@@ -224,49 +224,50 @@ Defines some extended options of sharing / access
 
 Currently supported Question-Types are:
 
-| Type-ID           | Description                                                                                                                                |
-| ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
-| `multiple`        | Typically known as 'Checkboxes'. Using pre-defined options, the user can select one or multiple from. Needs at least one option available. |
-| `multiple_unique` | Typically known as 'Radio Buttons'. Using pre-defined options, the user can select exactly one from. Needs at least one option available.  |
-| `dropdown`        | Similar to `multiple_unique`, but rendered as dropdown field.                                                                              |
-| `short`           | A short text answer. Single text line                                                                                                      |
-| `long`            | A long text answer. Multi-line supported                                                                                                   |
-| `date`            | Showing a dropdown calendar to select a date.                                                                                              |
-| _`datetime`_      | _deprecated: No longer available for new questions. Showing a dropdown calendar to select a date **and** a time._                          |
-| `time`            | Showing a dropdown menu to select a time.                                                                                                  |
-| `file`            | One or multiple files. It is possible to specify which mime types are allowed                                                              |
-| `linearscale`     | A linear or Likert scale question where you choose an option that best fits your opinion                                                   |
-| `color`           | A color answer, hex string representation (e. g. `#123456`)                                                                                |
+| Type-ID           | Description                                                                                                                                                                       |
+| ----------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `multiple`        | Typically known as 'Checkboxes'. Using pre-defined options, the user can select one or multiple from. Needs at least one option available.                                        |
+| `multiple_unique` | Typically known as 'Radio Buttons'. Using pre-defined options, the user can select exactly one from. Needs at least one option available.                                         |
+| `dropdown`        | Similar to `multiple_unique`, but rendered as dropdown field.                                                                                                                     |
+| `short`           | A short text answer. Single text line                                                                                                                                             |
+| `long`            | A long text answer. Multi-line supported                                                                                                                                          |
+| `date`            | Showing a dropdown calendar to select a date.                                                                                                                                     |
+| _`datetime`_      | _deprecated: No longer available for new questions. Showing a dropdown calendar to select a date **and** a time._                                                                 |
+| `time`            | Showing a dropdown menu to select a time.                                                                                                                                         |
+| `file`            | One or multiple files. It is possible to specify which mime types are allowed                                                                                                     |
+| `linearscale`     | A linear or Likert scale question where you choose an option that best fits your opinion                                                                                          |
+| `color`           | A color answer, hex string representation (e. g. `#123456`)                                                                                                                       |
+| `ranking`         | Using pre-defined options, the user ranks them from most to least preferred. Needs at least one option available. Answers are stored in ranked order (one answer row per option). |
 
 ## Extra Settings
 
 Optional extra settings for some [Question Types](#question-types)
 
-| Extra Setting           | Question Type                         | Type             | Values                                      | Description                                                                 |
-| ----------------------- | ------------------------------------- | ---------------- | ------------------------------------------- | --------------------------------------------------------------------------- |
-| `allowOtherAnswer`      | `multiple, multiple_unique`           | Boolean          | `true/false`                                | Allows the user to specify a custom answer                                  |
-| `shuffleOptions`        | `dropdown, multiple, multiple_unique` | Boolean          | `true/false`                                | The list of options should be shuffled                                      |
-| `optionsLimitMax`       | `multiple`                            | Integer          | -                                           | Maximum number of options that can be selected                              |
-| `optionsLimitMin`       | `multiple`                            | Integer          | -                                           | Minimum number of options that must be selected                             |
-| `validationType`        | `short`                               | string           | `null, 'phone', 'email', 'regex', 'number'` | Custom validation for checking a submission                                 |
-| `validationRegex`       | `short`                               | string           | regular expression                          | if `validationType` is 'regex' this defines the regular expression to apply |
-| `allowedFileTypes`      | `file`                                | Array of strings | `'image', 'x-office/document'`              | Allowed file types for file upload                                          |
-| `allowedFileExtensions` | `file`                                | Array of strings | `'jpg', 'png'`                              | Allowed file extensions for file upload                                     |
-| `maxAllowedFilesCount`  | `file`                                | Integer          | -                                           | Maximum number of files that can be uploaded, 0 means no limit              |
-| `maxFileSize`           | `file`                                | Integer          | -                                           | Maximum file size in bytes, 0 means no limit                                |
-| `dateMax`               | `date`                                | Integer          | -                                           | Maximum allowed date to be chosen (as Unix timestamp)                       |
-| `dateMin`               | `date`                                | Integer          | -                                           | Minimum allowed date to be chosen (as Unix timestamp)                       |
-| `dateRange`             | `date`                                | Boolean          | `true/false`                                | The date picker should query a date range                                   |
-| `timeMax`               | `time`                                | string           | -                                           | Maximum allowed time to be chosen (as `HH:mm` string)                       |
-| `timeMin`               | `time`                                | string           | -                                           | Minimum allowed time to be chosen (as `HH:mm` string)                       |
-| `timeRange`             | `time`                                | Boolean          | `true/false`                                | The time picker should query a time range                                   |
-| `optionsLowest`         | `linearscale`                         | Integer          | `0, 1`                                      | Set the lowest value of the scale, default: `1`                             |
-| `optionsHighest`        | `linearscale`                         | Integer          | `2, 3, 4, 5, 6, 7, 8, 9, 10`                | Set the highest value of the scale, default: `5`                            |
-| `optionsLabelLowest`    | `linearscale`                         | string           | -                                           | Set the label of the lowest value, default: `'Strongly disagree'`           |
-| `optionsLabelHighest`   | `linearscale`                         | string           | -                                           | Set the label of the highest value, default: `'Strongly agree'`             |
-| `columns`               | `grid`                                | Array            | -                                           | Array of column identifiers / labels for grid questions                     |
-| `rows`                  | `grid`                                | Array            | -                                           | Array of row identifiers / labels for grid questions                        |
-| `questionType`          | `grid`                                | String           | `checkbox`, `number`, `radio`               | Type of cell for grid questions (checkbox, numeric input, or radio)         |
+| Extra Setting           | Question Type                                  | Type             | Values                                      | Description                                                                 |
+| ----------------------- | ---------------------------------------------- | ---------------- | ------------------------------------------- | --------------------------------------------------------------------------- |
+| `allowOtherAnswer`      | `multiple, multiple_unique`                    | Boolean          | `true/false`                                | Allows the user to specify a custom answer                                  |
+| `shuffleOptions`        | `dropdown, multiple, multiple_unique, ranking` | Boolean          | `true/false`                                | The list of options should be shuffled                                      |
+| `optionsLimitMax`       | `multiple`                                     | Integer          | -                                           | Maximum number of options that can be selected                              |
+| `optionsLimitMin`       | `multiple`                                     | Integer          | -                                           | Minimum number of options that must be selected                             |
+| `validationType`        | `short`                                        | string           | `null, 'phone', 'email', 'regex', 'number'` | Custom validation for checking a submission                                 |
+| `validationRegex`       | `short`                                        | string           | regular expression                          | if `validationType` is 'regex' this defines the regular expression to apply |
+| `allowedFileTypes`      | `file`                                         | Array of strings | `'image', 'x-office/document'`              | Allowed file types for file upload                                          |
+| `allowedFileExtensions` | `file`                                         | Array of strings | `'jpg', 'png'`                              | Allowed file extensions for file upload                                     |
+| `maxAllowedFilesCount`  | `file`                                         | Integer          | -                                           | Maximum number of files that can be uploaded, 0 means no limit              |
+| `maxFileSize`           | `file`                                         | Integer          | -                                           | Maximum file size in bytes, 0 means no limit                                |
+| `dateMax`               | `date`                                         | Integer          | -                                           | Maximum allowed date to be chosen (as Unix timestamp)                       |
+| `dateMin`               | `date`                                         | Integer          | -                                           | Minimum allowed date to be chosen (as Unix timestamp)                       |
+| `dateRange`             | `date`                                         | Boolean          | `true/false`                                | The date picker should query a date range                                   |
+| `timeMax`               | `time`                                         | string           | -                                           | Maximum allowed time to be chosen (as `HH:mm` string)                       |
+| `timeMin`               | `time`                                         | string           | -                                           | Minimum allowed time to be chosen (as `HH:mm` string)                       |
+| `timeRange`             | `time`                                         | Boolean          | `true/false`                                | The time picker should query a time range                                   |
+| `optionsLowest`         | `linearscale`                                  | Integer          | `0, 1`                                      | Set the lowest value of the scale, default: `1`                             |
+| `optionsHighest`        | `linearscale`                                  | Integer          | `2, 3, 4, 5, 6, 7, 8, 9, 10`                | Set the highest value of the scale, default: `5`                            |
+| `optionsLabelLowest`    | `linearscale`                                  | string           | -                                           | Set the label of the lowest value, default: `'Strongly disagree'`           |
+| `optionsLabelHighest`   | `linearscale`                                  | string           | -                                           | Set the label of the highest value, default: `'Strongly agree'`             |
+| `columns`               | `grid`                                         | Array            | -                                           | Array of column identifiers / labels for grid questions                     |
+| `rows`                  | `grid`                                         | Array            | -                                           | Array of row identifiers / labels for grid questions                        |
+| `questionType`          | `grid`                                         | String           | `checkbox`, `number`, `radio`               | Type of cell for grid questions (checkbox, numeric input, or radio)         |
 
 ### Option Types
 

--- a/lib/Constants.php
+++ b/lib/Constants.php
@@ -76,6 +76,7 @@ class Constants {
 	public const ANSWER_TYPE_LONG = 'long';
 	public const ANSWER_TYPE_MULTIPLE = 'multiple';
 	public const ANSWER_TYPE_MULTIPLEUNIQUE = 'multiple_unique';
+	public const ANSWER_TYPE_RANKING = 'ranking';
 	public const ANSWER_TYPE_SHORT = 'short';
 	public const ANSWER_TYPE_TIME = 'time';
 
@@ -95,6 +96,7 @@ class Constants {
 		self::ANSWER_TYPE_LONG,
 		self::ANSWER_TYPE_MULTIPLE,
 		self::ANSWER_TYPE_MULTIPLEUNIQUE,
+		self::ANSWER_TYPE_RANKING,
 		self::ANSWER_TYPE_SHORT,
 		self::ANSWER_TYPE_TIME,
 	];
@@ -105,6 +107,7 @@ class Constants {
 		self::ANSWER_TYPE_LINEARSCALE,
 		self::ANSWER_TYPE_MULTIPLE,
 		self::ANSWER_TYPE_MULTIPLEUNIQUE,
+		self::ANSWER_TYPE_RANKING,
 	];
 
 	// AnswerTypes for date/time questions
@@ -189,6 +192,10 @@ class Constants {
 		'columns' => ['array'],
 		'questionType' => ['string'],
 		'rows' => ['array'],
+	];
+
+	public const EXTRA_SETTINGS_RANKING = [
+		'shuffleOptions' => ['boolean'],
 	];
 
 	public const EXTRA_SETTINGS_GRID_QUESTION_TYPE = [

--- a/lib/Constants.php
+++ b/lib/Constants.php
@@ -94,6 +94,7 @@ class Constants {
 	public const ANSWER_TYPE_LONG = 'long';
 	public const ANSWER_TYPE_MULTIPLE = 'multiple';
 	public const ANSWER_TYPE_MULTIPLEUNIQUE = 'multiple_unique';
+	public const ANSWER_TYPE_RANKING = 'ranking';
 	public const ANSWER_TYPE_SHORT = 'short';
 	public const ANSWER_TYPE_TIME = 'time';
 
@@ -113,6 +114,7 @@ class Constants {
 		self::ANSWER_TYPE_LONG,
 		self::ANSWER_TYPE_MULTIPLE,
 		self::ANSWER_TYPE_MULTIPLEUNIQUE,
+		self::ANSWER_TYPE_RANKING,
 		self::ANSWER_TYPE_SHORT,
 		self::ANSWER_TYPE_TIME,
 	];
@@ -124,6 +126,7 @@ class Constants {
 		self::ANSWER_TYPE_GRID,
 		self::ANSWER_TYPE_MULTIPLE,
 		self::ANSWER_TYPE_MULTIPLEUNIQUE,
+		self::ANSWER_TYPE_RANKING,
 	];
 
 	// AnswerTypes for date/time questions
@@ -208,6 +211,10 @@ class Constants {
 		'columns' => ['array'],
 		'questionType' => ['string'],
 		'rows' => ['array'],
+	];
+
+	public const EXTRA_SETTINGS_RANKING = [
+		'shuffleOptions' => ['boolean'],
 	];
 
 	public const EXTRA_SETTINGS_GRID_QUESTION_TYPE = [

--- a/lib/Controller/ApiController.php
+++ b/lib/Controller/ApiController.php
@@ -1755,6 +1755,22 @@ class ApiController extends OCSController {
 			return;
 		}
 
+		if ($question['type'] === Constants::ANSWER_TYPE_RANKING) {
+			if (!$answerArray) {
+				return;
+			}
+
+			$answerEntity = new Answer();
+			$answerEntity->setSubmissionId($submissionId);
+			$answerEntity->setQuestionId($question['id']);
+
+			$answerText = json_encode($answerArray);
+			$answerEntity->setText($answerText);
+			$this->answerMapper->insert($answerEntity);
+
+			return;
+		}
+
 		foreach ($answerArray as $answer) {
 			$answerEntity = new Answer();
 			$answerEntity->setSubmissionId($submissionId);

--- a/lib/Controller/ApiController.php
+++ b/lib/Controller/ApiController.php
@@ -1739,23 +1739,7 @@ class ApiController extends OCSController {
 	 * @param string[]|array<array{uploadedFileId: string, uploadedFileName: string}> $answerArray
 	 */
 	private function storeAnswersForQuestion(Form $form, $submissionId, array $question, array $answerArray): void {
-		if ($question['type'] === Constants::ANSWER_TYPE_GRID) {
-			if (!$answerArray) {
-				return;
-			}
-
-			$answerEntity = new Answer();
-			$answerEntity->setSubmissionId($submissionId);
-			$answerEntity->setQuestionId($question['id']);
-
-			$answerText = json_encode($answerArray);
-			$answerEntity->setText($answerText);
-			$this->answerMapper->insert($answerEntity);
-
-			return;
-		}
-
-		if ($question['type'] === Constants::ANSWER_TYPE_RANKING) {
+		if ($question['type'] === Constants::ANSWER_TYPE_GRID || $question['type'] === Constants::ANSWER_TYPE_RANKING) {
 			if (!$answerArray) {
 				return;
 			}

--- a/lib/Controller/ApiController.php
+++ b/lib/Controller/ApiController.php
@@ -1775,7 +1775,7 @@ class ApiController extends OCSController {
 	 * @param string[]|array<array{uploadedFileId: string, uploadedFileName: string}> $answerArray
 	 */
 	private function storeAnswersForQuestion(Form $form, $submissionId, array $question, array $answerArray): void {
-		if ($question['type'] === Constants::ANSWER_TYPE_GRID) {
+		if ($question['type'] === Constants::ANSWER_TYPE_GRID || $question['type'] === Constants::ANSWER_TYPE_RANKING) {
 			if (!$answerArray) {
 				return;
 			}

--- a/lib/Service/FormsService.php
+++ b/lib/Service/FormsService.php
@@ -810,6 +810,9 @@ class FormsService {
 			case Constants::ANSWER_TYPE_GRID:
 				$allowed = Constants::EXTRA_SETTINGS_GRID;
 				break;
+			case Constants::ANSWER_TYPE_RANKING:
+				$allowed = Constants::EXTRA_SETTINGS_RANKING;
+				break;
 			case Constants::ANSWER_TYPE_TIME:
 				$allowed = Constants::EXTRA_SETTINGS_TIME;
 				break;

--- a/lib/Service/FormsService.php
+++ b/lib/Service/FormsService.php
@@ -818,6 +818,9 @@ class FormsService {
 			case Constants::ANSWER_TYPE_GRID:
 				$allowed = Constants::EXTRA_SETTINGS_GRID;
 				break;
+			case Constants::ANSWER_TYPE_RANKING:
+				$allowed = Constants::EXTRA_SETTINGS_RANKING;
+				break;
 			case Constants::ANSWER_TYPE_TIME:
 				$allowed = Constants::EXTRA_SETTINGS_TIME;
 				break;

--- a/lib/Service/SubmissionService.php
+++ b/lib/Service/SubmissionService.php
@@ -367,11 +367,10 @@ class SubmissionService {
 						$carry[$questionId] = ['columns' => $columns];
 					} elseif ($questionType === Constants::ANSWER_TYPE_RANKING) {
 						$rankedIds = json_decode($answer->getText(), true);
-						// Build map: optionId -> rank position (1-based)
-						$rankByOptionId = array_flip($rankedIds);
 						$columns = [];
 						foreach ($rankingOptionsPerQuestionId[$questionId] as $optionId) {
-							$columns[] = isset($rankByOptionId[$optionId]) ? $rankByOptionId[$optionId] + 1 : '';
+							$position = array_search($optionId, $rankedIds);
+							$columns[] = $position !== false ? $position + 1 : '';
 						}
 						$carry[$questionId] = ['columns' => $columns];
 					} else {

--- a/lib/Service/SubmissionService.php
+++ b/lib/Service/SubmissionService.php
@@ -586,7 +586,10 @@ class SubmissionService {
 				$optionIds = array_map('intval', array_column($question['options'] ?? [], 'id'));
 				$rankedIds = array_map('intval', $answers[$questionId]);
 
-				if (sort($rankedIds) !== sort($optionIds)) {
+				sort($optionIds);
+				sort($rankedIds);
+
+				if ($rankedIds !== $optionIds) {
 					throw new \InvalidArgumentException(sprintf('Ranking for question "%s" must include all options exactly once.', $question['text']));
 				}
 			}

--- a/lib/Service/SubmissionService.php
+++ b/lib/Service/SubmissionService.php
@@ -585,11 +585,8 @@ class SubmissionService {
 			if ($question['type'] === Constants::ANSWER_TYPE_RANKING) {
 				$optionIds = array_map('intval', array_column($question['options'] ?? [], 'id'));
 				$rankedIds = array_map('intval', $answers[$questionId]);
-				$sortedRanked = $rankedIds;
-				$sortedOptions = $optionIds;
-				sort($sortedRanked);
-				sort($sortedOptions);
-				if ($sortedRanked !== $sortedOptions) {
+
+				if (sort($rankedIds) !== sort($optionIds)) {
 					throw new \InvalidArgumentException(sprintf('Ranking for question "%s" must include all options exactly once.', $question['text']));
 				}
 			}

--- a/lib/Service/SubmissionService.php
+++ b/lib/Service/SubmissionService.php
@@ -252,6 +252,8 @@ class SubmissionService {
 		$gridRowsPerQuestionId = [];
 		/** @var array<int, array<int, string>> $gridColumnsPerQuestionId */
 		$gridColumnsPerQuestionId = [];
+		/** @var array<int, list<int>> $rankingOptionsPerQuestionId */
+		$rankingOptionsPerQuestionId = [];
 
 		$optionPerOptionId = [];
 		foreach ($questions as $question) {
@@ -279,6 +281,15 @@ class SubmissionService {
 							$header[] = $question->getText() . ' (' . $optionPerOptionId[$rowId]->getText() . ' - ' . $optionPerOptionId[$columnId]->getText() . ')';
 						}
 					}
+				}
+			} elseif ($question->getType() === Constants::ANSWER_TYPE_RANKING) {
+				$options = $this->optionMapper->findByQuestion($question->getId());
+				foreach ($options as $option) {
+					$optionPerOptionId[$option->getId()] = $option;
+					$rankingOptionsPerQuestionId[$question->getId()][] = $option->getId();
+				}
+				foreach ($rankingOptionsPerQuestionId[$question->getId()] as $optionId) {
+					$header[] = $question->getText() . ' (' . $optionPerOptionId[$optionId]->getText() . ')';
 				}
 			} else {
 				$header[] = $question->getText();
@@ -311,7 +322,7 @@ class SubmissionService {
 
 			// Answers, make sure we keep the question order
 			$answers = array_reduce($this->answerMapper->findBySubmission($submission->getId()),
-				function (array $carry, Answer $answer) use ($questionPerQuestionId, $gridRowsPerQuestionId, $gridColumnsPerQuestionId, $optionPerOptionId) {
+				function (array $carry, Answer $answer) use ($questionPerQuestionId, $gridRowsPerQuestionId, $gridColumnsPerQuestionId, $rankingOptionsPerQuestionId, $optionPerOptionId) {
 					$questionId = $answer->getQuestionId();
 					$questionType = isset($questionPerQuestionId[$questionId]) ? $questionPerQuestionId[$questionId]->getType() : null;
 
@@ -352,6 +363,14 @@ class SubmissionService {
 									$columns[] = $answerText[$row][$column];
 								}
 							}
+						}
+						$carry[$questionId] = ['columns' => $columns];
+					} elseif ($questionType === Constants::ANSWER_TYPE_RANKING) {
+						$rankedIds = json_decode($answer->getText(), true);
+						$columns = [];
+						foreach ($rankingOptionsPerQuestionId[$questionId] as $optionId) {
+							$position = array_search($optionId, $rankedIds);
+							$columns[] = $position !== false ? $position + 1 : '';
 						}
 						$carry[$questionId] = ['columns' => $columns];
 					} else {
@@ -510,6 +529,7 @@ class SubmissionService {
 			} elseif ($answersCount > 1
 						&& $question['type'] !== Constants::ANSWER_TYPE_FILE
 						&& $question['type'] !== Constants::ANSWER_TYPE_GRID
+						&& $question['type'] !== Constants::ANSWER_TYPE_RANKING
 						&& !($question['type'] === Constants::ANSWER_TYPE_DATE && isset($question['extraSettings']['dateRange'])
 						|| $question['type'] === Constants::ANSWER_TYPE_TIME && isset($question['extraSettings']['timeRange']))) {
 				// Check if non-multiple questions have not more than one answer
@@ -559,6 +579,19 @@ class SubmissionService {
 			// Handle custom validation of short answers
 			if ($question['type'] === Constants::ANSWER_TYPE_SHORT && !$this->validateShortQuestion($question, $answers[$questionId][0])) {
 				throw new \InvalidArgumentException(sprintf('Invalid input for question "%s".', $question['text']));
+			}
+
+			// Handle ranking questions: answers must be a permutation of all option IDs
+			if ($question['type'] === Constants::ANSWER_TYPE_RANKING) {
+				$optionIds = array_map('intval', array_column($question['options'] ?? [], 'id'));
+				$rankedIds = array_map('intval', $answers[$questionId]);
+
+				sort($optionIds);
+				sort($rankedIds);
+
+				if ($rankedIds !== $optionIds) {
+					throw new \InvalidArgumentException(sprintf('Ranking for question "%s" must include all options exactly once.', $question['text']));
+				}
 			}
 
 			// Handle color questions

--- a/lib/Service/SubmissionService.php
+++ b/lib/Service/SubmissionService.php
@@ -252,6 +252,8 @@ class SubmissionService {
 		$gridRowsPerQuestionId = [];
 		/** @var array<int, array<int, string>> $gridColumnsPerQuestionId */
 		$gridColumnsPerQuestionId = [];
+		/** @var array<int, list<int>> $rankingOptionsPerQuestionId */
+		$rankingOptionsPerQuestionId = [];
 
 		$optionPerOptionId = [];
 		foreach ($questions as $question) {
@@ -279,6 +281,15 @@ class SubmissionService {
 							$header[] = $question->getText() . ' (' . $optionPerOptionId[$rowId]->getText() . ' - ' . $optionPerOptionId[$columnId]->getText() . ')';
 						}
 					}
+				}
+			} elseif ($question->getType() === Constants::ANSWER_TYPE_RANKING) {
+				$options = $this->optionMapper->findByQuestion($question->getId());
+				foreach ($options as $option) {
+					$optionPerOptionId[$option->getId()] = $option;
+					$rankingOptionsPerQuestionId[$question->getId()][] = $option->getId();
+				}
+				foreach ($rankingOptionsPerQuestionId[$question->getId()] as $optionId) {
+					$header[] = $question->getText() . ' (' . $optionPerOptionId[$optionId]->getText() . ')';
 				}
 			} else {
 				$header[] = $question->getText();
@@ -311,7 +322,7 @@ class SubmissionService {
 
 			// Answers, make sure we keep the question order
 			$answers = array_reduce($this->answerMapper->findBySubmission($submission->getId()),
-				function (array $carry, Answer $answer) use ($questionPerQuestionId, $gridRowsPerQuestionId, $gridColumnsPerQuestionId, $optionPerOptionId) {
+				function (array $carry, Answer $answer) use ($questionPerQuestionId, $gridRowsPerQuestionId, $gridColumnsPerQuestionId, $rankingOptionsPerQuestionId, $optionPerOptionId) {
 					$questionId = $answer->getQuestionId();
 					$questionType = isset($questionPerQuestionId[$questionId]) ? $questionPerQuestionId[$questionId]->getType() : null;
 
@@ -352,6 +363,15 @@ class SubmissionService {
 									$columns[] = $answerText[$row][$column];
 								}
 							}
+						}
+						$carry[$questionId] = ['columns' => $columns];
+					} elseif ($questionType === Constants::ANSWER_TYPE_RANKING) {
+						$rankedIds = json_decode($answer->getText(), true);
+						// Build map: optionId -> rank position (1-based)
+						$rankByOptionId = array_flip($rankedIds);
+						$columns = [];
+						foreach ($rankingOptionsPerQuestionId[$questionId] as $optionId) {
+							$columns[] = isset($rankByOptionId[$optionId]) ? $rankByOptionId[$optionId] + 1 : '';
 						}
 						$carry[$questionId] = ['columns' => $columns];
 					} else {
@@ -510,6 +530,7 @@ class SubmissionService {
 			} elseif ($answersCount > 1
 						&& $question['type'] !== Constants::ANSWER_TYPE_FILE
 						&& $question['type'] !== Constants::ANSWER_TYPE_GRID
+						&& $question['type'] !== Constants::ANSWER_TYPE_RANKING
 						&& !($question['type'] === Constants::ANSWER_TYPE_DATE && isset($question['extraSettings']['dateRange'])
 						|| $question['type'] === Constants::ANSWER_TYPE_TIME && isset($question['extraSettings']['timeRange']))) {
 				// Check if non-multiple questions have not more than one answer
@@ -559,6 +580,19 @@ class SubmissionService {
 			// Handle custom validation of short answers
 			if ($question['type'] === Constants::ANSWER_TYPE_SHORT && !$this->validateShortQuestion($question, $answers[$questionId][0])) {
 				throw new \InvalidArgumentException(sprintf('Invalid input for question "%s".', $question['text']));
+			}
+
+			// Handle ranking questions: answers must be a permutation of all option IDs
+			if ($question['type'] === Constants::ANSWER_TYPE_RANKING) {
+				$optionIds = array_map('intval', array_column($question['options'] ?? [], 'id'));
+				$rankedIds = array_map('intval', $answers[$questionId]);
+				$sortedRanked = $rankedIds;
+				$sortedOptions = $optionIds;
+				sort($sortedRanked);
+				sort($sortedOptions);
+				if ($sortedRanked !== $sortedOptions) {
+					throw new \InvalidArgumentException(sprintf('Ranking for question "%s" must include all options exactly once.', $question['text']));
+				}
 			}
 
 			// Handle color questions

--- a/playwright/e2e/ranking-question.spec.ts
+++ b/playwright/e2e/ranking-question.spec.ts
@@ -1,0 +1,179 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { expect, mergeTests } from '@playwright/test'
+import { test as formTest } from '../support/fixtures/form.ts'
+import { test as appNavigationTest } from '../support/fixtures/navigation.ts'
+import { test as randomUserTest } from '../support/fixtures/random-user.ts'
+import { test as submitTest } from '../support/fixtures/submit.ts'
+import { test as topBarTest } from '../support/fixtures/topBar.ts'
+import { QuestionType } from '../support/sections/QuestionType.ts'
+import { FormsView } from '../support/sections/TopBarSection.ts'
+
+const test = mergeTests(
+	randomUserTest,
+	appNavigationTest,
+	formTest,
+	topBarTest,
+	submitTest,
+)
+
+test.describe('Ranking question', () => {
+	test.beforeEach(async ({ page, appNavigation, form }) => {
+		await page.goto('apps/forms')
+		await page.waitForURL(/apps\/forms\/?$/)
+		await appNavigation.clickNewForm()
+		await form.fillTitle('Ranking test form')
+
+		await form.addQuestion(QuestionType.Ranking)
+		const questions = await form.getQuestions()
+		await questions[0].fillTitle('Rank snacks')
+		await questions[0].addAnswer('Pretzels')
+		await questions[0].addAnswer('Popcorn')
+		await questions[0].addAnswer('Nuts')
+	})
+
+	test('Restores unsubmitted ranking from local storage on reload', async ({
+		topBar,
+		submitView,
+		page,
+	}) => {
+		await topBar.toggleView(FormsView.View)
+
+		await submitView.rankOption('Rank snacks', 'Pretzels')
+		await submitView.rankOption('Rank snacks', 'Popcorn')
+
+		await page.reload()
+
+		const question = submitView.getQuestion('Rank snacks')
+		await expect(
+			question.getByRole('button', { name: 'Remove from ranking' }),
+		).toHaveCount(2)
+	})
+
+	test('Clear form resets ranked options', async ({ topBar, submitView }) => {
+		await topBar.toggleView(FormsView.View)
+
+		await submitView.rankOption('Rank snacks', 'Pretzels')
+		await submitView.rankOption('Rank snacks', 'Popcorn')
+		await submitView.clearForm()
+
+		const question = submitView.getQuestion('Rank snacks')
+		await expect(
+			question.getByRole('button', { name: 'Remove from ranking' }),
+		).toHaveCount(0)
+		await expect(
+			question.getByRole('button', { name: 'Pretzels' }),
+		).toBeVisible()
+		await expect(question.getByRole('button', { name: 'Popcorn' })).toBeVisible()
+	})
+
+	test('Required ranking blocks submit until all options are ranked', async ({
+		topBar,
+		submitView,
+		form,
+	}) => {
+		const questions = await form.getQuestions()
+		await questions[0].toggleRequired()
+
+		await topBar.toggleView(FormsView.View)
+
+		await submitView.submitButton.click()
+		await expect(submitView.successMessage).not.toBeVisible()
+
+		await submitView.rankOption('Rank snacks', 'Pretzels')
+		await submitView.submitButton.click()
+		await expect(submitView.successMessage).not.toBeVisible()
+
+		await submitView.rankOption('Rank snacks', 'Popcorn')
+		await submitView.rankOption('Rank snacks', 'Nuts')
+		await submitView.submit()
+		await expect(submitView.successMessage).toBeVisible()
+	})
+
+	test('Partial ranking submission is blocked by required validation', async ({
+		topBar,
+		submitView,
+	}) => {
+		await topBar.toggleView(FormsView.View)
+
+		// Rank only 2 out of 3 items
+		await submitView.rankOption('Rank snacks', 'Pretzels')
+		await submitView.rankOption('Rank snacks', 'Popcorn')
+
+		// Try to submit — should fail
+		await submitView.submitButton.click()
+
+		// Verify error prevents submission (success message hidden)
+		await expect(submitView.successMessage).not.toBeVisible()
+	})
+
+	test('Complete ranking submission succeeds after partial attempt', async ({
+		topBar,
+		submitView,
+	}) => {
+		await topBar.toggleView(FormsView.View)
+
+		// Rank first 2 items
+		await submitView.rankOption('Rank snacks', 'Pretzels')
+		await submitView.rankOption('Rank snacks', 'Popcorn')
+
+		// Submit attempt fails (partial ranking)
+		await submitView.submitButton.click()
+		await expect(submitView.successMessage).not.toBeVisible()
+
+		// Complete the ranking
+		await submitView.rankOption('Rank snacks', 'Nuts')
+
+		// Now submit should succeed
+		await submitView.submit()
+		await expect(submitView.successMessage).toBeVisible()
+	})
+
+	test('Multiple ranking questions maintain separate drag contexts', async ({
+		form,
+		topBar,
+		submitView,
+	}) => {
+		// Add a second ranking question
+		await form.addQuestion(QuestionType.Ranking)
+		const questions = await form.getQuestions()
+		await questions[1].fillTitle('Rank preferences')
+		await questions[1].addAnswer('Option X')
+		await questions[1].addAnswer('Option Y')
+		await questions[1].addAnswer('Option Z')
+
+		await topBar.toggleView(FormsView.View)
+
+		// Rank first question completely
+		await submitView.rankOption('Rank snacks', 'Pretzels')
+		await submitView.rankOption('Rank snacks', 'Popcorn')
+		await submitView.rankOption('Rank snacks', 'Nuts')
+
+		// Rank second question partially
+		await submitView.rankOption('Rank preferences', 'Option X')
+		await submitView.rankOption('Rank preferences', 'Option Z')
+
+		// Verify both rankings are correct
+		const q1 = submitView.getQuestion('Rank snacks')
+		const q2 = submitView.getQuestion('Rank preferences')
+
+		await expect(
+			q1.getByRole('button', { name: 'Remove from ranking' }),
+		).toHaveCount(3)
+		await expect(
+			q2.getByRole('button', { name: 'Remove from ranking' }),
+		).toHaveCount(2)
+
+		// Submit should require q2 to be complete
+		await submitView.submitButton.click()
+		await expect(submitView.successMessage).not.toBeVisible()
+
+		// Complete q2
+		await submitView.rankOption('Rank preferences', 'Option Y')
+		await submitView.submit()
+		await expect(submitView.successMessage).toBeVisible()
+	})
+})

--- a/playwright/support/sections/QuestionType.ts
+++ b/playwright/support/sections/QuestionType.ts
@@ -11,6 +11,7 @@ export enum QuestionType {
 	File = 'File',
 	LinearScale = 'Linear scale',
 	LongAnswer = 'Long text',
+	Ranking = 'Ranking',
 	RadioButtons = 'Radio buttons',
 	ShortAnswer = 'Short answer',
 }

--- a/playwright/support/sections/SubmitSection.ts
+++ b/playwright/support/sections/SubmitSection.ts
@@ -6,10 +6,12 @@
 import type { Locator, Page, Response } from '@playwright/test'
 
 export class SubmitSection {
+	public readonly clearFormButton: Locator
 	public readonly submitButton: Locator
 	public readonly successMessage: Locator
 
 	constructor(public readonly page: Page) {
+		this.clearFormButton = this.page.getByRole('button', { name: 'Clear form' })
 		this.submitButton = this.page.getByRole('button', { name: 'Submit' })
 		this.successMessage = this.page.getByText(
 			'Thank you for completing the form!',
@@ -97,6 +99,29 @@ export class SubmitSection {
 		await question.getByRole('combobox').click()
 		// NcSelect renders its option list in a teleported element outside the question <li>
 		await this.page.getByRole('option', { name: optionName }).click()
+	}
+
+	/**
+	 * Rank an option by clicking it in the unranked pool.
+	 *
+	 * @param questionName the title of the question
+	 * @param optionName the option text to move into ranked list
+	 */
+	public async rankOption(
+		questionName: string | RegExp,
+		optionName: string | RegExp,
+	): Promise<void> {
+		const question = this.getQuestion(questionName)
+		await question.getByRole('button', { name: optionName }).click()
+	}
+
+	/**
+	 * Click clear form and confirm the dialog.
+	 */
+	public async clearForm(): Promise<void> {
+		await this.clearFormButton.click()
+		const dialog = this.page.getByRole('dialog', { name: 'Clear form' })
+		await dialog.getByRole('button', { name: 'Clear' }).click()
 	}
 
 	/** Click submit and wait for the API response. */

--- a/src/components/Questions/AnswerInput.vue
+++ b/src/components/Questions/AnswerInput.vue
@@ -8,6 +8,7 @@
 		<component
 			:is="pseudoIcon"
 			v-if="!isDropdown"
+			:size="24"
 			class="question__item__pseudoInput" />
 		<input
 			ref="input"
@@ -145,6 +146,11 @@ export default {
 			default: false,
 		},
 
+		isRanking: {
+			type: Boolean,
+			default: false,
+		},
+
 		maxIndex: {
 			type: Number,
 			required: true,
@@ -254,6 +260,10 @@ export default {
 
 			if (this.optionType === OptionType.Row) {
 				return IconTableRow
+			}
+
+			if (this.isRanking) {
+				return IconDragIndicator
 			}
 
 			return this.isUnique ? IconRadioboxBlank : IconCheckboxBlankOutline
@@ -538,8 +548,7 @@ export default {
 		height: 100%;
 	}
 
-	.option__drag-handle,
-	.drag-indicator-icon {
+	.option__drag-handle {
 		color: var(--color-text-maxcontrast);
 		cursor: grab;
 		margin-block: auto;

--- a/src/components/Questions/AnswerInput.vue
+++ b/src/components/Questions/AnswerInput.vue
@@ -139,6 +139,11 @@ export default {
 			default: false,
 		},
 
+		isRanking: {
+			type: Boolean,
+			default: false,
+		},
+
 		maxIndex: {
 			type: Number,
 			required: true,
@@ -258,6 +263,10 @@ export default {
 
 			if (this.optionType === OptionType.Row) {
 				return IconTableRow
+			}
+
+			if (this.isRanking) {
+				return IconDragIndicator
 			}
 
 			return this.isUnique ? IconRadioboxBlank : IconCheckboxBlankOutline
@@ -542,8 +551,7 @@ export default {
 		height: 100%;
 	}
 
-	.option__drag-handle,
-	.drag-indicator-icon {
+	.option__drag-handle {
 		color: var(--color-text-maxcontrast);
 		cursor: grab;
 		margin-block: auto;

--- a/src/components/Questions/Question.vue
+++ b/src/components/Questions/Question.vue
@@ -82,7 +82,7 @@
 					forceMenu
 					placement="bottom-end"
 					class="question__header__title__menu">
-					<template v-if="isRequired && allowRequired" #icon>
+					<template v-if="isRequired" #icon>
 						<IconOverlay>
 							<template #overlay>
 								<IconAsterisk :size="20" />
@@ -91,7 +91,6 @@
 						</IconOverlay>
 					</template>
 					<NcActionCheckbox
-						v-if="allowRequired"
 						:modelValue="isRequired"
 						@update:modelValue="onRequiredChange">
 						<!-- TRANSLATORS Making this question necessary to be answered when submitting to a form -->
@@ -245,11 +244,6 @@ export default {
 		name: {
 			type: String,
 			default: '',
-		},
-
-		allowRequired: {
-			type: Boolean,
-			default: true,
 		},
 
 		contentValid: {

--- a/src/components/Questions/Question.vue
+++ b/src/components/Questions/Question.vue
@@ -82,7 +82,7 @@
 					forceMenu
 					placement="bottom-end"
 					class="question__header__title__menu">
-					<template v-if="isRequired" #icon>
+					<template v-if="isRequired && allowRequired" #icon>
 						<IconOverlay>
 							<template #overlay>
 								<IconAsterisk :size="20" />
@@ -91,6 +91,7 @@
 						</IconOverlay>
 					</template>
 					<NcActionCheckbox
+						v-if="allowRequired"
 						:modelValue="isRequired"
 						@update:modelValue="onRequiredChange">
 						<!-- TRANSLATORS Making this question necessary to be answered when submitting to a form -->
@@ -244,6 +245,11 @@ export default {
 		name: {
 			type: String,
 			default: '',
+		},
+
+		allowRequired: {
+			type: Boolean,
+			default: true,
 		},
 
 		contentValid: {

--- a/src/components/Questions/QuestionRanking.vue
+++ b/src/components/Questions/QuestionRanking.vue
@@ -10,7 +10,6 @@
 		:warningInvalid="answerType.warningInvalid"
 		:contentValid="contentValid"
 		:shiftDragHandle="shiftDragHandle"
-		:allowRequired="false"
 		v-on="commonListeners">
 		<template #actions>
 			<NcActionCheckbox
@@ -26,13 +25,38 @@
 			</NcActionButton>
 		</template>
 
-		<!-- Submit mode: drag to rank -->
+		<!-- Submit mode -->
 		<div
 			v-if="readOnly"
 			class="question__content"
 			role="list"
 			:aria-labelledby="titleId"
 			:aria-describedby="description ? descriptionId : undefined">
+			<!-- Unranked pool (visible when items remain) -->
+			<div v-if="unrankedOptions.length > 0" class="ranking-unranked">
+				<p class="ranking-unranked__label">
+					{{ t('forms', 'Tap to rank') }}
+				</p>
+				<button
+					v-for="option in unrankedOptions"
+					:key="option.id"
+					class="ranking-unranked__item"
+					@click="rankOption(option)">
+					{{ option.text }}
+				</button>
+			</div>
+
+			<!-- Empty state when nothing ranked yet -->
+			<p v-if="rankedOptions.length === 0" class="ranking-empty">
+				{{ t('forms', 'Tap items above to rank them') }}
+			</p>
+
+			<!-- Ranked list header (to separate from pool) -->
+			<p v-if="rankedOptions.length > 0" class="ranking-ranked__label">
+				{{ t('forms', 'Your ranking') }}
+			</p>
+
+			<!-- Ranked list -->
 			<Draggable
 				v-model="rankedOptions"
 				:animation="200"
@@ -49,6 +73,14 @@
 						<IconDragHorizontalVariant :size="20" />
 					</span>
 					<span class="ranking-item__text">{{ option.text }}</span>
+					<NcButton
+						variant="tertiary"
+						:ariaLabel="t('forms', 'Remove from ranking')"
+						@click="unrankOption(option)">
+						<template #icon>
+							<IconClose :size="20" />
+						</template>
+					</NcButton>
 				</div>
 			</Draggable>
 		</div>
@@ -107,7 +139,9 @@
 import { VueDraggable as Draggable } from 'vue-draggable-plus'
 import NcActionButton from '@nextcloud/vue/components/NcActionButton'
 import NcActionCheckbox from '@nextcloud/vue/components/NcActionCheckbox'
+import NcButton from '@nextcloud/vue/components/NcButton'
 import NcLoadingIcon from '@nextcloud/vue/components/NcLoadingIcon'
+import IconClose from 'vue-material-design-icons/Close.vue'
 import IconContentPaste from 'vue-material-design-icons/ContentPaste.vue'
 import IconDragHorizontalVariant from 'vue-material-design-icons/DragHorizontalVariant.vue'
 import OptionInputDialog from '../OptionInputDialog.vue'
@@ -123,10 +157,12 @@ export default {
 	components: {
 		AnswerInput,
 		Draggable,
+		IconClose,
 		IconContentPaste,
 		IconDragHorizontalVariant,
 		NcActionButton,
 		NcActionCheckbox,
+		NcButton,
 		NcLoadingIcon,
 		OptionInputDialog,
 		Question,
@@ -141,6 +177,7 @@ export default {
 			isLoading: false,
 			isOptionDialogShown: false,
 			rankedOptions: [],
+			unrankedOptions: [],
 			OptionType,
 		}
 	},
@@ -176,7 +213,7 @@ export default {
 
 	methods: {
 		/**
-		 * Initialize ranked options from existing values or default order
+		 * Initialize ranked/unranked options from existing values or default order
 		 */
 		initRankedOptions() {
 			const sorted = this.sortOptionsOfType(this.options, OptionType.Choice)
@@ -187,28 +224,64 @@ export default {
 				this.rankedOptions = this.values
 					.map((id) => byId[parseInt(id)])
 					.filter(Boolean)
+				this.unrankedOptions = sorted.filter(
+					(o) => !this.rankedOptions.some((r) => r.id === o.id),
+				)
+			} else if (this.readOnly) {
+				// Submit mode: start with all options unranked
+				this.rankedOptions = []
+				this.unrankedOptions = [...sorted]
 			} else {
+				// Edit mode: show all options in default order
 				this.rankedOptions = [...sorted]
+				this.unrankedOptions = []
 			}
+		},
 
-			// In submit mode, emit the initial ranking so the answer is always
-			// recorded – even when the user agrees with the default order.
-			if (this.readOnly && this.rankedOptions.length > 0) {
+		/**
+		 * Move an option from the unranked pool to the ranked list
+		 *
+		 * @param {object} option The option to rank
+		 */
+		rankOption(option) {
+			this.unrankedOptions = this.unrankedOptions.filter(
+				(o) => o.id !== option.id,
+			)
+			this.rankedOptions.push(option)
+			this.emitValues()
+		},
+
+		/**
+		 * Move an option from the ranked list back to the unranked pool
+		 *
+		 * @param {object} option The option to unrank
+		 */
+		unrankOption(option) {
+			this.rankedOptions = this.rankedOptions.filter((o) => o.id !== option.id)
+			this.unrankedOptions.push(option)
+			this.emitValues()
+		},
+
+		/**
+		 * Emit the current ranking after a drag reorder
+		 */
+		onRankingEnd() {
+			this.emitValues()
+		},
+
+		/**
+		 * Emit the current values based on ranking state
+		 */
+		emitValues() {
+			if (this.rankedOptions.length === 0) {
+				// Nothing ranked — emit empty to signal unanswered
+				this.$emit('update:values', [])
+			} else {
 				this.$emit(
 					'update:values',
 					this.rankedOptions.map((o) => o.id),
 				)
 			}
-		},
-
-		/**
-		 * Emit the new ranking after a drag ends
-		 */
-		onRankingEnd() {
-			this.$emit(
-				'update:values',
-				this.rankedOptions.map((o) => o.id),
-			)
 		},
 	},
 }
@@ -219,6 +292,47 @@ export default {
 	display: flex;
 	flex-direction: column;
 	gap: var(--default-grid-baseline);
+}
+
+.ranking-unranked {
+	margin-block-end: 12px;
+
+	&__label {
+		font-weight: bold;
+		color: var(--color-text-maxcontrast);
+		margin-block-end: 8px;
+	}
+
+	&__item {
+		display: inline-block;
+		padding: 8px 16px;
+		margin: 0 8px 8px 0;
+		background-color: var(--color-background-dark);
+		border: 1px solid var(--color-border);
+		border-radius: var(--border-radius-large);
+		cursor: pointer;
+		font-size: inherit;
+		color: var(--color-main-text);
+		transition: background-color var(--animation-quick);
+
+		&:hover,
+		&:focus-visible {
+			background-color: var(--color-background-hover);
+			border-color: var(--color-primary-element);
+		}
+	}
+}
+
+.ranking-empty {
+	color: var(--color-text-maxcontrast);
+	font-style: italic;
+	padding: 12px 0;
+}
+
+.ranking-ranked__label {
+	font-weight: bold;
+	color: var(--color-text-maxcontrast);
+	margin-block-end: 4px;
 }
 
 .ranking-item {

--- a/src/components/Questions/QuestionRanking.vue
+++ b/src/components/Questions/QuestionRanking.vue
@@ -28,16 +28,18 @@
 		<!-- Submit mode -->
 		<div
 			v-if="readOnly"
-			class="question__content ranking-columns"
+			class="question__content"
 			role="list"
 			:aria-labelledby="titleId"
 			:aria-describedby="description ? descriptionId : undefined">
-			<!-- Left: Unranked pool -->
+			<!-- Unranked pool -->
 			<div class="ranking-unranked">
-				<p class="ranking-column__label">
-					{{ t('forms', 'Options') }}
+				<p class="ranking-section__label">
+					{{ t('forms', 'Tap to rank') }}
 				</p>
-				<div class="ranking-unranked__pool">
+				<div
+					v-show="unrankedOptions.length > 0"
+					class="ranking-unranked__pool">
 					<button
 						v-for="option in unrankedOptions"
 						:key="option.id"
@@ -45,17 +47,17 @@
 						@click="rankOption(option)">
 						{{ option.text }}
 					</button>
-					<p
-						v-if="unrankedOptions.length === 0"
-						class="ranking-unranked__empty">
-						{{ t('forms', 'All options ranked') }}
-					</p>
 				</div>
+				<p
+					v-show="unrankedOptions.length === 0"
+					class="ranking-unranked__empty">
+					{{ t('forms', 'All options ranked') }}
+				</p>
 			</div>
 
-			<!-- Right: Ranked list -->
+			<!-- Ranked list -->
 			<div class="ranking-ranked">
-				<p class="ranking-column__label">
+				<p class="ranking-section__label">
 					{{ t('forms', 'Your ranking') }}
 				</p>
 				<Draggable
@@ -79,7 +81,6 @@
 								<IconDragIndicator :size="20" />
 							</template>
 							<NcActionButton
-								ref="buttonOptionUp"
 								:disabled="index === 0"
 								@click="onMoveUp(index)">
 								<template #icon>
@@ -88,7 +89,6 @@
 								{{ t('forms', 'Move option up') }}
 							</NcActionButton>
 							<NcActionButton
-								ref="buttonOptionDown"
 								:disabled="index === rankedOptions.length - 1"
 								@click="onMoveDown(index)">
 								<template #icon>
@@ -108,8 +108,8 @@
 						</NcButton>
 					</div>
 				</Draggable>
-				<p v-if="rankedOptions.length === 0" class="ranking-ranked__empty">
-					{{ t('forms', 'Tap options to rank them') }}
+				<p v-show="rankedOptions.length === 0" class="ranking-ranked__empty">
+					{{ t('forms', 'Tap options above to rank them') }}
 				</p>
 			</div>
 		</div>
@@ -355,41 +355,30 @@ export default {
 	gap: var(--default-grid-baseline);
 }
 
-.ranking-columns {
-	display: grid;
-	grid-template-columns: 1fr 1fr;
-	gap: calc(2 * var(--default-grid-baseline));
-	align-items: start;
-}
-
-.ranking-column__label {
+.ranking-section__label {
 	color: var(--color-text-maxcontrast);
 	margin-block-end: var(--default-grid-baseline);
 	font-size: small;
 }
 
 .ranking-unranked {
+	margin-block-end: calc(2 * var(--default-grid-baseline));
+
 	&__pool {
 		display: flex;
-		flex-direction: column;
+		flex-wrap: wrap;
 		gap: var(--default-grid-baseline);
 	}
 
 	&__item {
-		display: block;
-		width: 100%;
+		display: inline-block;
 		padding: var(--default-grid-baseline) calc(2 * var(--default-grid-baseline));
-		min-height: var(--default-clickable-area);
-		line-height: calc(
-			var(--default-clickable-area) - 2 * var(--default-grid-baseline)
-		);
 		background-color: var(--color-background-dark);
 		border: 1px solid var(--color-border);
 		border-radius: var(--border-radius-large);
 		cursor: pointer;
 		font-size: inherit;
 		color: var(--color-main-text);
-		text-align: start;
 		transition: background-color var(--animation-quick);
 
 		&:hover,
@@ -425,7 +414,6 @@ export default {
 	align-items: center;
 	gap: var(--default-grid-baseline);
 	min-height: var(--default-clickable-area);
-	background-color: var(--color-background-dark);
 	border-radius: var(--border-radius-large);
 	user-select: none;
 

--- a/src/components/Questions/QuestionRanking.vue
+++ b/src/components/Questions/QuestionRanking.vue
@@ -1,5 +1,5 @@
 <!--
-  - SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+  - SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
   - SPDX-License-Identifier: AGPL-3.0-or-later
 -->
 
@@ -28,49 +28,49 @@
 		<!-- Submit mode -->
 		<div
 			v-if="readOnly"
-			class="question__content"
+			class="question__content ranking-columns"
 			role="list"
 			:aria-labelledby="titleId"
 			:aria-describedby="description ? descriptionId : undefined">
-			<!-- Unranked pool (visible when items remain) -->
-			<div v-if="unrankedOptions.length > 0" class="ranking-unranked">
-				<p class="ranking-unranked__label">
-					{{ t('forms', 'Tap to rank') }}
+			<!-- Left: Unranked pool -->
+			<div class="ranking-unranked">
+				<p class="ranking-column__label">
+					{{ t('forms', 'Options') }}
 				</p>
-				<button
-					v-for="option in unrankedOptions"
-					:key="option.id"
-					class="ranking-unranked__item"
-					@click="rankOption(option)">
-					{{ option.text }}
-				</button>
+				<div class="ranking-unranked__pool">
+					<button
+						v-for="option in unrankedOptions"
+						:key="option.id"
+						class="ranking-unranked__item"
+						@click="rankOption(option)">
+						{{ option.text }}
+					</button>
+					<p
+						v-if="unrankedOptions.length === 0"
+						class="ranking-unranked__empty">
+						{{ t('forms', 'All options ranked') }}
+					</p>
+				</div>
 			</div>
 
-			<!-- Empty state when nothing ranked yet -->
-			<p v-if="rankedOptions.length === 0" class="ranking-empty">
-				{{ t('forms', 'Tap items above to rank them') }}
-			</p>
-
-			<!-- Ranked list header (to separate from pool) -->
-			<p v-if="rankedOptions.length > 0" class="ranking-ranked__label">
-				{{ t('forms', 'Your ranking') }}
-			</p>
-
-			<!-- Ranked list -->
-			<Draggable
-				v-model="rankedOptions"
-				:animation="200"
-				direction="vertical"
-				handle=".ranking-item__drag-handle"
-				@end="onRankingEnd">
-				<div
-					v-for="(option, index) in rankedOptions"
-					:key="option.id"
-					class="ranking-item"
-					role="listitem">
-					<span class="ranking-item__position">{{ index + 1 }}.</span>
-					<span class="ranking-item__text">{{ option.text }}</span>
-					<div class="ranking-item__actions">
+			<!-- Right: Ranked list -->
+			<div class="ranking-ranked">
+				<p class="ranking-column__label">
+					{{ t('forms', 'Your ranking') }}
+				</p>
+				<Draggable
+					v-model="rankedOptions"
+					class="ranking-ranked__list"
+					:animation="200"
+					direction="vertical"
+					handle=".ranking-item__drag-handle"
+					@end="onRankingEnd">
+					<div
+						v-for="(option, index) in rankedOptions"
+						:key="option.id"
+						class="ranking-item"
+						role="listitem">
+						<span class="ranking-item__position">{{ index + 1 }}.</span>
 						<NcActions
 							:aria-label="t('forms', 'Move option actions')"
 							class="ranking-item__drag-handle"
@@ -97,6 +97,7 @@
 								{{ t('forms', 'Move option down') }}
 							</NcActionButton>
 						</NcActions>
+						<span class="ranking-item__text">{{ option.text }}</span>
 						<NcButton
 							variant="tertiary"
 							:ariaLabel="t('forms', 'Remove from ranking')"
@@ -106,8 +107,11 @@
 							</template>
 						</NcButton>
 					</div>
-				</div>
-			</Draggable>
+				</Draggable>
+				<p v-if="rankedOptions.length === 0" class="ranking-ranked__empty">
+					{{ t('forms', 'Tap options to rank them') }}
+				</p>
+			</div>
 		</div>
 
 		<!-- Edit mode: manage options -->
@@ -351,25 +355,41 @@ export default {
 	gap: var(--default-grid-baseline);
 }
 
-.ranking-unranked {
-	margin-block-end: 12px;
+.ranking-columns {
+	display: grid;
+	grid-template-columns: 1fr 1fr;
+	gap: calc(2 * var(--default-grid-baseline));
+	align-items: start;
+}
 
-	&__label {
-		font-weight: bold;
-		color: var(--color-text-maxcontrast);
-		margin-block-end: 8px;
+.ranking-column__label {
+	color: var(--color-text-maxcontrast);
+	margin-block-end: var(--default-grid-baseline);
+	font-size: small;
+}
+
+.ranking-unranked {
+	&__pool {
+		display: flex;
+		flex-direction: column;
+		gap: var(--default-grid-baseline);
 	}
 
 	&__item {
-		display: inline-block;
-		padding: 8px 16px;
-		margin: 0 8px 8px 0;
+		display: block;
+		width: 100%;
+		padding: var(--default-grid-baseline) calc(2 * var(--default-grid-baseline));
+		min-height: var(--default-clickable-area);
+		line-height: calc(
+			var(--default-clickable-area) - 2 * var(--default-grid-baseline)
+		);
 		background-color: var(--color-background-dark);
 		border: 1px solid var(--color-border);
 		border-radius: var(--border-radius-large);
 		cursor: pointer;
 		font-size: inherit;
 		color: var(--color-main-text);
+		text-align: start;
 		transition: background-color var(--animation-quick);
 
 		&:hover,
@@ -378,27 +398,33 @@ export default {
 			border-color: var(--color-primary-element);
 		}
 	}
+
+	&__empty {
+		color: var(--color-text-maxcontrast);
+		font-style: italic;
+		padding: var(--default-grid-baseline) 0;
+	}
 }
 
-.ranking-empty {
-	color: var(--color-text-maxcontrast);
-	font-style: italic;
-	padding: 12px 0;
-}
+.ranking-ranked {
+	&__list {
+		display: flex;
+		flex-direction: column;
+		gap: var(--default-grid-baseline);
+	}
 
-.ranking-ranked__label {
-	font-weight: bold;
-	color: var(--color-text-maxcontrast);
-	margin-block-end: 4px;
+	&__empty {
+		color: var(--color-text-maxcontrast);
+		font-style: italic;
+		padding: var(--default-grid-baseline) 0;
+	}
 }
 
 .ranking-item {
 	display: flex;
 	align-items: center;
-	gap: 12px;
-	padding: 12px 16px;
-	min-height: 44px;
-	margin-block-end: 8px;
+	gap: var(--default-grid-baseline);
+	min-height: var(--default-clickable-area);
 	background-color: var(--color-background-dark);
 	border-radius: var(--border-radius-large);
 	user-select: none;
@@ -412,12 +438,6 @@ export default {
 
 	&__text {
 		flex: 1;
-	}
-
-	&__actions {
-		display: flex;
-		gap: var(--default-grid-baseline);
-		margin-inline-start: auto;
 	}
 
 	&__drag-handle {
@@ -445,7 +465,7 @@ export default {
 .options-list-transition-enter-from,
 .options-list-transition-leave-to {
 	opacity: 0;
-	transform: translateX(44px);
+	transform: translateX(var(--default-clickable-area));
 }
 
 .options-list-transition-leave-active {

--- a/src/components/Questions/QuestionRanking.vue
+++ b/src/components/Questions/QuestionRanking.vue
@@ -449,6 +449,14 @@ export default {
 	min-height: var(--default-clickable-area);
 	border-radius: var(--border-radius-large);
 	user-select: none;
+	transition-property: background-color;
+	transition-duration: 0.1s;
+	transition-timing-function: linear;
+
+	&:hover,
+	&:focus-within {
+		background-color: var(--color-background-hover);
+	}
 
 	&__position {
 		font-weight: bold;

--- a/src/components/Questions/QuestionRanking.vue
+++ b/src/components/Questions/QuestionRanking.vue
@@ -10,6 +10,7 @@
 		:warningInvalid="answerType.warningInvalid"
 		:contentValid="contentValid"
 		:shiftDragHandle="shiftDragHandle"
+		:allowRequired="false"
 		v-on="commonListeners">
 		<template #actions>
 			<NcActionCheckbox
@@ -188,6 +189,15 @@ export default {
 					.filter(Boolean)
 			} else {
 				this.rankedOptions = [...sorted]
+			}
+
+			// In submit mode, emit the initial ranking so the answer is always
+			// recorded – even when the user agrees with the default order.
+			if (this.readOnly && this.rankedOptions.length > 0) {
+				this.$emit(
+					'update:values',
+					this.rankedOptions.map((o) => o.id),
+				)
 			}
 		},
 

--- a/src/components/Questions/QuestionRanking.vue
+++ b/src/components/Questions/QuestionRanking.vue
@@ -157,6 +157,7 @@ export default {
 			get() {
 				return this.sortOptionsOfType(this.options, OptionType.Choice)
 			},
+
 			set(value) {
 				this.updateOptionsOrder(value, OptionType.Choice)
 			},

--- a/src/components/Questions/QuestionRanking.vue
+++ b/src/components/Questions/QuestionRanking.vue
@@ -34,12 +34,13 @@
 			:aria-describedby="description ? descriptionId : undefined">
 			<!-- Unranked pool -->
 			<div class="ranking-unranked">
-				<p class="ranking-section__label">
-					{{ t('forms', 'Tap to rank') }}
-				</p>
-				<div
+				<Draggable
 					v-show="unrankedOptions.length > 0"
-					class="ranking-unranked__pool">
+					v-model="unrankedOptions"
+					class="ranking-unranked__pool"
+					:animation="200"
+					:group="{ name: 'ranking', pull: true, put: true }"
+					@end="emitValues">
 					<button
 						v-for="option in unrankedOptions"
 						:key="option.id"
@@ -47,7 +48,7 @@
 						@click="rankOption(option)">
 						{{ option.text }}
 					</button>
-				</div>
+				</Draggable>
 				<p
 					v-show="unrankedOptions.length === 0"
 					class="ranking-unranked__empty">
@@ -64,6 +65,7 @@
 					v-model="rankedOptions"
 					class="ranking-ranked__list"
 					:animation="200"
+					:group="{ name: 'ranking', pull: true, put: true }"
 					direction="vertical"
 					handle=".ranking-item__drag-handle"
 					@end="onRankingEnd">

--- a/src/components/Questions/QuestionRanking.vue
+++ b/src/components/Questions/QuestionRanking.vue
@@ -74,13 +74,13 @@
 						:key="option.id"
 						class="ranking-item"
 						role="listitem">
-						<span class="ranking-item__position">{{ index + 1 }}.</span>
 						<NcActions
 							:id="`ranking-${option.id}-drag`"
 							:container="`#ranking-${option.id}-drag`"
 							:aria-label="t('forms', 'Move option actions')"
 							class="ranking-item__drag-handle"
 							variant="tertiary-no-background">
+
 							<template #icon>
 								<IconDragIndicator :size="20" />
 							</template>
@@ -103,6 +103,7 @@
 								{{ t('forms', 'Move option down') }}
 							</NcActionButton>
 						</NcActions>
+						<span class="ranking-item__position">{{ index + 1 }}.</span>
 						<span class="ranking-item__text">{{ option.text }}</span>
 						<NcButton
 							variant="tertiary"
@@ -445,7 +446,6 @@ export default {
 .ranking-item {
 	display: flex;
 	align-items: center;
-	gap: var(--default-grid-baseline);
 	min-height: var(--default-clickable-area);
 	border-radius: var(--border-radius-large);
 	user-select: none;
@@ -454,6 +454,7 @@ export default {
 		font-weight: bold;
 		min-width: 1.5em;
 		text-align: end;
+		margin-inline-end: calc(3 * var(--default-grid-baseline));
 		color: var(--color-text-maxcontrast);
 	}
 

--- a/src/components/Questions/QuestionRanking.vue
+++ b/src/components/Questions/QuestionRanking.vue
@@ -80,7 +80,6 @@
 							:aria-label="t('forms', 'Move option actions')"
 							class="ranking-item__drag-handle"
 							variant="tertiary-no-background">
-
 							<template #icon>
 								<IconDragIndicator :size="20" />
 							</template>
@@ -153,6 +152,7 @@
 					:isUnique="true"
 					:maxIndex="options.length - 1"
 					:maxOptionLength="maxStringLengths.optionText"
+					:isRanking="true"
 					optionType="choice"
 					@createAnswer="onCreateAnswer"
 					@update:answer="updateAnswer"

--- a/src/components/Questions/QuestionRanking.vue
+++ b/src/components/Questions/QuestionRanking.vue
@@ -69,18 +69,43 @@
 					class="ranking-item"
 					role="listitem">
 					<span class="ranking-item__position">{{ index + 1 }}.</span>
-					<span class="ranking-item__drag-handle">
-						<IconDragHorizontalVariant :size="20" />
-					</span>
 					<span class="ranking-item__text">{{ option.text }}</span>
-					<NcButton
-						variant="tertiary"
-						:ariaLabel="t('forms', 'Remove from ranking')"
-						@click="unrankOption(option)">
-						<template #icon>
-							<IconClose :size="20" />
-						</template>
-					</NcButton>
+					<div class="ranking-item__actions">
+						<NcActions
+							:aria-label="t('forms', 'Move option actions')"
+							class="ranking-item__drag-handle"
+							variant="tertiary-no-background">
+							<template #icon>
+								<IconDragIndicator :size="20" />
+							</template>
+							<NcActionButton
+								ref="buttonOptionUp"
+								:disabled="index === 0"
+								@click="onMoveUp(index)">
+								<template #icon>
+									<IconArrowUp :size="20" />
+								</template>
+								{{ t('forms', 'Move option up') }}
+							</NcActionButton>
+							<NcActionButton
+								ref="buttonOptionDown"
+								:disabled="index === rankedOptions.length - 1"
+								@click="onMoveDown(index)">
+								<template #icon>
+									<IconArrowDown :size="20" />
+								</template>
+								{{ t('forms', 'Move option down') }}
+							</NcActionButton>
+						</NcActions>
+						<NcButton
+							variant="tertiary"
+							:ariaLabel="t('forms', 'Remove from ranking')"
+							@click="unrankOption(option)">
+							<template #icon>
+								<IconClose :size="20" />
+							</template>
+						</NcButton>
+					</div>
 				</div>
 			</Draggable>
 		</div>
@@ -139,11 +164,14 @@
 import { VueDraggable as Draggable } from 'vue-draggable-plus'
 import NcActionButton from '@nextcloud/vue/components/NcActionButton'
 import NcActionCheckbox from '@nextcloud/vue/components/NcActionCheckbox'
+import NcActions from '@nextcloud/vue/components/NcActions'
 import NcButton from '@nextcloud/vue/components/NcButton'
 import NcLoadingIcon from '@nextcloud/vue/components/NcLoadingIcon'
+import IconArrowDown from 'vue-material-design-icons/ArrowDown.vue'
+import IconArrowUp from 'vue-material-design-icons/ArrowUp.vue'
 import IconClose from 'vue-material-design-icons/Close.vue'
 import IconContentPaste from 'vue-material-design-icons/ContentPaste.vue'
-import IconDragHorizontalVariant from 'vue-material-design-icons/DragHorizontalVariant.vue'
+import IconDragIndicator from '../Icons/IconDragIndicator.vue'
 import OptionInputDialog from '../OptionInputDialog.vue'
 import AnswerInput from './AnswerInput.vue'
 import Question from './Question.vue'
@@ -157,11 +185,14 @@ export default {
 	components: {
 		AnswerInput,
 		Draggable,
+		IconArrowDown,
+		IconArrowUp,
 		IconClose,
 		IconContentPaste,
-		IconDragHorizontalVariant,
+		IconDragIndicator,
 		NcActionButton,
 		NcActionCheckbox,
+		NcActions,
 		NcButton,
 		NcLoadingIcon,
 		OptionInputDialog,
@@ -263,6 +294,32 @@ export default {
 		},
 
 		/**
+		 * Move the ranked option at index up by one position
+		 *
+		 * @param {number} index Current index
+		 */
+		onMoveUp(index) {
+			if (index <= 0) return
+			const items = [...this.rankedOptions]
+			;[items[index - 1], items[index]] = [items[index], items[index - 1]]
+			this.rankedOptions = items
+			this.emitValues()
+		},
+
+		/**
+		 * Move the ranked option at index down by one position
+		 *
+		 * @param {number} index Current index
+		 */
+		onMoveDown(index) {
+			if (index >= this.rankedOptions.length - 1) return
+			const items = [...this.rankedOptions]
+			;[items[index], items[index + 1]] = [items[index + 1], items[index]]
+			this.rankedOptions = items
+			this.emitValues()
+		},
+
+		/**
 		 * Emit the current ranking after a drag reorder
 		 */
 		onRankingEnd() {
@@ -353,18 +410,29 @@ export default {
 		color: var(--color-text-maxcontrast);
 	}
 
-	&__drag-handle {
+	&__text {
+		flex: 1;
+	}
+
+	&__actions {
 		display: flex;
-		align-items: center;
+		gap: var(--default-grid-baseline);
+		margin-inline-start: auto;
+	}
+
+	&__drag-handle {
+		color: var(--color-text-maxcontrast);
 		cursor: grab;
+
+		&:hover,
+		&:focus,
+		&:focus-within {
+			color: var(--color-main-text);
+		}
 
 		&:active {
 			cursor: grabbing;
 		}
-	}
-
-	&__text {
-		flex: 1;
 	}
 }
 

--- a/src/components/Questions/QuestionRanking.vue
+++ b/src/components/Questions/QuestionRanking.vue
@@ -74,6 +74,8 @@
 						role="listitem">
 						<span class="ranking-item__position">{{ index + 1 }}.</span>
 						<NcActions
+							:id="`ranking-${option.id}-drag`"
+							:container="`#ranking-${option.id}-drag`"
 							:aria-label="t('forms', 'Move option actions')"
 							class="ranking-item__drag-handle"
 							variant="tertiary-no-background">
@@ -81,6 +83,7 @@
 								<IconDragIndicator :size="20" />
 							</template>
 							<NcActionButton
+								ref="buttonOptionUp"
 								:disabled="index === 0"
 								@click="onMoveUp(index)">
 								<template #icon>
@@ -89,6 +92,7 @@
 								{{ t('forms', 'Move option up') }}
 							</NcActionButton>
 							<NcActionButton
+								ref="buttonOptionDown"
 								:disabled="index === rankedOptions.length - 1"
 								@click="onMoveDown(index)">
 								<template #icon>
@@ -308,6 +312,11 @@ export default {
 			;[items[index - 1], items[index]] = [items[index], items[index - 1]]
 			this.rankedOptions = items
 			this.emitValues()
+			const newIndex = index - 1
+			this.focusButton(
+				newIndex > 0 ? 'buttonOptionUp' : 'buttonOptionDown',
+				newIndex,
+			)
 		},
 
 		/**
@@ -321,6 +330,28 @@ export default {
 			;[items[index], items[index + 1]] = [items[index + 1], items[index]]
 			this.rankedOptions = items
 			this.emitValues()
+			const newIndex = index + 1
+			this.focusButton(
+				newIndex < this.rankedOptions.length - 1
+					? 'buttonOptionDown'
+					: 'buttonOptionUp',
+				newIndex,
+			)
+		},
+
+		/**
+		 * Re-focus a button ref inside a v-for after reorder
+		 *
+		 * @param {string} refName The ref name ('buttonOptionUp' or 'buttonOptionDown')
+		 * @param {number} index The index of the item in the v-for
+		 */
+		focusButton(refName, index) {
+			this.$nextTick(() => {
+				const refs = this.$refs[refName]
+				if (Array.isArray(refs) && refs[index]) {
+					refs[index].$el?.focus()
+				}
+			})
 		},
 
 		/**

--- a/src/components/Questions/QuestionRanking.vue
+++ b/src/components/Questions/QuestionRanking.vue
@@ -1,0 +1,261 @@
+<!--
+  - SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+  - SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
+<template>
+	<Question
+		v-bind="questionProps"
+		:titlePlaceholder="answerType.titlePlaceholder"
+		:warningInvalid="answerType.warningInvalid"
+		:contentValid="contentValid"
+		:shiftDragHandle="shiftDragHandle"
+		v-on="commonListeners">
+		<template #actions>
+			<NcActionCheckbox
+				:modelValue="extraSettings?.shuffleOptions"
+				@update:modelValue="onShuffleOptionsChange">
+				{{ t('forms', 'Shuffle options') }}
+			</NcActionCheckbox>
+			<NcActionButton closeAfterClick @click="isOptionDialogShown = true">
+				<template #icon>
+					<IconContentPaste :size="20" />
+				</template>
+				{{ t('forms', 'Add multiple options') }}
+			</NcActionButton>
+		</template>
+
+		<!-- Submit mode: drag to rank -->
+		<div
+			v-if="readOnly"
+			class="question__content"
+			role="list"
+			:aria-labelledby="titleId"
+			:aria-describedby="description ? descriptionId : undefined">
+			<Draggable
+				v-model="rankedOptions"
+				:animation="200"
+				direction="vertical"
+				handle=".ranking-item__drag-handle"
+				@end="onRankingEnd">
+				<div
+					v-for="(option, index) in rankedOptions"
+					:key="option.id"
+					class="ranking-item"
+					role="listitem">
+					<span class="ranking-item__position">{{ index + 1 }}.</span>
+					<span class="ranking-item__drag-handle">
+						<IconDragHorizontalVariant :size="20" />
+					</span>
+					<span class="ranking-item__text">{{ option.text }}</span>
+				</div>
+			</Draggable>
+		</div>
+
+		<!-- Edit mode: manage options -->
+		<template v-else>
+			<div v-if="isLoading">
+				<NcLoadingIcon :size="64" />
+			</div>
+			<Draggable
+				v-else
+				v-model="choices"
+				class="question__content"
+				:animation="200"
+				direction="vertical"
+				handle=".option__drag-handle"
+				invertSwap
+				tag="transition-group"
+				:componentData="{
+					name: isDragging
+						? 'no-external-transition-on-drag'
+						: 'options-list-transition',
+				}"
+				@change="saveOptionsOrder('choice')"
+				@start="isDragging = true"
+				@end="isDragging = false">
+				<AnswerInput
+					v-for="(answer, index) in choices"
+					:key="answer.local ? 'option-local' : answer.id"
+					ref="input"
+					:answer="answer"
+					:formId="formId"
+					:index="index"
+					:isUnique="true"
+					:maxIndex="options.length - 1"
+					:maxOptionLength="maxStringLengths.optionText"
+					optionType="choice"
+					@createAnswer="onCreateAnswer"
+					@update:answer="updateAnswer"
+					@delete="deleteOption"
+					@focusNext="focusNextInput"
+					@moveUp="onOptionMoveUp(index, OptionType.Choice)"
+					@moveDown="onOptionMoveDown(index, OptionType.Choice)"
+					@tabbedOut="checkValidOption" />
+			</Draggable>
+		</template>
+
+		<!-- Add multiple options modal -->
+		<OptionInputDialog
+			v-model:open="isOptionDialogShown"
+			@multipleAnswers="handleMultipleOptions" />
+	</Question>
+</template>
+
+<script>
+import { VueDraggable as Draggable } from 'vue-draggable-plus'
+import NcActionButton from '@nextcloud/vue/components/NcActionButton'
+import NcActionCheckbox from '@nextcloud/vue/components/NcActionCheckbox'
+import NcLoadingIcon from '@nextcloud/vue/components/NcLoadingIcon'
+import IconContentPaste from 'vue-material-design-icons/ContentPaste.vue'
+import IconDragHorizontalVariant from 'vue-material-design-icons/DragHorizontalVariant.vue'
+import OptionInputDialog from '../OptionInputDialog.vue'
+import AnswerInput from './AnswerInput.vue'
+import Question from './Question.vue'
+import QuestionMixin from '../../mixins/QuestionMixin.js'
+import QuestionMultipleMixin from '../../mixins/QuestionMultipleMixin.ts'
+import { OptionType } from '../../models/Constants.ts'
+
+export default {
+	name: 'QuestionRanking',
+
+	components: {
+		AnswerInput,
+		Draggable,
+		IconContentPaste,
+		IconDragHorizontalVariant,
+		NcActionButton,
+		NcActionCheckbox,
+		NcLoadingIcon,
+		OptionInputDialog,
+		Question,
+	},
+
+	mixins: [QuestionMixin, QuestionMultipleMixin],
+	emits: ['update:values'],
+
+	data() {
+		return {
+			isDragging: false,
+			isLoading: false,
+			isOptionDialogShown: false,
+			rankedOptions: [],
+			OptionType,
+		}
+	},
+
+	computed: {
+		contentValid() {
+			return this.answerType.validate(this)
+		},
+
+		shiftDragHandle() {
+			return !this.readOnly && this.options.length !== 0 && !this.isLastEmpty
+		},
+
+		choices: {
+			get() {
+				return this.sortOptionsOfType(this.options, OptionType.Choice)
+			},
+			set(value) {
+				this.updateOptionsOrder(value, OptionType.Choice)
+			},
+		},
+	},
+
+	watch: {
+		options: {
+			immediate: true,
+			handler() {
+				this.initRankedOptions()
+			},
+		},
+	},
+
+	methods: {
+		/**
+		 * Initialize ranked options from existing values or default order
+		 */
+		initRankedOptions() {
+			const sorted = this.sortOptionsOfType(this.options, OptionType.Choice)
+
+			if (this.values && this.values.length > 0) {
+				// Restore order from saved values (array of option IDs)
+				const byId = Object.fromEntries(sorted.map((o) => [o.id, o]))
+				this.rankedOptions = this.values
+					.map((id) => byId[parseInt(id)])
+					.filter(Boolean)
+			} else {
+				this.rankedOptions = [...sorted]
+			}
+		},
+
+		/**
+		 * Emit the new ranking after a drag ends
+		 */
+		onRankingEnd() {
+			this.$emit(
+				'update:values',
+				this.rankedOptions.map((o) => o.id),
+			)
+		},
+	},
+}
+</script>
+
+<style lang="scss" scoped>
+.question__content {
+	display: flex;
+	flex-direction: column;
+	gap: var(--default-grid-baseline);
+}
+
+.ranking-item {
+	display: flex;
+	align-items: center;
+	gap: 12px;
+	padding: 12px 16px;
+	min-height: 44px;
+	margin-block-end: 8px;
+	background-color: var(--color-background-dark);
+	border-radius: var(--border-radius-large);
+	user-select: none;
+
+	&__position {
+		font-weight: bold;
+		min-width: 1.5em;
+		text-align: end;
+		color: var(--color-text-maxcontrast);
+	}
+
+	&__drag-handle {
+		display: flex;
+		align-items: center;
+		cursor: grab;
+
+		&:active {
+			cursor: grabbing;
+		}
+	}
+
+	&__text {
+		flex: 1;
+	}
+}
+
+.options-list-transition-move,
+.options-list-transition-enter-active,
+.options-list-transition-leave-active {
+	transition: all var(--animation-slow) ease;
+}
+
+.options-list-transition-enter-from,
+.options-list-transition-leave-to {
+	opacity: 0;
+	transform: translateX(44px);
+}
+
+.options-list-transition-leave-active {
+	position: absolute;
+}
+</style>

--- a/src/components/Questions/QuestionRanking.vue
+++ b/src/components/Questions/QuestionRanking.vue
@@ -1,0 +1,538 @@
+<!--
+  - SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+  - SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
+<template>
+	<Question
+		v-bind="questionProps"
+		:titlePlaceholder="answerType.titlePlaceholder"
+		:warningInvalid="answerType.warningInvalid"
+		:contentValid="contentValid"
+		:shiftDragHandle="shiftDragHandle"
+		:errorMessage="errorMessage"
+		v-on="commonListeners">
+		<template #actions>
+			<NcActionCheckbox
+				:modelValue="extraSettings?.shuffleOptions"
+				@update:modelValue="onShuffleOptionsChange">
+				{{ t('forms', 'Shuffle options') }}
+			</NcActionCheckbox>
+			<NcActionButton closeAfterClick @click="isOptionDialogShown = true">
+				<template #icon>
+					<NcIconSvgWrapper :svg="IconContentPaste" />
+				</template>
+				{{ t('forms', 'Add multiple options') }}
+			</NcActionButton>
+		</template>
+
+		<!-- Submit mode -->
+		<div
+			v-if="readOnly"
+			class="question__content"
+			role="list"
+			:aria-labelledby="titleId"
+			:aria-describedby="description ? descriptionId : undefined">
+			<!-- Unranked pool -->
+			<div class="ranking-unranked">
+				<Draggable
+					v-if="unrankedOptions.length > 0"
+					v-model="unrankedOptions"
+					class="ranking-unranked__pool"
+					:animation="200"
+					:group="'ranking_' + id"
+					@end="emitValues">
+					<button
+						v-for="option in unrankedOptions"
+						:key="option.id"
+						class="ranking-unranked__item"
+						@click="rankOption(option)">
+						{{ option.text }}
+					</button>
+				</Draggable>
+				<p v-else class="ranking-unranked__empty">
+					{{ t('forms', 'All options ranked') }}
+				</p>
+			</div>
+
+			<!-- Ranked list -->
+			<div class="ranking-ranked">
+				<p class="ranking-section__label">
+					{{ t('forms', 'Your ranking') }}
+				</p>
+				<Draggable
+					v-model="rankedOptions"
+					class="ranking-ranked__list"
+					:animation="200"
+					:group="'ranking_' + id"
+					direction="vertical"
+					handle=".ranking-item__drag-handle"
+					@end="onRankingEnd">
+					<div
+						v-for="(option, index) in rankedOptions"
+						:key="option.id"
+						class="ranking-item"
+						role="listitem">
+						<NcActions
+							:id="`ranking-${option.id}-drag`"
+							:container="`#ranking-${option.id}-drag`"
+							:aria-label="t('forms', 'Move option actions')"
+							class="ranking-item__drag-handle"
+							variant="tertiary-no-background">
+							<template #icon>
+								<IconDragIndicator :size="20" />
+							</template>
+							<NcActionButton
+								ref="buttonOptionUp"
+								:disabled="index === 0"
+								@click="onMoveUp(index)">
+								<template #icon>
+									<IconArrowUp :size="20" />
+								</template>
+								{{ t('forms', 'Move option up') }}
+							</NcActionButton>
+							<NcActionButton
+								ref="buttonOptionDown"
+								:disabled="index === rankedOptions.length - 1"
+								@click="onMoveDown(index)">
+								<template #icon>
+									<IconArrowDown :size="20" />
+								</template>
+								{{ t('forms', 'Move option down') }}
+							</NcActionButton>
+						</NcActions>
+						<span class="ranking-item__position">{{ index + 1 }}.</span>
+						<span class="ranking-item__text">{{ option.text }}</span>
+						<NcButton
+							variant="tertiary"
+							:ariaLabel="t('forms', 'Remove from ranking')"
+							@click="unrankOption(option)">
+							<template #icon>
+								<IconClose :size="20" />
+							</template>
+						</NcButton>
+					</div>
+				</Draggable>
+				<p v-if="rankedOptions.length === 0" class="ranking-ranked__empty">
+					{{ t('forms', 'Tap options above to rank them') }}
+				</p>
+			</div>
+		</div>
+
+		<!-- Edit mode: manage options -->
+		<template v-else>
+			<div v-if="isLoading">
+				<NcLoadingIcon :size="64" />
+			</div>
+			<Draggable
+				v-else
+				v-model="choices"
+				class="question__content"
+				:animation="200"
+				direction="vertical"
+				handle=".option__drag-handle"
+				invertSwap
+				tag="transition-group"
+				:componentData="{
+					name: isDragging
+						? 'no-external-transition-on-drag'
+						: 'options-list-transition',
+				}"
+				@change="saveOptionsOrder('choice')"
+				@start="isDragging = true"
+				@end="isDragging = false">
+				<AnswerInput
+					v-for="(answer, index) in choices"
+					:key="answer.local ? 'option-local' : answer.id"
+					ref="input"
+					:answer="answer"
+					:formId="formId"
+					:index="index"
+					:isUnique="true"
+					:maxIndex="options.length - 1"
+					:maxOptionLength="maxStringLengths.optionText"
+					:isRanking="true"
+					optionType="choice"
+					@createAnswer="onCreateAnswer"
+					@update:answer="updateAnswer"
+					@delete="deleteOption"
+					@focusNext="focusNextInput"
+					@moveUp="onOptionMoveUp(index, OptionType.Choice)"
+					@moveDown="onOptionMoveDown(index, OptionType.Choice)"
+					@tabbedOut="checkValidOption" />
+			</Draggable>
+		</template>
+
+		<!-- Add multiple options modal -->
+		<OptionInputDialog
+			v-model:open="isOptionDialogShown"
+			@multipleAnswers="handleMultipleOptions" />
+	</Question>
+</template>
+
+<script>
+import IconClose from '@material-symbols/svg-400/outlined/close.svg?raw'
+import IconContentPaste from '@material-symbols/svg-400/outlined/content_paste.svg?raw'
+import IconDragIndicator from '@material-symbols/svg-400/outlined/drag_indicator.svg?raw'
+import IconArrowDown from '@material-symbols/svg-400/outlined/keyboard_arrow_down.svg?raw'
+import IconArrowUp from '@material-symbols/svg-400/outlined/keyboard_arrow_up.svg?raw'
+import { translate as t } from '@nextcloud/l10n'
+import { VueDraggable as Draggable } from 'vue-draggable-plus'
+import NcActionButton from '@nextcloud/vue/components/NcActionButton'
+import NcActionCheckbox from '@nextcloud/vue/components/NcActionCheckbox'
+import NcActions from '@nextcloud/vue/components/NcActions'
+import NcButton from '@nextcloud/vue/components/NcButton'
+import NcIconSvgWrapper from '@nextcloud/vue/components/NcIconSvgWrapper'
+import NcLoadingIcon from '@nextcloud/vue/components/NcLoadingIcon'
+import OptionInputDialog from '../OptionInputDialog.vue'
+import AnswerInput from './AnswerInput.vue'
+import Question from './Question.vue'
+import QuestionMixin from '../../mixins/QuestionMixin.js'
+import QuestionMultipleMixin from '../../mixins/QuestionMultipleMixin.ts'
+import { OptionType } from '../../models/Constants.ts'
+
+export default {
+	name: 'QuestionRanking',
+
+	components: {
+		AnswerInput,
+		Draggable,
+		NcActionButton,
+		NcActionCheckbox,
+		NcActions,
+		NcButton,
+		NcIconSvgWrapper,
+		NcLoadingIcon,
+		OptionInputDialog,
+		Question,
+	},
+
+	mixins: [QuestionMixin, QuestionMultipleMixin],
+	emits: ['update:values'],
+
+	setup() {
+		return {
+			IconArrowDown,
+			IconArrowUp,
+			IconClose,
+			IconContentPaste,
+			IconDragIndicator,
+		}
+	},
+
+	data() {
+		return {
+			errorMessage: null,
+			isDragging: false,
+			isLoading: false,
+			isOptionDialogShown: false,
+			rankedOptions: [],
+			unrankedOptions: [],
+			OptionType,
+		}
+	},
+
+	computed: {
+		contentValid() {
+			return this.answerType.validate(this)
+		},
+
+		shiftDragHandle() {
+			return !this.readOnly && this.options.length !== 0 && !this.isLastEmpty
+		},
+
+		choices: {
+			get() {
+				return this.sortOptionsOfType(this.options, OptionType.Choice)
+			},
+
+			set(value) {
+				this.updateOptionsOrder(value, OptionType.Choice)
+			},
+		},
+	},
+
+	watch: {
+		options: {
+			immediate: true,
+			handler() {
+				this.initRankedOptions()
+			},
+		},
+
+		values: {
+			immediate: true,
+			handler() {
+				this.initRankedOptions()
+			},
+		},
+	},
+
+	methods: {
+		async validate() {
+			const optionsCount = this.sortOptionsOfType(
+				this.options,
+				OptionType.Choice,
+			).length
+
+			if (
+				(this.isRequired && this.rankedOptions.length === 0)
+				|| (this.rankedOptions.length > 0
+					&& this.rankedOptions.length !== optionsCount)
+			) {
+				this.errorMessage = t('forms', 'You must rank all options')
+				return false
+			}
+
+			this.errorMessage = null
+			return true
+		},
+
+		/**
+		 * Initialize ranked/unranked options from existing values or default order
+		 */
+		initRankedOptions() {
+			const sorted = this.sortOptionsOfType(this.options, OptionType.Choice)
+
+			if (this.values && this.values.length > 0) {
+				// Restore order from saved values (array of option IDs)
+				const byId = Object.fromEntries(sorted.map((o) => [o.id, o]))
+				this.rankedOptions = this.values
+					.map((id) => byId[parseInt(id)])
+					.filter(Boolean)
+				this.unrankedOptions = sorted.filter(
+					(o) => !this.rankedOptions.some((r) => r.id === o.id),
+				)
+			} else if (this.readOnly) {
+				// Submit mode: start with all options unranked
+				this.rankedOptions = []
+				this.unrankedOptions = [...sorted]
+			} else {
+				// Edit mode: show all options in default order
+				this.rankedOptions = [...sorted]
+				this.unrankedOptions = []
+			}
+		},
+
+		/**
+		 * Move an option from the unranked pool to the ranked list
+		 *
+		 * @param {object} option The option to rank
+		 */
+		rankOption(option) {
+			this.unrankedOptions = this.unrankedOptions.filter(
+				(o) => o.id !== option.id,
+			)
+			this.rankedOptions.push(option)
+			this.emitValues()
+		},
+
+		/**
+		 * Move an option from the ranked list back to the unranked pool
+		 *
+		 * @param {object} option The option to unrank
+		 */
+		unrankOption(option) {
+			this.rankedOptions = this.rankedOptions.filter((o) => o.id !== option.id)
+			this.unrankedOptions.push(option)
+			this.emitValues()
+		},
+
+		/**
+		 * Move the ranked option at index up by one position
+		 *
+		 * @param {number} index Current index
+		 */
+		onMoveUp(index) {
+			if (index <= 0) return
+			const items = [...this.rankedOptions]
+			;[items[index - 1], items[index]] = [items[index], items[index - 1]]
+			this.rankedOptions = items
+			this.emitValues()
+			const newIndex = index - 1
+			this.focusButton(
+				newIndex > 0 ? 'buttonOptionUp' : 'buttonOptionDown',
+				newIndex,
+			)
+		},
+
+		/**
+		 * Move the ranked option at index down by one position
+		 *
+		 * @param {number} index Current index
+		 */
+		onMoveDown(index) {
+			if (index >= this.rankedOptions.length - 1) return
+			const items = [...this.rankedOptions]
+			;[items[index], items[index + 1]] = [items[index + 1], items[index]]
+			this.rankedOptions = items
+			this.emitValues()
+			const newIndex = index + 1
+			this.focusButton(
+				newIndex < this.rankedOptions.length - 1
+					? 'buttonOptionDown'
+					: 'buttonOptionUp',
+				newIndex,
+			)
+		},
+
+		/**
+		 * Re-focus a button ref inside a v-for after reorder
+		 *
+		 * @param {string} refName The ref name ('buttonOptionUp' or 'buttonOptionDown')
+		 * @param {number} index The index of the item in the v-for
+		 */
+		focusButton(refName, index) {
+			this.$nextTick(() => {
+				const refs = this.$refs[refName]
+				if (Array.isArray(refs) && refs[index]) {
+					refs[index].$el?.focus()
+				}
+			})
+		},
+
+		/**
+		 * Emit the current ranking after a drag reorder
+		 */
+		onRankingEnd() {
+			this.emitValues()
+		},
+
+		/**
+		 * Emit the current values based on ranking state
+		 */
+		emitValues() {
+			if (this.rankedOptions.length === 0) {
+				// Nothing ranked — emit empty to signal unanswered
+				this.$emit('update:values', [])
+			} else {
+				this.$emit(
+					'update:values',
+					this.rankedOptions.map((o) => o.id),
+				)
+			}
+		},
+	},
+}
+</script>
+
+<style lang="scss" scoped>
+.question__content {
+	display: flex;
+	flex-direction: column;
+	gap: var(--default-grid-baseline);
+}
+
+.ranking-section__label {
+	color: var(--color-text-maxcontrast);
+	margin-block-end: var(--default-grid-baseline);
+	font-size: small;
+}
+
+.ranking-unranked {
+	margin-block-end: calc(2 * var(--default-grid-baseline));
+
+	&__pool {
+		display: flex;
+		flex-wrap: wrap;
+		gap: var(--default-grid-baseline);
+	}
+
+	&__item {
+		display: inline-block;
+		padding: var(--default-grid-baseline) calc(2 * var(--default-grid-baseline));
+		background-color: var(--color-background-dark);
+		border: 1px solid var(--color-border);
+		border-radius: var(--border-radius-large);
+		cursor: pointer;
+		font-size: inherit;
+		color: var(--color-main-text);
+		transition: background-color var(--animation-quick);
+
+		&:hover,
+		&:focus-visible {
+			background-color: var(--color-background-hover);
+			border-color: var(--color-primary-element);
+		}
+	}
+
+	&__empty {
+		color: var(--color-text-maxcontrast);
+		font-style: italic;
+		padding: var(--default-grid-baseline) 0;
+	}
+}
+
+.ranking-ranked {
+	&__list {
+		display: flex;
+		flex-direction: column;
+		gap: var(--default-grid-baseline);
+	}
+
+	&__empty {
+		color: var(--color-text-maxcontrast);
+		font-style: italic;
+		padding: var(--default-grid-baseline) 0;
+	}
+}
+
+.ranking-item {
+	display: flex;
+	align-items: center;
+	min-height: var(--default-clickable-area);
+	border-radius: var(--border-radius-large);
+	user-select: none;
+	transition-property: background-color;
+	transition-duration: 0.1s;
+	transition-timing-function: linear;
+
+	&:hover,
+	&:focus-within {
+		background-color: var(--color-background-hover);
+	}
+
+	&__position {
+		font-weight: bold;
+		min-width: 1.5em;
+		text-align: end;
+		margin-inline-end: calc(3 * var(--default-grid-baseline));
+		color: var(--color-text-maxcontrast);
+	}
+
+	&__text {
+		flex: 1;
+	}
+
+	&__drag-handle {
+		color: var(--color-text-maxcontrast);
+		cursor: grab;
+
+		&:hover,
+		&:focus,
+		&:focus-within {
+			color: var(--color-main-text);
+		}
+
+		&:active {
+			cursor: grabbing;
+		}
+	}
+}
+
+.options-list-transition-move,
+.options-list-transition-enter-active,
+.options-list-transition-leave-active {
+	transition: all var(--animation-slow) ease;
+}
+
+.options-list-transition-enter-from,
+.options-list-transition-leave-to {
+	opacity: 0;
+	transform: translateX(var(--default-clickable-area));
+}
+
+.options-list-transition-leave-active {
+	position: absolute;
+}
+</style>

--- a/src/components/Results/ResultsSummary.vue
+++ b/src/components/Results/ResultsSummary.vue
@@ -13,33 +13,42 @@
 		</p>
 
 		<!-- Ranking questions: Borda count with average rank -->
-		<div
-			v-if="question.type === 'ranking'"
-			class="question-summary__statistic">
+		<div v-if="question.type === 'ranking'" class="question-summary__statistic">
 			<p class="question-summary__ranking-description">
-				{{ t('forms', 'Ranked by Borda count: each 1st place receives {n} points, 2nd place {n1} points, and so on. Higher score means more preferred.', { n: question.options.length, n1: question.options.length - 1 }) }}
+				{{
+					t(
+						'forms',
+						'Ranked by Borda count: each 1st place receives {n} points, 2nd place {n1} points, and so on. Higher score means more preferred.',
+						{
+							n: question.options.length,
+							n1: question.options.length - 1,
+						},
+					)
+				}}
 			</p>
 			<ol>
-			<li v-for="option in rankingStats" :key="option.id">
-				<label>
-					<span class="question-summary__statistic-score">
-						{{ option.bordaTotal }}
-					</span>
-					<span class="question-summary__statistic-percentage">
-						({{ t('forms', 'avg. rank {average}', { average: option.avgRank }) }}):
-					</span>
-					<span
-						:class="{
-							'question-summary__statistic-text--best': option.best,
-						}">
-						{{ option.text }}
-					</span>
-				</label>
-				<meter
-					min="0"
-					:max="maxBordaScore"
-					:value="option.bordaTotal" />
-			</li>
+				<li v-for="option in rankingStats" :key="option.id">
+					<label>
+						<span class="question-summary__statistic-score">
+							{{ option.bordaTotal }}
+						</span>
+						<span class="question-summary__statistic-percentage">
+							({{
+								t('forms', 'avg. rank {average}', {
+									average: option.avgRank,
+								})
+							}}):
+						</span>
+						<span
+							:class="{
+								'question-summary__statistic-text--best':
+									option.best,
+							}">
+							{{ option.text }}
+						</span>
+					</label>
+					<meter min="0" :max="maxBordaScore" :value="option.bordaTotal" />
+				</li>
 			</ol>
 		</div>
 
@@ -362,10 +371,7 @@ export default {
 			const result = Object.values(stats)
 				.map((s) => ({
 					...s,
-					avgRank:
-						s.count > 0
-							? (s.rankSum / s.count).toFixed(1)
-							: '-',
+					avgRank: s.count > 0 ? (s.rankSum / s.count).toFixed(1) : '-',
 				}))
 				.sort((a, b) => b.bordaTotal - a.bordaTotal)
 

--- a/src/components/Results/ResultsSummary.vue
+++ b/src/components/Results/ResultsSummary.vue
@@ -12,9 +12,40 @@
 			{{ questionTypeLabel }}
 		</p>
 
+		<!-- Ranking questions: Borda count with average rank -->
+		<div
+			v-if="question.type === 'ranking'"
+			class="question-summary__statistic">
+			<p class="question-summary__ranking-description">
+				{{ t('forms', 'Ranked by Borda count: each 1st place receives {n} points, 2nd place {n1} points, and so on. Higher score means more preferred.', { n: question.options.length, n1: question.options.length - 1 }) }}
+			</p>
+			<ol>
+			<li v-for="option in rankingStats" :key="option.id">
+				<label>
+					<span class="question-summary__statistic-score">
+						{{ option.bordaTotal }}
+					</span>
+					<span class="question-summary__statistic-percentage">
+						({{ t('forms', 'avg. rank {average}', { average: option.avgRank }) }}):
+					</span>
+					<span
+						:class="{
+							'question-summary__statistic-text--best': option.best,
+						}">
+						{{ option.text }}
+					</span>
+				</label>
+				<meter
+					min="0"
+					:max="maxBordaScore"
+					:value="option.bordaTotal" />
+			</li>
+			</ol>
+		</div>
+
 		<!-- Answers with countable results for visualization -->
 		<ol
-			v-if="answerTypes[question.type].predefined"
+			v-else-if="answerTypes[question.type].predefined"
 			class="question-summary__statistic">
 			<li v-for="option in questionOptions" :key="option.id">
 				<label :for="`option-${option.questionId}-${option.id}`">
@@ -296,6 +327,64 @@ export default {
 			return questionOptionsStats
 		},
 
+		/**
+		 * Borda count ranking statistics
+		 */
+		rankingStats() {
+			const n = this.question.options.length
+			const stats = {}
+
+			for (const opt of this.question.options) {
+				stats[opt.id] = {
+					id: opt.id,
+					text: opt.text,
+					bordaTotal: 0,
+					rankSum: 0,
+					count: 0,
+				}
+			}
+
+			for (const submission of this.submissions) {
+				const answer = submission.answers.find(
+					(a) => a.questionId === this.question.id,
+				)
+				if (!answer) continue
+				const ranked = JSON.parse(answer.text)
+				ranked.forEach((optionId, index) => {
+					if (stats[optionId]) {
+						stats[optionId].bordaTotal += n - index
+						stats[optionId].rankSum += index + 1
+						stats[optionId].count++
+					}
+				})
+			}
+
+			const result = Object.values(stats)
+				.map((s) => ({
+					...s,
+					avgRank:
+						s.count > 0
+							? (s.rankSum / s.count).toFixed(1)
+							: '-',
+				}))
+				.sort((a, b) => b.bordaTotal - a.bordaTotal)
+
+			// Mark best (highest Borda score)
+			if (result.length > 0 && result[0].bordaTotal > 0) {
+				const best = result[0].bordaTotal
+				result.forEach((o) => {
+					o.best = o.bordaTotal === best
+				})
+			}
+
+			return result
+		},
+
+		maxBordaScore() {
+			const n = this.question.options.length
+			return n * this.submissions.length
+		},
+
 		gridColumns() {
 			return this.question.options.filter(
 				(option) => option.optionType === OptionType.Column,
@@ -535,6 +624,12 @@ export default {
 
 			label {
 				cursor: default;
+			}
+
+			.question-summary__ranking-description {
+				color: var(--color-text-maxcontrast);
+				font-style: italic;
+				margin-block-end: 8px;
 			}
 
 			.question-summary__statistic-text--best {

--- a/src/components/Results/ResultsSummary.vue
+++ b/src/components/Results/ResultsSummary.vue
@@ -12,9 +12,49 @@
 			{{ questionTypeLabel }}
 		</p>
 
+		<!-- Ranking questions: Borda count with average rank -->
+		<div v-if="question.type === 'ranking'" class="question-summary__statistic">
+			<p class="question-summary__ranking-description">
+				{{
+					t(
+						'forms',
+						'Ranked by Borda count: each 1st place receives {n} points, 2nd place {n1} points, and so on. Higher score means more preferred.',
+						{
+							n: question.options.length,
+							n1: question.options.length - 1,
+						},
+					)
+				}}
+			</p>
+			<ol>
+				<li v-for="option in rankingStats" :key="option.id">
+					<label>
+						<span class="question-summary__statistic-score">
+							{{ option.bordaTotal }}
+						</span>
+						<span class="question-summary__statistic-percentage">
+							({{
+								t('forms', 'avg. rank {average}', {
+									average: option.avgRank,
+								})
+							}}):
+						</span>
+						<span
+							:class="{
+								'question-summary__statistic-text--best':
+									option.best,
+							}">
+							{{ option.text }}
+						</span>
+					</label>
+					<meter min="0" :max="maxBordaScore" :value="option.bordaTotal" />
+				</li>
+			</ol>
+		</div>
+
 		<!-- Answers with countable results for visualization -->
 		<ol
-			v-if="answerTypes[question.type].predefined"
+			v-else-if="answerTypes[question.type].predefined"
 			class="question-summary__statistic">
 			<li v-for="option in questionOptions" :key="option.id">
 				<label :for="`option-${option.questionId}-${option.id}`">
@@ -303,6 +343,61 @@ export default {
 			return questionOptionsStats
 		},
 
+		/**
+		 * Borda count ranking statistics
+		 */
+		rankingStats() {
+			const n = this.question.options.length
+			const stats = {}
+
+			for (const opt of this.question.options) {
+				stats[opt.id] = {
+					id: opt.id,
+					text: opt.text,
+					bordaTotal: 0,
+					rankSum: 0,
+					count: 0,
+				}
+			}
+
+			for (const submission of this.submissions) {
+				const answer = submission.answers.find(
+					(a) => a.questionId === this.question.id,
+				)
+				if (!answer) continue
+				const ranked = JSON.parse(answer.text)
+				ranked.forEach((optionId, index) => {
+					if (stats[optionId]) {
+						stats[optionId].bordaTotal += n - index
+						stats[optionId].rankSum += index + 1
+						stats[optionId].count++
+					}
+				})
+			}
+
+			const result = Object.values(stats)
+				.map((s) => ({
+					...s,
+					avgRank: s.count > 0 ? (s.rankSum / s.count).toFixed(1) : '-',
+				}))
+				.sort((a, b) => b.bordaTotal - a.bordaTotal)
+
+			// Mark best (highest Borda score)
+			if (result.length > 0 && result[0].bordaTotal > 0) {
+				const best = result[0].bordaTotal
+				result.forEach((o) => {
+					o.best = o.bordaTotal === best
+				})
+			}
+
+			return result
+		},
+
+		maxBordaScore() {
+			const n = this.question.options.length
+			return n * this.submissions.length
+		},
+
 		gridColumns() {
 			return this.question.options.filter(
 				(option) => option.optionType === OptionType.Column,
@@ -536,6 +631,12 @@ export default {
 
 			label {
 				cursor: default;
+			}
+
+			.question-summary__ranking-description {
+				color: var(--color-text-maxcontrast);
+				font-style: italic;
+				margin-block-end: 8px;
 			}
 
 			.question-summary__statistic-text--best {

--- a/src/components/Results/Submission.vue
+++ b/src/components/Results/Submission.vue
@@ -224,6 +224,29 @@ export default {
 						type: question.type,
 						squashedAnswers,
 					})
+				} else if (question.type === 'ranking') {
+					const optionsPerId = {}
+					question.options.forEach((option) => {
+						optionsPerId[option.id] = option
+					})
+					const rankedIds = answers[0]?.text
+						? JSON.parse(answers[0].text)
+						: []
+					const squashedAnswers = rankedIds
+						.map((id, index) => {
+							const option = optionsPerId[id]
+							return option
+								? `${index + 1}. ${option.text}`
+								: `${index + 1}. ?`
+						})
+						.join('\n')
+
+					answeredQuestionsArray.push({
+						id: question.id,
+						text: question.text,
+						type: question.type,
+						squashedAnswers,
+					})
 				} else {
 					const squashedAnswers = answers
 						.map((answer) => answer.text)

--- a/src/components/Results/Submission.vue
+++ b/src/components/Results/Submission.vue
@@ -231,6 +231,29 @@ export default {
 						type: question.type,
 						squashedAnswers,
 					})
+				} else if (question.type === 'ranking') {
+					const optionsPerId = {}
+					question.options.forEach((option) => {
+						optionsPerId[option.id] = option
+					})
+					const rankedIds = answers[0]?.text
+						? JSON.parse(answers[0].text)
+						: []
+					const squashedAnswers = rankedIds
+						.map((id, index) => {
+							const option = optionsPerId[id]
+							return option
+								? `${index + 1}. ${option.text}`
+								: `${index + 1}. ?`
+						})
+						.join('\n')
+
+					answeredQuestionsArray.push({
+						id: question.id,
+						text: question.text,
+						type: question.type,
+						squashedAnswers,
+					})
 				} else {
 					const squashedAnswers = answers
 						.map((answer) => answer.text)

--- a/src/models/AnswerTypes.js
+++ b/src/models/AnswerTypes.js
@@ -12,6 +12,7 @@ import IconFile from 'vue-material-design-icons/FileOutline.vue'
 import IconGrid from 'vue-material-design-icons/Grid.vue'
 import IconNumeric from 'vue-material-design-icons/Numeric.vue'
 import IconRadioboxMarked from 'vue-material-design-icons/RadioboxMarked.vue'
+import IconReorderHorizontal from 'vue-material-design-icons/ReorderHorizontal.vue'
 import IconTextLong from 'vue-material-design-icons/TextLong.vue'
 import IconTextShort from 'vue-material-design-icons/TextShort.vue'
 import IconLinearScale from '../components/Icons/IconLinearScale.vue'
@@ -24,6 +25,7 @@ import QuestionGrid from '../components/Questions/QuestionGrid.vue'
 import QuestionLinearScale from '../components/Questions/QuestionLinearScale.vue'
 import QuestionLong from '../components/Questions/QuestionLong.vue'
 import QuestionMultiple from '../components/Questions/QuestionMultiple.vue'
+import QuestionRanking from '../components/Questions/QuestionRanking.vue'
 import QuestionShort from '../components/Questions/QuestionShort.vue'
 import { OptionType } from './Constants.ts'
 
@@ -263,5 +265,21 @@ export default {
 		createPlaceholder: t('forms', 'People can pick a color'),
 		submitPlaceholder: t('forms', 'Pick a color'),
 		warningInvalid: t('forms', 'This question needs a title!'),
+	},
+
+	ranking: {
+		component: markRaw(QuestionRanking),
+		icon: markRaw(IconReorderHorizontal),
+		label: t('forms', 'Ranking'),
+		predefined: true,
+		validate: (question) => question.options.length > 0,
+
+		titlePlaceholder: t('forms', 'Ranking question title'),
+		createPlaceholder: t('forms', 'People can rank options'),
+		submitPlaceholder: t('forms', 'Drag to rank'),
+		warningInvalid: t(
+			'forms',
+			'This question needs a title and at least one answer!',
+		),
 	},
 }

--- a/src/models/AnswerTypes.js
+++ b/src/models/AnswerTypes.js
@@ -12,7 +12,7 @@ import IconFile from 'vue-material-design-icons/FileOutline.vue'
 import IconGrid from 'vue-material-design-icons/Grid.vue'
 import IconNumeric from 'vue-material-design-icons/Numeric.vue'
 import IconRadioboxMarked from 'vue-material-design-icons/RadioboxMarked.vue'
-import IconReorderHorizontal from 'vue-material-design-icons/ReorderHorizontal.vue'
+import IconSwapVertical from 'vue-material-design-icons/SwapVertical.vue'
 import IconTextLong from 'vue-material-design-icons/TextLong.vue'
 import IconTextShort from 'vue-material-design-icons/TextShort.vue'
 import IconLinearScale from '../components/Icons/IconLinearScale.vue'
@@ -269,7 +269,7 @@ export default {
 
 	ranking: {
 		component: markRaw(QuestionRanking),
-		icon: markRaw(IconReorderHorizontal),
+		icon: markRaw(IconSwapVertical),		
 		label: t('forms', 'Ranking'),
 		predefined: true,
 		validate: (question) => question.options.length > 0,

--- a/src/models/AnswerTypes.js
+++ b/src/models/AnswerTypes.js
@@ -269,7 +269,7 @@ export default {
 
 	ranking: {
 		component: markRaw(QuestionRanking),
-		icon: markRaw(IconSwapVertical),		
+		icon: markRaw(IconSwapVertical),
 		label: t('forms', 'Ranking'),
 		predefined: true,
 		validate: (question) => question.options.length > 0,

--- a/src/models/AnswerTypes.js
+++ b/src/models/AnswerTypes.js
@@ -15,6 +15,7 @@ import IconRadioboxMarked from '@material-symbols/svg-400/outlined/radio_button_
 import IconClockOutline from '@material-symbols/svg-400/outlined/schedule.svg?raw'
 import IconTextShort from '@material-symbols/svg-400/outlined/short_text.svg?raw'
 import IconTextLong from '@material-symbols/svg-400/outlined/subject.svg?raw'
+import IconSwapVertical from '@material-symbols/svg-400/outlined/swap_vert.svg?raw'
 import { markRaw } from 'vue'
 import QuestionColor from '../components/Questions/QuestionColor.vue'
 import QuestionDate from '../components/Questions/QuestionDate.vue'
@@ -24,6 +25,7 @@ import QuestionGrid from '../components/Questions/QuestionGrid.vue'
 import QuestionLinearScale from '../components/Questions/QuestionLinearScale.vue'
 import QuestionLong from '../components/Questions/QuestionLong.vue'
 import QuestionMultiple from '../components/Questions/QuestionMultiple.vue'
+import QuestionRanking from '../components/Questions/QuestionRanking.vue'
 import QuestionShort from '../components/Questions/QuestionShort.vue'
 import { OptionType } from './Constants.ts'
 
@@ -263,5 +265,21 @@ export default {
 		createPlaceholder: t('forms', 'People can pick a color'),
 		submitPlaceholder: t('forms', 'Pick a color'),
 		warningInvalid: t('forms', 'This question needs a title!'),
+	},
+
+	ranking: {
+		component: markRaw(QuestionRanking),
+		icon: IconSwapVertical,
+		label: t('forms', 'Ranking'),
+		predefined: true,
+		validate: (question) => question.options.length > 0,
+
+		titlePlaceholder: t('forms', 'Ranking question title'),
+		createPlaceholder: t('forms', 'People can rank options'),
+		submitPlaceholder: t('forms', 'Drag to rank'),
+		warningInvalid: t(
+			'forms',
+			'This question needs a title and at least one answer!',
+		),
 	},
 }

--- a/src/views/Submit.vue
+++ b/src/views/Submit.vue
@@ -575,10 +575,12 @@ export default {
 					continue
 				}
 
-				answers[questionId] =
-					answer.type === 'QuestionMultiple'
-						? answer.value.map(String)
-						: answer.value
+				answers[questionId] = [
+					'QuestionMultiple',
+					'QuestionRanking',
+				].includes(answer.type)
+					? answer.value.map(String)
+					: answer.value
 			}
 			this.answers = answers
 		},
@@ -654,7 +656,16 @@ export default {
 					const question = this.form.questions.find(
 						(question) => question.id === questionId,
 					)
-					if (
+					if (question.type === 'ranking') {
+						try {
+							answers[questionId].push(...JSON.parse(text).map(String))
+						} catch (error) {
+							logger.debug(
+								`Could not parse ranking answer ${text} for question ${questionId}`,
+								{ error },
+							)
+						}
+					} else if (
 						['multiple', 'multiple_unique', 'dropdown'].includes(
 							question.type,
 						)

--- a/tests/Unit/Service/SubmissionServiceTest.php
+++ b/tests/Unit/Service/SubmissionServiceTest.php
@@ -573,6 +573,32 @@ file2.txt"
 				"","Anonymous user","1973-11-29T22:33:09+01:00"
 				'
 			],
+			'ranking-submission' => [
+				// Questions
+				[
+					['id' => 1, 'type' => 'ranking', 'text' => 'Rank these', 'options' => [
+						['id' => 10, 'text' => 'Option A'],
+						['id' => 11, 'text' => 'Option B'],
+						['id' => 12, 'text' => 'Option C'],
+					]]
+				],
+				// Array of Submissions incl. Answers
+				[
+					[
+						'id' => 1,
+						'userId' => 'user1',
+						'timestamp' => 123456789,
+						'answers' => [
+							['questionId' => 1, 'text' => '[11,10,12]'],
+						]
+					],
+				],
+				// Expected CSV-Result: one column per option with rank position
+				'
+				"User ID","User display name","Timestamp","Rank these (Option A)","Rank these (Option B)","Rank these (Option C)"
+				"user1","User 1","1973-11-29T22:33:09+01:00","2","1","3"
+				'
+			],
 		];
 	}
 	/**
@@ -1121,6 +1147,11 @@ file2.txt"
 					// time range
 					['id' => 18, 'type' => 'time', 'text' => 'q1', 'isRequired' => true, 'extraSettings' => ['timeRange' => true]],
 					['id' => 19, 'type' => 'color', 'isRequired' => false],
+					['id' => 20, 'type' => 'ranking', 'text' => 'Rank these', 'isRequired' => false, 'options' => [
+						['id' => 30],
+						['id' => 31],
+						['id' => 32]
+					]],
 				],
 				// Answers
 				[
@@ -1144,10 +1175,73 @@ file2.txt"
 					// valid time range
 					'18' => ['12:33', '12:34'],
 					'19' => ['#FF0000'],
+					'20' => [31, 30, 32],
 				],
 				// Expected Result
 				null,
-			]
+			],
+			'valid-ranking-submission' => [
+				// Questions
+				[
+					['id' => 1, 'type' => 'ranking', 'text' => 'Rank these', 'isRequired' => false, 'options' => [
+						['id' => 10],
+						['id' => 11],
+						['id' => 12]
+					]]
+				],
+				// Answers
+				[
+					'1' => [12, 10, 11]
+				],
+				// Expected Result
+				null,
+			],
+			'invalid-ranking-missing-option' => [
+				// Questions
+				[
+					['id' => 1, 'type' => 'ranking', 'text' => 'Rank these', 'isRequired' => false, 'options' => [
+						['id' => 10],
+						['id' => 11],
+						['id' => 12]
+					]]
+				],
+				// Answers
+				[
+					'1' => [10, 11]
+				],
+				// Expected Result
+				'Ranking for question "Rank these" must include all options exactly once.',
+			],
+			'invalid-ranking-unknown-option' => [
+				// Questions
+				[
+					['id' => 1, 'type' => 'ranking', 'text' => 'Rank these', 'isRequired' => false, 'options' => [
+						['id' => 10],
+						['id' => 11]
+					]]
+				],
+				// Answers
+				[
+					'1' => [10, 99]
+				],
+				// Expected Result – caught by generic predefined-options check before ranking check
+				'Answer "99" for question "Rank these" is not a valid option.',
+			],
+			'invalid-ranking-duplicate-option' => [
+				// Questions
+				[
+					['id' => 1, 'type' => 'ranking', 'text' => 'Rank these', 'isRequired' => false, 'options' => [
+						['id' => 10],
+						['id' => 11]
+					]]
+				],
+				// Answers
+				[
+					'1' => [10, 10]
+				],
+				// Expected Result
+				'Ranking for question "Rank these" must include all options exactly once.',
+			],
 		];
 	}
 

--- a/tests/Unit/Service/SubmissionServiceTest.php
+++ b/tests/Unit/Service/SubmissionServiceTest.php
@@ -599,6 +599,29 @@ file2.txt"
 				"user1","User 1","1973-11-29T22:33:09+01:00","2","1","3"
 				'
 			],
+			'ranking-unanswered' => [
+				// Questions
+				[
+					['id' => 1, 'type' => 'ranking', 'text' => 'Rank these', 'options' => [
+						['id' => 10, 'text' => 'Option A'],
+						['id' => 11, 'text' => 'Option B'],
+					]]
+				],
+				// Submission with no ranking answer
+				[
+					[
+						'id' => 1,
+						'userId' => 'user1',
+						'timestamp' => 123456789,
+						'answers' => [],
+					],
+				],
+				// Expected CSV-Result: columns exist but values are empty
+				'
+				"User ID","User display name","Timestamp","Rank these (Option A)","Rank these (Option B)"
+				"user1","User 1","1973-11-29T22:33:09+01:00","",""
+				'
+			],
 		];
 	}
 	/**
@@ -1241,6 +1264,34 @@ file2.txt"
 				],
 				// Expected Result
 				'Ranking for question "Rank these" must include all options exactly once.',
+			],
+			'valid-ranking-not-required-unanswered' => [
+				// Questions
+				[
+					['id' => 1, 'type' => 'ranking', 'text' => 'Rank these', 'isRequired' => false, 'options' => [
+						['id' => 10],
+						['id' => 11],
+						['id' => 12]
+					]]
+				],
+				// Answers – user did not rank anything
+				[],
+				// Expected Result – no error
+				null,
+			],
+			'invalid-ranking-required-unanswered' => [
+				// Questions
+				[
+					['id' => 1, 'type' => 'ranking', 'text' => 'Rank these', 'isRequired' => true, 'options' => [
+						['id' => 10],
+						['id' => 11],
+						['id' => 12]
+					]]
+				],
+				// Answers – user did not rank anything
+				[],
+				// Expected Result – required question must be answered
+				'Question "Rank these" is required.',
 			],
 		];
 	}

--- a/tests/Unit/Service/SubmissionServiceTest.php
+++ b/tests/Unit/Service/SubmissionServiceTest.php
@@ -542,6 +542,55 @@ file2.txt"
 				"","Anonymous user","1973-11-29T22:33:09+01:00"
 				'
 			],
+			'ranking-submission' => [
+				// Questions
+				[
+					['id' => 1, 'type' => 'ranking', 'text' => 'Rank these', 'options' => [
+						['id' => 10, 'text' => 'Option A'],
+						['id' => 11, 'text' => 'Option B'],
+						['id' => 12, 'text' => 'Option C'],
+					]]
+				],
+				// Array of Submissions incl. Answers
+				[
+					[
+						'id' => 1,
+						'userId' => 'user1',
+						'timestamp' => 123456789,
+						'answers' => [
+							['questionId' => 1, 'text' => '[11,10,12]'],
+						]
+					],
+				],
+				// Expected CSV-Result: one column per option with rank position
+				'
+				"User ID","User display name","Timestamp","Rank these (Option A)","Rank these (Option B)","Rank these (Option C)"
+				"user1","User 1","1973-11-29T22:33:09+01:00","2","1","3"
+				'
+			],
+			'ranking-unanswered' => [
+				// Questions
+				[
+					['id' => 1, 'type' => 'ranking', 'text' => 'Rank these', 'options' => [
+						['id' => 10, 'text' => 'Option A'],
+						['id' => 11, 'text' => 'Option B'],
+					]]
+				],
+				// Submission with no ranking answer
+				[
+					[
+						'id' => 1,
+						'userId' => 'user1',
+						'timestamp' => 123456789,
+						'answers' => [],
+					],
+				],
+				// Expected CSV-Result: columns exist but values are empty
+				'
+				"User ID","User display name","Timestamp","Rank these (Option A)","Rank these (Option B)"
+				"user1","User 1","1973-11-29T22:33:09+01:00","",""
+				'
+			],
 		];
 	}
 	/**
@@ -1090,6 +1139,11 @@ file2.txt"
 					// time range
 					['id' => 18, 'type' => 'time', 'text' => 'q1', 'isRequired' => true, 'extraSettings' => ['timeRange' => true]],
 					['id' => 19, 'type' => 'color', 'isRequired' => false],
+					['id' => 20, 'type' => 'ranking', 'text' => 'Rank these', 'isRequired' => false, 'options' => [
+						['id' => 30],
+						['id' => 31],
+						['id' => 32]
+					]],
 				],
 				// Answers
 				[
@@ -1113,10 +1167,101 @@ file2.txt"
 					// valid time range
 					'18' => ['12:33', '12:34'],
 					'19' => ['#FF0000'],
+					'20' => [31, 30, 32],
 				],
 				// Expected Result
 				null,
-			]
+			],
+			'valid-ranking-submission' => [
+				// Questions
+				[
+					['id' => 1, 'type' => 'ranking', 'text' => 'Rank these', 'isRequired' => false, 'options' => [
+						['id' => 10],
+						['id' => 11],
+						['id' => 12]
+					]]
+				],
+				// Answers
+				[
+					'1' => [12, 10, 11]
+				],
+				// Expected Result
+				null,
+			],
+			'invalid-ranking-missing-option' => [
+				// Questions
+				[
+					['id' => 1, 'type' => 'ranking', 'text' => 'Rank these', 'isRequired' => false, 'options' => [
+						['id' => 10],
+						['id' => 11],
+						['id' => 12]
+					]]
+				],
+				// Answers
+				[
+					'1' => [10, 11]
+				],
+				// Expected Result
+				'Ranking for question "Rank these" must include all options exactly once.',
+			],
+			'invalid-ranking-unknown-option' => [
+				// Questions
+				[
+					['id' => 1, 'type' => 'ranking', 'text' => 'Rank these', 'isRequired' => false, 'options' => [
+						['id' => 10],
+						['id' => 11]
+					]]
+				],
+				// Answers
+				[
+					'1' => [10, 99]
+				],
+				// Expected Result – caught by generic predefined-options check before ranking check
+				'Answer "99" for question "Rank these" is not a valid option.',
+			],
+			'invalid-ranking-duplicate-option' => [
+				// Questions
+				[
+					['id' => 1, 'type' => 'ranking', 'text' => 'Rank these', 'isRequired' => false, 'options' => [
+						['id' => 10],
+						['id' => 11]
+					]]
+				],
+				// Answers
+				[
+					'1' => [10, 10]
+				],
+				// Expected Result
+				'Ranking for question "Rank these" must include all options exactly once.',
+			],
+			'valid-ranking-not-required-unanswered' => [
+				// Questions
+				[
+					['id' => 1, 'type' => 'ranking', 'text' => 'Rank these', 'isRequired' => false, 'options' => [
+						['id' => 10],
+						['id' => 11],
+						['id' => 12]
+					]]
+				],
+				// Answers – user did not rank anything
+				[],
+				// Expected Result – no error
+				null,
+			],
+			'invalid-ranking-required-unanswered' => [
+				// Questions
+				[
+					['id' => 1, 'type' => 'ranking', 'text' => 'Rank these', 'isRequired' => true, 'options' => [
+						['id' => 10],
+						['id' => 11],
+						['id' => 12]
+					]]
+				],
+				// Answers – user did not rank anything
+				[],
+				// Expected Result – required question must be answered
+				'Question "Rank these" is required.',
+			],
 		];
 	}
 


### PR DESCRIPTION
As proposed in #1278: Add Ranking question type

Refactored to Vue3, after closing: #3247

Rebased to main after closing: #3248

This adds a new question type that lets respondents rank options by dragging them into order.

Results are scored using Borda count — first place gets the most points, last place gets the least. The summary shows each option's total score and average rank with a visual bar, along with a short explanation of how scoring works.

For export, ranking questions get one column per option (like grid questions do), with the rank number as the value. Answers are stored as a JSON array of option IDs, which keeps things consistent with how grid answers are stored.

There's also an optional shuffle setting.

Again disclaimer: heavy use of genAI, I did try to check the code to the best of my abilities and ran it on nextcloud-docker-dev to actually interact with it and export data.

Ok, it is now implemented as a tap-and-drag interface, which allows to set a required-flag or leave it blank. 🎊
Sorry, for the forth-and-back.

See attached video for demonstration: https://github.com/user-attachments/assets/9745e93c-87db-49ae-990f-ed305827deee