### PR TITLE
fix: Allow editing own response by correctly ordering submissions

### DIFF
--- a/lib/Service/SubmissionService.php
+++ b/lib/Service/SubmissionService.php
@@ -109,10 +109,13 @@ class SubmissionService {
 	 */
 	public function getSubmissions(int $formId, ?string $userId = null, ?string $query = null, ?int $limit = null, int $offset = 0): array {
 		$submissionList = [];
+		$submissionEntities = [];
 		try {
 			$submissionEntities = $this->submissionMapper->findByForm($formId, $userId, $query, $limit, $offset);
 
-			foreach ($submissionEntities as $submissionEntity) {
+			// newest first
+			$sortedSubmissions = array_reverse($submissionEntities);
+			foreach ($sortedSubmissions as $submissionEntity) {
 				$submission = $submissionEntity->read();
 				$submission['answers'] = $this->getAnswers($submission['id']);
 				$submissionList[] = $submission;


### PR DESCRIPTION
## Summary

A recent change altered the default sort order of form submissions to be oldest-first. This broke the 'edit own response' feature, which expects the latest submission to be first in the list. This patch corrects the issue by reversing the order of submissions in the `SubmissionService`, ensuring the newest response is always processed for editing.

## Changes

- **lib/Service/SubmissionService.php**: In `lib/Service/SubmissionService.php`, the `getSubmissions` method has been updated to reverse the order of submissions retrieved from the database. This ensures that submissions are sorted from newest to oldest, allowing the controller to correctly pick the latest submission for a user to edit.

## Related Issue

Closes #3243

