### PR TITLE
v5.2.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@
 
 # Changelog
 
+## v5.2.7 - 2026-04-14
+
+[Full Changelog](https://github.com/nextcloud/forms/compare/v5.2.6...v5.2.7)
+
+### Fixed
+
+- [stable5.2] fix: clean up file shares on collaborator removal by @pringelmann in [\#3294](https://github.com/nextcloud/forms/pull/3294)
+- [stable5.2] fix: require explicit share permission for bulk submission endpoints by @pringelmann in [\#3292](https://github.com/nextcloud/forms/pull/3292)
+- [stable5.2] fix: cap pagination limit for submissions endpoint by @backportbot[bot] in [\#3277](https://github.com/nextcloud/forms/pull/3277)
+
 ## v5.2.6 - 2026-04-07
 
 [Full Changelog](https://github.com/nextcloud/forms/compare/v5.2.5...v5.2.6)

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -17,7 +17,7 @@
 - **🙋 Get involved!** We have lots of stuff planned like more question types, collaboration on forms, [and much more](https://github.com/nextcloud/forms/milestones)!
 	]]></description>
 
-	<version>5.2.6</version>
+	<version>5.2.7</version>
 	<licence>agpl</licence>
 
 	<author>Affan Hussain</author>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "forms",
-  "version": "5.2.6",
+  "version": "5.2.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "forms",
-      "version": "5.2.6",
+      "version": "5.2.7",
       "license": "AGPL-3.0",
       "dependencies": {
         "@nextcloud/auth": "^2.5.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forms",
-  "version": "5.2.6",
+  "version": "5.2.7",
   "private": true,
   "description": "Forms app for nextcloud",
   "homepage": "https://github.com/nextcloud/forms#readme",


### PR DESCRIPTION
Release v5.2.7

### Fixed

- [stable5.2] fix: clean up file shares on collaborator removal (#3294)
- [stable5.2] fix: require explicit share permission for bulk submission endpoints (#3292)
- [stable5.2] fix: cap pagination limit for submissions endpoint (#3277)