### PR TITLE
fix: only allow modifying of sharing to form owners

### DIFF
--- a/src/components/SidebarTabs/SharingSearchDiv.vue
+++ b/src/components/SidebarTabs/SharingSearchDiv.vue
@@ -8,7 +8,7 @@
 		<NcSelectUsers
 			keepOpen
 			:loading="showLoadingCircle"
-			:disabled="locked"
+			:disabled="locked || !isCurrentUserOwner"
 			:options="options"
 			:placeholder="t('forms', 'Search for user, group or team …')"
 			:aria-label-listbox="t('forms', 'Search for user, group or team …')"
@@ -44,6 +44,11 @@ export default {
 		},
 
 		locked: {
+			type: Boolean,
+			required: true,
+		},
+
+		isCurrentUserOwner: {
 			type: Boolean,
 			required: true,
 		},

--- a/src/components/SidebarTabs/SharingShareDiv.vue
+++ b/src/components/SidebarTabs/SharingShareDiv.vue
@@ -14,7 +14,7 @@
 			<span>{{ displayName }}</span>
 			<span>{{ displayNameAppendix }}</span>
 		</div>
-		<NcActions class="share-div__actions">
+		<NcActions class="share-div__actions" :disabled="!isCurrentUserOwner">
 			<NcActionCaption :name="t('forms', 'Permissions')" />
 			<NcActionCheckbox
 				:modelValue="canEditForm"
@@ -76,6 +76,11 @@ export default {
 		},
 
 		locked: {
+			type: Boolean,
+			required: true,
+		},
+
+		isCurrentUserOwner: {
 			type: Boolean,
 			required: true,
 		},

--- a/src/components/SidebarTabs/SharingSidebarTab.vue
+++ b/src/components/SidebarTabs/SharingSidebarTab.vue
@@ -20,6 +20,7 @@
 			:currentShares="form.shares"
 			:showLoading="isLoading"
 			:locked="locked"
+			:isCurrentUserOwner="isCurrentUserOwner"
 			@addShare="addShare" />
 
 		<!-- Public Link -->
@@ -31,7 +32,9 @@
 			</div>
 			<span class="share-div__desc">{{ t('forms', 'Share link') }}</span>
 			<NcActions>
-				<NcActionButton :disabled="locked" @click="addPublicLink">
+				<NcActionButton
+					:disabled="locked || !isCurrentUserOwner"
+					@click="addPublicLink">
 					<template #icon>
 						<IconPlus :size="20" />
 					</template>
@@ -80,7 +83,7 @@
 					</NcActionButton>
 					<NcActionButton
 						v-else
-						:disabled="locked"
+						:disabled="locked || !isCurrentUserOwner"
 						@click="makeEmbeddable(share)">
 						<template #icon>
 							<IconLinkBoxVariantOutline :size="20" />
@@ -88,7 +91,9 @@
 						<!-- TRANSLATORS: This means the link can be embedded into external websites -->
 						{{ t('forms', 'Convert to embeddable link') }}
 					</NcActionButton>
-					<NcActionButton :disabled="locked" @click="removeShare(share)">
+					<NcActionButton
+						:disabled="locked || !isCurrentUserOwner"
+						@click="removeShare(share)">
 						<template #icon>
 							<IconDelete :size="20" />
 						</template>
@@ -97,7 +102,7 @@
 					<NcActionButton
 						v-if="appConfig.allowPublicLink"
 						closeAfterClick
-						:disabled="locked"
+						:disabled="locked || !isCurrentUserOwner"
 						@click="addPublicLink">
 						<template #icon>
 							<IconPlus :size="20" />
@@ -160,7 +165,7 @@
 				<NcCheckboxRadioSwitch
 					id="share-switch__permit-all"
 					:modelValue="form.access.permitAllUsers"
-					:disabled="locked"
+					:disabled="locked || !isCurrentUserOwner"
 					type="switch"
 					@update:modelValue="onPermitAllUsersChange" />
 			</div>
@@ -176,7 +181,7 @@
 				<NcCheckboxRadioSwitch
 					id="share-switch__show-to-all"
 					:modelValue="form.access.showToAllUsers"
-					:disabled="locked"
+					:disabled="locked || !isCurrentUserOwner"
 					type="switch"
 					@update:modelValue="onShowToAllUsersChange" />
 			</div>
@@ -189,6 +194,7 @@
 				:key="'share-' + share.shareType + '-' + share.shareWith"
 				:share="share"
 				:locked="locked"
+				:isCurrentUserOwner="isCurrentUserOwner"
 				@removeShare="removeShare"
 				@update:share="updateShare" />
 		</TransitionGroup>
@@ -196,6 +202,7 @@
 </template>
 
 <script>
+import { getCurrentUser } from '@nextcloud/auth'
 import axios from '@nextcloud/axios'
 import { showError } from '@nextcloud/dialogs'
 import { loadState } from '@nextcloud/initial-state'
@@ -274,6 +281,10 @@ export default {
 	},
 
 	computed: {
+		isCurrentUserOwner() {
+			return getCurrentUser().uid === this.form.ownerId
+		},
+
 		sortedShares() {
 			// Remove Link-Shares, which are handled separately, then sort
 			return this.form.shares


### PR DESCRIPTION
This fixes #3278 by restricting actions that modify shares to form owners. These actions are already blocked server-side when they try to add new shares or modify/delete existing shares.

Signed-off-by: Christian Hartmann <chris-hartmann@gmx.de>