### PR TITLE
Allow custom public share tokens for form links

### DIFF
--- a/.github/workflows/lint-eslint.yml
+++ b/.github/workflows/lint-eslint.yml
@@ -28,12 +28,6 @@ jobs:
       src: ${{ steps.changes.outputs.src}}
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          persist-credentials: false
-          fetch-depth: 0
-
       - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         id: changes
         continue-on-error: true

--- a/.github/workflows/lint-eslint.yml
+++ b/.github/workflows/lint-eslint.yml
@@ -28,6 +28,12 @@ jobs:
       src: ${{ steps.changes.outputs.src}}
 
     steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+
       - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         id: changes
         continue-on-error: true

--- a/docs/API_v3.md
+++ b/docs/API_v3.md
@@ -631,7 +631,12 @@ Update a single or all properties of an option-object
   | Parameter | Type | Description |
   |------------------|----------|-------------|
   | _keyValuePairs_ | Array | Array of key-value pairs to update |
-- Restrictions: Currently only the _permissions_ can be updated.
+- Restrictions:
+  - Allowed keys are _permissions_ and _token_.
+  - _token_ updates are only available when the admin setting _allowCustomPublicShareTokens_ is enabled.
+  - _token_ can only be updated on link shares.
+  - _token_ must be unique among link shares and only contain alphanumeric characters.
+  - _token_ length must be between 8 and 256 characters.
 - Response: **Status-Code OK**, as well as the id of the share object.
 
 ```
@@ -648,30 +653,6 @@ Update a single or all properties of an option-object
   | _formId_ | Integer | ID of the form containing the share |
   | _shareId_ | Integer | ID of the share to delete |
 - Response: **Status-Code OK**, as well as the id of the deleted share.
-
-```
-"data": 5
-```
-
-### Update a Public Share Token
-
-- Endpoint: `/api/v3/forms/{formId}/shares/{shareId}/token`
-- Method: `PATCH`
-- Url-Parameters:
-  | Parameter | Type | Description |
-  |-----------|---------|-------------|
-  | _formId_ | Integer | ID of the form containing the share |
-  | _shareId_ | Integer | ID of the public link share to update |
-- Parameters:
-  | Parameter | Type | Description |
-  |-----------|---------|-------------|
-  | _token_ | String | New token for the public share link |
-- Restrictions:
-  - Only available when the admin setting _allowCustomPublicShareTokens_ is enabled.
-  - Only link shares can be updated.
-  - Token must be unique among link shares and only contain alphanumeric characters.
-  - Token length must be between 8 and 256 characters.
-- Response: **Status-Code OK**, as well as the id of the updated share.
 
 ```
 "data": 5

--- a/docs/API_v3.md
+++ b/docs/API_v3.md
@@ -653,6 +653,30 @@ Update a single or all properties of an option-object
 "data": 5
 ```
 
+### Update a Public Share Token
+
+- Endpoint: `/api/v3/forms/{formId}/shares/{shareId}/token`
+- Method: `PATCH`
+- Url-Parameters:
+  | Parameter | Type | Description |
+  |-----------|---------|-------------|
+  | _formId_ | Integer | ID of the form containing the share |
+  | _shareId_ | Integer | ID of the public link share to update |
+- Parameters:
+  | Parameter | Type | Description |
+  |-----------|---------|-------------|
+  | _token_ | String | New token for the public share link |
+- Restrictions:
+  - Only available when the admin setting _allowCustomPublicShareTokens_ is enabled.
+  - Only link shares can be updated.
+  - Token must be unique among link shares and only contain alphanumeric characters.
+  - Token length must be between 8 and 256 characters.
+- Response: **Status-Code OK**, as well as the id of the updated share.
+
+```
+"data": 5
+```
+
 ## Submission Endpoints
 
 ### Get Form Submissions

--- a/lib/Constants.php
+++ b/lib/Constants.php
@@ -15,16 +15,21 @@ class Constants {
 	 */
 	public const CONFIG_KEY_ALLOWPERMITALL = 'allowPermitAll';
 	public const CONFIG_KEY_ALLOWPUBLICLINK = 'allowPublicLink';
+	public const CONFIG_KEY_ALLOWCUSTOMPUBLICTOKEN = 'allowCustomPublicShareTokens';
 	public const CONFIG_KEY_ALLOWSHOWTOALL = 'allowShowToAll';
 	public const CONFIG_KEY_CREATIONALLOWEDGROUPS = 'creationAllowedGroups';
 	public const CONFIG_KEY_RESTRICTCREATION = 'restrictCreation';
 	public const CONFIG_KEYS = [
 		self::CONFIG_KEY_ALLOWPERMITALL,
 		self::CONFIG_KEY_ALLOWPUBLICLINK,
+		self::CONFIG_KEY_ALLOWCUSTOMPUBLICTOKEN,
 		self::CONFIG_KEY_ALLOWSHOWTOALL,
 		self::CONFIG_KEY_CREATIONALLOWEDGROUPS,
 		self::CONFIG_KEY_RESTRICTCREATION
 	];
+
+	public const PUBLIC_SHARE_TOKEN_MIN_LENGTH = 8;
+	public const PUBLIC_SHARE_TOKEN_MAX_LENGTH = 256;
 
 	/**
 	 * Maximum String lengths, the database is set to store.

--- a/lib/Constants.php
+++ b/lib/Constants.php
@@ -30,6 +30,7 @@ class Constants {
 
 	public const PUBLIC_SHARE_TOKEN_MIN_LENGTH = 8;
 	public const PUBLIC_SHARE_TOKEN_MAX_LENGTH = 256;
+	public const PUBLIC_SHARE_HASH_REQUIREMENT = '[a-zA-Z0-9]{' . self::PUBLIC_SHARE_TOKEN_MIN_LENGTH . ',' . self::PUBLIC_SHARE_TOKEN_MAX_LENGTH . '}';
 
 	/**
 	 * Maximum String lengths, the database is set to store.

--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -40,7 +40,6 @@ use OCP\Util;
 #[OpenAPI(scope: OpenAPI::SCOPE_IGNORE)]
 class PageController extends Controller {
 	private const TEMPLATE_MAIN = 'main';
-	private const PUBLIC_SHARE_HASH_REQUIREMENT = '[a-zA-Z0-9]{8,256}';
 
 	public function __construct(
 		string $appName,
@@ -146,7 +145,7 @@ class PageController extends Controller {
 	#[NoAdminRequired()]
 	#[NoCSRFRequired()]
 	#[PublicPage()]
-	#[FrontpageRoute(verb: 'GET', url: '/s/{hash}', requirements: ['hash' => self::PUBLIC_SHARE_HASH_REQUIREMENT])]
+	#[FrontpageRoute(verb: 'GET', url: '/s/{hash}', requirements: ['hash' => Constants::PUBLIC_SHARE_HASH_REQUIREMENT])]
 	public function publicLinkView(string $hash): Response {
 		try {
 			$share = $this->shareMapper->findPublicShareByHash($hash);

--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -40,6 +40,7 @@ use OCP\Util;
 #[OpenAPI(scope: OpenAPI::SCOPE_IGNORE)]
 class PageController extends Controller {
 	private const TEMPLATE_MAIN = 'main';
+	private const PUBLIC_SHARE_HASH_REQUIREMENT = '[a-zA-Z0-9]{8,256}';
 
 	public function __construct(
 		string $appName,
@@ -145,7 +146,7 @@ class PageController extends Controller {
 	#[NoAdminRequired()]
 	#[NoCSRFRequired()]
 	#[PublicPage()]
-	#[FrontpageRoute(verb: 'GET', url: '/s/{hash}', requirements: ['hash' => '[a-zA-Z0-9]{24,}'])]
+	#[FrontpageRoute(verb: 'GET', url: '/s/{hash}', requirements: ['hash' => self::PUBLIC_SHARE_HASH_REQUIREMENT])]
 	public function publicLinkView(string $hash): Response {
 		try {
 			$share = $this->shareMapper->findPublicShareByHash($hash);

--- a/lib/Controller/ShareApiController.php
+++ b/lib/Controller/ShareApiController.php
@@ -302,6 +302,85 @@ class ShareApiController extends OCSController {
 	}
 
 	/**
+	 * Update token/hash of a public link share
+	 *
+	 * @param int $formId of the form
+	 * @param int $shareId of the share to update
+	 * @param string $token The new share token
+	 * @return DataResponse<Http::STATUS_OK, int, array{}>
+	 * @throws OCSBadRequestException Share doesn't belong to given Form
+	 * @throws OCSBadRequestException Invalid share token
+	 * @throws OCSBadRequestException Share hash exists, please retry
+	 * @throws OCSForbiddenException Custom public share tokens are not allowed
+	 * @throws OCSForbiddenException Not allowed to update token on non-link share
+	 * @throws OCSForbiddenException This form is not owned by the current user
+	 * @throws OCSNotFoundException Could not find share
+	 *
+	 * 200: the id of the updated share
+	 */
+	#[CORS()]
+	#[NoAdminRequired()]
+	#[ApiRoute(verb: 'PATCH', url: '/api/v3/forms/{formId}/shares/{shareId}/token')]
+	public function updateShareToken(int $formId, int $shareId, string $token): DataResponse {
+		$this->logger->debug('Updating share token: {shareId} of form {formId}', [
+			'formId' => $formId,
+			'shareId' => $shareId,
+		]);
+
+		if (!$this->configService->getAllowCustomPublicToken()) {
+			$this->logger->debug('Custom public share tokens are not allowed.');
+			throw new OCSForbiddenException('Custom public share tokens are not allowed.');
+		}
+
+		$form = $this->formsService->getFormIfAllowed($formId);
+		if ($this->formsService->isFormArchived($form)) {
+			$this->logger->debug('This form is archived and can not be modified');
+			throw new OCSForbiddenException('This form is archived and can not be modified');
+		}
+
+		try {
+			$formShare = $this->shareMapper->findById($shareId);
+		} catch (IMapperException $e) {
+			$this->logger->debug('Could not find share', ['exception' => $e]);
+			throw new OCSNotFoundException('Could not find share');
+		}
+
+		if ($formId !== $formShare->getFormId()) {
+			$this->logger->debug('This share doesn\'t belong to the given Form');
+			throw new OCSBadRequestException('Share doesn\'t belong to given Form');
+		}
+
+		if ($formShare->getShareType() !== IShare::TYPE_LINK) {
+			$this->logger->debug('Not allowed to update token on non-link share');
+			throw new OCSForbiddenException('Not allowed to update token on non-link share');
+		}
+
+		if ($token === $formShare->getShareWith()) {
+			return new DataResponse($formShare->getId());
+		}
+
+		$this->validatePublicShareToken($token);
+
+		try {
+			$existingShare = $this->shareMapper->findPublicShareByHash($token);
+			if ($existingShare->getId() !== $formShare->getId()) {
+				$this->logger->debug('Share hash already exists.');
+				throw new OCSBadRequestException('Share hash exists, please retry.');
+			}
+		} catch (DoesNotExistException $e) {
+			// Just continue, this is what we expect to happen (share hash not existing yet).
+		}
+
+		$this->formsService->obtainFormLock($form);
+
+		$formShare->setShareWith($token);
+		$formShare = $this->shareMapper->update($formShare);
+		$this->formMapper->update($form);
+
+		return new DataResponse($formShare->getId());
+	}
+
+	/**
 	 * Delete a share
 	 *
 	 * @param int $formId of the form
@@ -420,5 +499,23 @@ class ShareApiController extends OCSController {
 			}
 		}
 		return true;
+	}
+
+	/**
+	 * @throws OCSBadRequestException If token does not satisfy basic safety checks
+	 */
+	private function validatePublicShareToken(string $token): void {
+		if ($token !== trim($token)) {
+			throw new OCSBadRequestException('Invalid share token');
+		}
+
+		$tokenLength = strlen($token);
+		if ($tokenLength < Constants::PUBLIC_SHARE_TOKEN_MIN_LENGTH || $tokenLength > Constants::PUBLIC_SHARE_TOKEN_MAX_LENGTH) {
+			throw new OCSBadRequestException('Invalid share token');
+		}
+
+		if (preg_match('/^[a-zA-Z0-9]+$/', $token) !== 1) {
+			throw new OCSBadRequestException('Invalid share token');
+		}
 	}
 }

--- a/lib/Controller/ShareApiController.php
+++ b/lib/Controller/ShareApiController.php
@@ -263,8 +263,8 @@ class ShareApiController extends OCSController {
 		$allowedKeys = ['permissions', 'token'];
 		foreach (array_keys($keyValuePairs) as $key) {
 			if (!in_array($key, $allowedKeys, true)) {
-				$this->logger->debug('Not allowed to update unknown properties');
-				throw new OCSForbiddenException('Not allowed to update unknown properties');
+				$this->logger->debug('Not allowed to update other properties than permissions or token');
+				throw new OCSForbiddenException('Not allowed to update other properties than permissions or token');
 			}
 		}
 

--- a/lib/Controller/ShareApiController.php
+++ b/lib/Controller/ShareApiController.php
@@ -207,7 +207,7 @@ class ShareApiController extends OCSController {
 	}
 
 	/**
-	 * Update permissions of a share
+	 * Update properties of a share
 	 *
 	 * @param int $formId of the form
 	 * @param int $shareId of the share to update
@@ -215,9 +215,13 @@ class ShareApiController extends OCSController {
 	 * @return DataResponse<Http::STATUS_OK, int, array{}>
 	 * @throws OCSBadRequestException Share doesn't belong to given Form
 	 * @throws OCSBadRequestException Invalid permission given
+	 * @throws OCSBadRequestException Invalid share token
+	 * @throws OCSBadRequestException Share hash exists, please retry
+	 * @throws OCSForbiddenException Custom public share tokens are not allowed
 	 * @throws OCSForbiddenException This form is not owned by the current user
 	 * @throws OCSForbiddenException Empty keyValuePairs, will not update
-	 * @throws OCSForbiddenException Not allowed to update other properties than permissions
+	 * @throws OCSForbiddenException Not allowed to update token on non-link share
+	 * @throws OCSForbiddenException Not allowed to update unknown properties
 	 * @throws OCSNotFoundException Could not find share
 	 *
 	 * 200: the id of the updated share
@@ -226,7 +230,7 @@ class ShareApiController extends OCSController {
 	#[NoAdminRequired()]
 	#[ApiRoute(verb: 'PATCH', url: '/api/v3/forms/{formId}/shares/{shareId}')]
 	public function updateShare(int $formId, int $shareId, array $keyValuePairs): DataResponse {
-		$this->logger->debug('Updating share: {shareId} of form {formId}, permissions: {permissions}', [
+		$this->logger->debug('Updating share: {shareId} of form {formId}, values: {keyValuePairs}', [
 			'formId' => $formId,
 			'shareId' => $shareId,
 			'keyValuePairs' => $keyValuePairs
@@ -256,22 +260,64 @@ class ShareApiController extends OCSController {
 			throw new OCSForbiddenException('Empty keyValuePairs, will not update');
 		}
 
-		//Don't allow to change other properties than permissions
-		if (count($keyValuePairs) > 1 || !array_key_exists('permissions', $keyValuePairs)) {
-			$this->logger->debug('Not allowed to update other properties than permissions');
-			throw new OCSForbiddenException('Not allowed to update other properties than permissions');
+		$allowedKeys = ['permissions', 'token'];
+		foreach (array_keys($keyValuePairs) as $key) {
+			if (!in_array($key, $allowedKeys, true)) {
+				$this->logger->debug('Not allowed to update unknown properties');
+				throw new OCSForbiddenException('Not allowed to update unknown properties');
+			}
 		}
 
-		if (!$this->validatePermissions($keyValuePairs['permissions'], $formShare->getShareType())) {
+		if (array_key_exists('permissions', $keyValuePairs) && !$this->validatePermissions($keyValuePairs['permissions'], $formShare->getShareType())) {
 			throw new OCSBadRequestException('Invalid permission given');
+		}
+
+		if (array_key_exists('token', $keyValuePairs)) {
+			if (!$this->configService->getAllowCustomPublicToken()) {
+				$this->logger->debug('Custom public share tokens are not allowed.');
+				throw new OCSForbiddenException('Custom public share tokens are not allowed.');
+			}
+
+			if ($formShare->getShareType() !== IShare::TYPE_LINK) {
+				$this->logger->debug('Not allowed to update token on non-link share');
+				throw new OCSForbiddenException('Not allowed to update token on non-link share');
+			}
+
+			if (!is_string($keyValuePairs['token'])) {
+				throw new OCSBadRequestException('Invalid share token');
+			}
+
+			$token = $keyValuePairs['token'];
+			if (!array_key_exists('permissions', $keyValuePairs) && $token === $formShare->getShareWith()) {
+				return new DataResponse($formShare->getId());
+			}
+
+			if ($token !== $formShare->getShareWith()) {
+				$this->validatePublicShareToken($token);
+
+				try {
+					$existingShare = $this->shareMapper->findPublicShareByHash($token);
+					if ($existingShare->getId() !== $formShare->getId()) {
+						$this->logger->debug('Share hash already exists.');
+						throw new OCSBadRequestException('Share hash exists, please retry.');
+					}
+				} catch (DoesNotExistException $e) {
+					// Just continue, this is what we expect to happen (share hash not existing yet).
+				}
+
+				$formShare->setShareWith($token);
+			}
 		}
 
 		$this->formsService->obtainFormLock($form);
 
-		$formShare->setPermissions($keyValuePairs['permissions']);
+		if (array_key_exists('permissions', $keyValuePairs)) {
+			$formShare->setPermissions($keyValuePairs['permissions']);
+		}
 		$formShare = $this->shareMapper->update($formShare);
 
-		if (in_array($formShare->getShareType(), [IShare::TYPE_USER, IShare::TYPE_GROUP, IShare::TYPE_USERGROUP, IShare::TYPE_CIRCLE], true)) {
+		if (array_key_exists('permissions', $keyValuePairs)
+			&& in_array($formShare->getShareType(), [IShare::TYPE_USER, IShare::TYPE_GROUP, IShare::TYPE_USERGROUP, IShare::TYPE_CIRCLE], true)) {
 			if (in_array(Constants::PERMISSION_RESULTS, $keyValuePairs['permissions'], true)) {
 				$userFolder = $this->rootFolder->getUserFolder($form->getOwnerId());
 				$uploadedFilesFolderPath = $this->formsService->getFormUploadedFilesFolderPath($form);
@@ -296,85 +342,6 @@ class ShareApiController extends OCSController {
 			}
 		}
 
-		$this->formMapper->update($form);
-
-		return new DataResponse($formShare->getId());
-	}
-
-	/**
-	 * Update token/hash of a public link share
-	 *
-	 * @param int $formId of the form
-	 * @param int $shareId of the share to update
-	 * @param string $token The new share token
-	 * @return DataResponse<Http::STATUS_OK, int, array{}>
-	 * @throws OCSBadRequestException Share doesn't belong to given Form
-	 * @throws OCSBadRequestException Invalid share token
-	 * @throws OCSBadRequestException Share hash exists, please retry
-	 * @throws OCSForbiddenException Custom public share tokens are not allowed
-	 * @throws OCSForbiddenException Not allowed to update token on non-link share
-	 * @throws OCSForbiddenException This form is not owned by the current user
-	 * @throws OCSNotFoundException Could not find share
-	 *
-	 * 200: the id of the updated share
-	 */
-	#[CORS()]
-	#[NoAdminRequired()]
-	#[ApiRoute(verb: 'PATCH', url: '/api/v3/forms/{formId}/shares/{shareId}/token')]
-	public function updateShareToken(int $formId, int $shareId, string $token): DataResponse {
-		$this->logger->debug('Updating share token: {shareId} of form {formId}', [
-			'formId' => $formId,
-			'shareId' => $shareId,
-		]);
-
-		if (!$this->configService->getAllowCustomPublicToken()) {
-			$this->logger->debug('Custom public share tokens are not allowed.');
-			throw new OCSForbiddenException('Custom public share tokens are not allowed.');
-		}
-
-		$form = $this->formsService->getFormIfAllowed($formId);
-		if ($this->formsService->isFormArchived($form)) {
-			$this->logger->debug('This form is archived and can not be modified');
-			throw new OCSForbiddenException('This form is archived and can not be modified');
-		}
-
-		try {
-			$formShare = $this->shareMapper->findById($shareId);
-		} catch (IMapperException $e) {
-			$this->logger->debug('Could not find share', ['exception' => $e]);
-			throw new OCSNotFoundException('Could not find share');
-		}
-
-		if ($formId !== $formShare->getFormId()) {
-			$this->logger->debug('This share doesn\'t belong to the given Form');
-			throw new OCSBadRequestException('Share doesn\'t belong to given Form');
-		}
-
-		if ($formShare->getShareType() !== IShare::TYPE_LINK) {
-			$this->logger->debug('Not allowed to update token on non-link share');
-			throw new OCSForbiddenException('Not allowed to update token on non-link share');
-		}
-
-		if ($token === $formShare->getShareWith()) {
-			return new DataResponse($formShare->getId());
-		}
-
-		$this->validatePublicShareToken($token);
-
-		try {
-			$existingShare = $this->shareMapper->findPublicShareByHash($token);
-			if ($existingShare->getId() !== $formShare->getId()) {
-				$this->logger->debug('Share hash already exists.');
-				throw new OCSBadRequestException('Share hash exists, please retry.');
-			}
-		} catch (DoesNotExistException $e) {
-			// Just continue, this is what we expect to happen (share hash not existing yet).
-		}
-
-		$this->formsService->obtainFormLock($form);
-
-		$formShare->setShareWith($token);
-		$formShare = $this->shareMapper->update($formShare);
 		$this->formMapper->update($form);
 
 		return new DataResponse($formShare->getId());

--- a/lib/Service/ConfigService.php
+++ b/lib/Service/ConfigService.php
@@ -37,7 +37,10 @@ class ConfigService {
 	public function getAllowPublicLink(): bool {
 		return json_decode($this->config->getAppValue($this->appName, Constants::CONFIG_KEY_ALLOWPUBLICLINK, 'true'));
 	}
-	public function getAllowShowToAll() : bool {
+	public function getAllowCustomPublicToken(): bool {
+		return json_decode($this->config->getAppValue($this->appName, Constants::CONFIG_KEY_ALLOWCUSTOMPUBLICTOKEN, 'false'));
+	}
+	public function getAllowShowToAll(): bool {
 		return json_decode($this->config->getAppValue($this->appName, Constants::CONFIG_KEY_ALLOWSHOWTOALL, 'true'));
 	}
 	private function getUnformattedCreationAllowedGroups(): array {
@@ -57,6 +60,7 @@ class ConfigService {
 		return [
 			Constants::CONFIG_KEY_ALLOWPERMITALL => $this->getAllowPermitAll(),
 			Constants::CONFIG_KEY_ALLOWPUBLICLINK => $this->getAllowPublicLink(),
+			Constants::CONFIG_KEY_ALLOWCUSTOMPUBLICTOKEN => $this->getAllowCustomPublicToken(),
 			Constants::CONFIG_KEY_ALLOWSHOWTOALL => $this->getAllowShowToAll(),
 			Constants::CONFIG_KEY_CREATIONALLOWEDGROUPS => $this->getCreationAllowedGroups(),
 			Constants::CONFIG_KEY_RESTRICTCREATION => $this->getRestrictCreation(),

--- a/openapi.json
+++ b/openapi.json
@@ -5557,6 +5557,217 @@
                     }
                 }
             }
+        },
+        "/ocs/v2.php/apps/forms/api/v3/forms/{formId}/shares/{shareId}/token": {
+            "patch": {
+                "operationId": "share_api-update-share-token",
+                "summary": "Update token/hash of a public link share",
+                "description": "This endpoint allows CORS requests",
+                "tags": [
+                    "share_api"
+                ],
+                "security": [
+                    {
+                        "basic_auth": []
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "token"
+                                ],
+                                "properties": {
+                                    "token": {
+                                        "type": "string",
+                                        "description": "The new share token"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "parameters": [
+                    {
+                        "name": "formId",
+                        "in": "path",
+                        "description": "of the form",
+                        "required": true,
+                        "schema": {
+                            "type": "integer",
+                            "format": "int64"
+                        }
+                    },
+                    {
+                        "name": "shareId",
+                        "in": "path",
+                        "description": "of the share to update",
+                        "required": true,
+                        "schema": {
+                            "type": "integer",
+                            "format": "int64"
+                        }
+                    },
+                    {
+                        "name": "OCS-APIRequest",
+                        "in": "header",
+                        "description": "Required to be true for the API request to pass",
+                        "required": true,
+                        "schema": {
+                            "type": "boolean",
+                            "default": true
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "the id of the updated share",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "type": "integer",
+                                                    "format": "int64"
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Share hash exists, please retry",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {}
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "This form is not owned by the current user",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {}
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Could not find share",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {}
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Current user is not logged in",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {}
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
         }
     },
     "tags": []

--- a/openapi.json
+++ b/openapi.json
@@ -5157,7 +5157,7 @@
         "/ocs/v2.php/apps/forms/api/v3/forms/{formId}/shares/{shareId}": {
             "patch": {
                 "operationId": "share_api-update-share",
-                "summary": "Update permissions of a share",
+                "summary": "Update properties of a share",
                 "description": "This endpoint allows CORS requests",
                 "tags": [
                     "share_api"
@@ -5254,7 +5254,7 @@
                         }
                     },
                     "400": {
-                        "description": "Invalid permission given",
+                        "description": "Share hash exists, please retry",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -5282,7 +5282,7 @@
                         }
                     },
                     "403": {
-                        "description": "Not allowed to update other properties than permissions",
+                        "description": "Not allowed to update unknown properties",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -5445,217 +5445,6 @@
                     },
                     "400": {
                         "description": "Share doesn't belong to given Form",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "object",
-                                    "required": [
-                                        "ocs"
-                                    ],
-                                    "properties": {
-                                        "ocs": {
-                                            "type": "object",
-                                            "required": [
-                                                "meta",
-                                                "data"
-                                            ],
-                                            "properties": {
-                                                "meta": {
-                                                    "$ref": "#/components/schemas/OCSMeta"
-                                                },
-                                                "data": {}
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "403": {
-                        "description": "This form is not owned by the current user",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "object",
-                                    "required": [
-                                        "ocs"
-                                    ],
-                                    "properties": {
-                                        "ocs": {
-                                            "type": "object",
-                                            "required": [
-                                                "meta",
-                                                "data"
-                                            ],
-                                            "properties": {
-                                                "meta": {
-                                                    "$ref": "#/components/schemas/OCSMeta"
-                                                },
-                                                "data": {}
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "404": {
-                        "description": "Could not find share",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "object",
-                                    "required": [
-                                        "ocs"
-                                    ],
-                                    "properties": {
-                                        "ocs": {
-                                            "type": "object",
-                                            "required": [
-                                                "meta",
-                                                "data"
-                                            ],
-                                            "properties": {
-                                                "meta": {
-                                                    "$ref": "#/components/schemas/OCSMeta"
-                                                },
-                                                "data": {}
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "401": {
-                        "description": "Current user is not logged in",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "object",
-                                    "required": [
-                                        "ocs"
-                                    ],
-                                    "properties": {
-                                        "ocs": {
-                                            "type": "object",
-                                            "required": [
-                                                "meta",
-                                                "data"
-                                            ],
-                                            "properties": {
-                                                "meta": {
-                                                    "$ref": "#/components/schemas/OCSMeta"
-                                                },
-                                                "data": {}
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/ocs/v2.php/apps/forms/api/v3/forms/{formId}/shares/{shareId}/token": {
-            "patch": {
-                "operationId": "share_api-update-share-token",
-                "summary": "Update token/hash of a public link share",
-                "description": "This endpoint allows CORS requests",
-                "tags": [
-                    "share_api"
-                ],
-                "security": [
-                    {
-                        "basic_auth": []
-                    }
-                ],
-                "requestBody": {
-                    "required": true,
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "type": "object",
-                                "required": [
-                                    "token"
-                                ],
-                                "properties": {
-                                    "token": {
-                                        "type": "string",
-                                        "description": "The new share token"
-                                    }
-                                }
-                            }
-                        }
-                    }
-                },
-                "parameters": [
-                    {
-                        "name": "formId",
-                        "in": "path",
-                        "description": "of the form",
-                        "required": true,
-                        "schema": {
-                            "type": "integer",
-                            "format": "int64"
-                        }
-                    },
-                    {
-                        "name": "shareId",
-                        "in": "path",
-                        "description": "of the share to update",
-                        "required": true,
-                        "schema": {
-                            "type": "integer",
-                            "format": "int64"
-                        }
-                    },
-                    {
-                        "name": "OCS-APIRequest",
-                        "in": "header",
-                        "description": "Required to be true for the API request to pass",
-                        "required": true,
-                        "schema": {
-                            "type": "boolean",
-                            "default": true
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "the id of the updated share",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "object",
-                                    "required": [
-                                        "ocs"
-                                    ],
-                                    "properties": {
-                                        "ocs": {
-                                            "type": "object",
-                                            "required": [
-                                                "meta",
-                                                "data"
-                                            ],
-                                            "properties": {
-                                                "meta": {
-                                                    "$ref": "#/components/schemas/OCSMeta"
-                                                },
-                                                "data": {
-                                                    "type": "integer",
-                                                    "format": "int64"
-                                                }
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Share hash exists, please retry",
                         "content": {
                             "application/json": {
                                 "schema": {

--- a/src/FormsSettings.vue
+++ b/src/FormsSettings.vue
@@ -33,6 +33,13 @@
 				{{ t('forms', 'Allow sharing by link') }}
 			</NcCheckboxRadioSwitch>
 			<NcCheckboxRadioSwitch
+				ref="switchAllowCustomPublicShareTokens"
+				v-model="appConfig.allowCustomPublicShareTokens"
+				type="switch"
+				@update:modelValue="onAllowCustomPublicShareTokensChange">
+				{{ t('forms', 'Allow custom public share tokens') }}
+			</NcCheckboxRadioSwitch>
+			<NcCheckboxRadioSwitch
 				ref="switchAllowPermitAll"
 				v-model="appConfig.allowPermitAll"
 				type="switch"
@@ -112,6 +119,13 @@ export default {
 			const el = this.$refs.switchAllowPublicLink
 			el.loading = true
 			await this.saveAppConfig('allowPublicLink', newVal)
+			el.loading = false
+		},
+
+		async onAllowCustomPublicShareTokensChange(newVal) {
+			const el = this.$refs.switchAllowCustomPublicShareTokens
+			el.loading = true
+			await this.saveAppConfig('allowCustomPublicShareTokens', newVal)
 			el.loading = false
 		},
 

--- a/src/components/SidebarTabs/SharingSidebarTab.vue
+++ b/src/components/SidebarTabs/SharingSidebarTab.vue
@@ -560,13 +560,10 @@ export default {
 
 			try {
 				const response = await axios.patch(
-					generateOcsUrl(
-						'apps/forms/api/v3/forms/{id}/shares/{shareId}',
-						{
-							id: this.form.id,
-							shareId: share.id,
-						},
-					),
+					generateOcsUrl('apps/forms/api/v3/forms/{id}/shares/{shareId}', {
+						id: this.form.id,
+						shareId: share.id,
+					}),
 					{
 						keyValuePairs: {
 							token,

--- a/src/components/SidebarTabs/SharingSidebarTab.vue
+++ b/src/components/SidebarTabs/SharingSidebarTab.vue
@@ -561,14 +561,16 @@ export default {
 			try {
 				const response = await axios.patch(
 					generateOcsUrl(
-						'apps/forms/api/v3/forms/{id}/shares/{shareId}/token',
+						'apps/forms/api/v3/forms/{id}/shares/{shareId}',
 						{
 							id: this.form.id,
 							shareId: share.id,
 						},
 					),
 					{
-						token,
+						keyValuePairs: {
+							token,
+						},
 					},
 				)
 

--- a/src/components/SidebarTabs/SharingSidebarTab.vue
+++ b/src/components/SidebarTabs/SharingSidebarTab.vue
@@ -53,11 +53,23 @@
 					<IconLinkBoxVariantOutline v-if="isEmbeddable" :size="20" />
 					<IconLinkVariant v-else :size="20" />
 				</div>
-				<span class="share-div__desc">{{
-					isEmbeddable
-						? t('forms', 'Embeddable link')
-						: t('forms', 'Share link')
-				}}</span>
+				<div class="share-div__desc share-div__desc--tokenized">
+					<span>{{
+						isEmbeddable
+							? t('forms', 'Embeddable link')
+							: t('forms', 'Share link')
+					}}</span>
+					<NcTextField
+						v-if="appConfig.allowCustomPublicShareTokens"
+						:modelValue="getShareTokenInput(share)"
+						:disabled="
+							locked
+							|| !isCurrentUserOwner
+							|| isShareTokenSaving(share)
+						"
+						:label="t('forms', 'Link token')"
+						@update:modelValue="setShareTokenInput(share, $event)" />
+				</div>
 				<NcActions :inline="1">
 					<NcActionLink
 						:href="getPublicShareLink(share)"
@@ -72,6 +84,20 @@
 							<IconQr :size="20" />
 						</template>
 						{{ t('forms', 'Show QR code') }}
+					</NcActionButton>
+					<NcActionButton
+						v-if="appConfig.allowCustomPublicShareTokens"
+						:disabled="
+							locked
+							|| !isCurrentUserOwner
+							|| isShareTokenSaving(share)
+							|| !isShareTokenDirty(share)
+						"
+						@click="updateShareToken(share)">
+						<template #icon>
+							<IconCheck :size="20" />
+						</template>
+						{{ t('forms', 'Save token') }}
 					</NcActionButton>
 					<NcActionButton
 						v-if="isEmbeddable"
@@ -212,7 +238,9 @@ import NcActionLink from '@nextcloud/vue/components/NcActionLink'
 import NcActions from '@nextcloud/vue/components/NcActions'
 import NcCheckboxRadioSwitch from '@nextcloud/vue/components/NcCheckboxRadioSwitch'
 import NcNoteCard from '@nextcloud/vue/components/NcNoteCard'
+import NcTextField from '@nextcloud/vue/components/NcTextField'
 import IconAccountMultiple from 'vue-material-design-icons/AccountMultipleOutline.vue'
+import IconCheck from 'vue-material-design-icons/Check.vue'
 import IconCodeBrackets from 'vue-material-design-icons/CodeBrackets.vue'
 import IconLinkVariant from 'vue-material-design-icons/Link.vue'
 import IconLinkBoxVariantOutline from 'vue-material-design-icons/LinkBoxOutline.vue'
@@ -234,6 +262,7 @@ export default {
 	components: {
 		FormsIcon,
 		IconAccountMultiple,
+		IconCheck,
 		IconCodeBrackets,
 		IconCopyAll,
 		IconDelete,
@@ -246,6 +275,7 @@ export default {
 		NcActionLink,
 		NcCheckboxRadioSwitch,
 		NcNoteCard,
+		NcTextField,
 		QRDialog,
 		SharingSearchDiv,
 		SharingShareDiv,
@@ -276,8 +306,25 @@ export default {
 		return {
 			isLoading: false,
 			appConfig: loadState(appName, 'appConfig'),
+			shareTokens: {},
+			savingShareTokens: {},
 			qrDialogText: '',
 		}
+	},
+
+	watch: {
+		publicLinkShares: {
+			immediate: true,
+			handler(shares) {
+				const nextShareTokens = {}
+				for (const share of shares) {
+					nextShareTokens[share.id] =
+						this.shareTokens[share.id] ?? share.shareWith
+				}
+
+				this.shareTokens = nextShareTokens
+			},
+		},
 	},
 
 	computed: {
@@ -480,6 +527,76 @@ export default {
 			this.$emit('update:formProp', 'access', newAccess)
 		},
 
+		getShareTokenInput(share) {
+			return this.shareTokens[share.id] ?? share.shareWith
+		},
+
+		setShareTokenInput(share, value) {
+			this.shareTokens = {
+				...this.shareTokens,
+				[share.id]: value,
+			}
+		},
+
+		isShareTokenSaving(share) {
+			return !!this.savingShareTokens[share.id]
+		},
+
+		isShareTokenDirty(share) {
+			return this.getShareTokenInput(share).trim() !== share.shareWith
+		},
+
+		async updateShareToken(share) {
+			const token = this.getShareTokenInput(share).trim()
+			if (token === share.shareWith) {
+				return
+			}
+
+			this.isLoading = true
+			this.savingShareTokens = {
+				...this.savingShareTokens,
+				[share.id]: true,
+			}
+
+			try {
+				const response = await axios.patch(
+					generateOcsUrl(
+						'apps/forms/api/v3/forms/{id}/shares/{shareId}/token',
+						{
+							id: this.form.id,
+							shareId: share.id,
+						},
+					),
+					{
+						token,
+					},
+				)
+
+				this.$emit('updateShare', {
+					...share,
+					id: OcsResponse2Data(response),
+					shareWith: token,
+				})
+
+				this.setShareTokenInput(share, token)
+			} catch (error) {
+				logger.error('Error while updating share token', {
+					error,
+					share,
+					token,
+				})
+				showError(
+					t('forms', 'There was an error while updating the link token'),
+				)
+			} finally {
+				this.savingShareTokens = {
+					...this.savingShareTokens,
+					[share.id]: false,
+				}
+				this.isLoading = false
+			}
+		},
+
 		openQrDialog(share) {
 			this.qrDialogText = this.getPublicShareLink(share)
 		},
@@ -534,6 +651,13 @@ export default {
 		padding: 0px 8px;
 		flex-grow: 1;
 
+		&--tokenized {
+			display: flex;
+			flex-direction: column;
+			justify-content: center;
+			padding-block: 8px;
+		}
+
 		&--twoline {
 			span {
 				display: block;
@@ -544,6 +668,10 @@ export default {
 				color: var(--color-text-maxcontrast);
 			}
 		}
+	}
+
+	:deep(.share-div__desc--tokenized .input-field__main-wrapper) {
+		min-inline-size: 220px;
 	}
 }
 </style>

--- a/tests/Unit/Controller/ConfigControllerTest.php
+++ b/tests/Unit/Controller/ConfigControllerTest.php
@@ -69,13 +69,18 @@ class ConfigControllerTest extends TestCase {
 
 	public static function dataUpdateAppConfig() {
 		return [
-			'booleanConfig' => [
+			'booleanConfigAllowPermitAll' => [
 				'configKey' => 'allowPermitAll',
 				'configValue' => true,
 				'strConfig' => 'true'
 			],
-			'booleanConfig' => [
+			'booleanConfigAllowShowToAll' => [
 				'configKey' => 'allowShowToAll',
+				'configValue' => true,
+				'strConfig' => 'true'
+			],
+			'booleanConfigAllowCustomPublicShareTokens' => [
+				'configKey' => 'allowCustomPublicShareTokens',
 				'configValue' => true,
 				'strConfig' => 'true'
 			],

--- a/tests/Unit/Controller/ShareApiControllerTest.php
+++ b/tests/Unit/Controller/ShareApiControllerTest.php
@@ -1103,4 +1103,186 @@ class ShareApiControllerTest extends TestCase {
 		$this->expectException(OCSBadRequestException::class);
 		$this->shareApiController->updateShareToken(5, 8, 'invalid-token');
 	}
+
+	public function testUpdateShareToken_WhitespaceToken()
+	{
+		$form = new Form();
+		$form->setId('5');
+		$form->setOwnerId('currentUser');
+
+		$this->configService->expects($this->once())
+			->method('getAllowCustomPublicToken')
+			->willReturn(true);
+
+		$this->formsService->expects($this->once())
+			->method('getFormIfAllowed')
+			->with(5)
+			->willReturn($form);
+
+		$share = new Share();
+		$share->setId(8);
+		$share->setFormId(5);
+		$share->setShareType(IShare::TYPE_LINK);
+		$share->setShareWith('abcdefgh');
+
+		$this->shareMapper->expects($this->once())
+			->method('findById')
+			->with(8)
+			->willReturn($share);
+
+		$this->shareMapper->expects($this->never())
+			->method('findPublicShareByHash');
+
+		$this->expectException(OCSBadRequestException::class);
+		$this->shareApiController->updateShareToken(5, 8, ' customtoken ');
+	}
+
+	public function testUpdateShareToken_TooShortToken()
+	{
+		$form = new Form();
+		$form->setId('5');
+		$form->setOwnerId('currentUser');
+
+		$this->configService->expects($this->once())
+			->method('getAllowCustomPublicToken')
+			->willReturn(true);
+
+		$this->formsService->expects($this->once())
+			->method('getFormIfAllowed')
+			->with(5)
+			->willReturn($form);
+
+		$share = new Share();
+		$share->setId(8);
+		$share->setFormId(5);
+		$share->setShareType(IShare::TYPE_LINK);
+		$share->setShareWith('abcdefgh');
+
+		$this->shareMapper->expects($this->once())
+			->method('findById')
+			->with(8)
+			->willReturn($share);
+
+		$this->shareMapper->expects($this->never())
+			->method('findPublicShareByHash');
+
+		$this->expectException(OCSBadRequestException::class);
+		$this->shareApiController->updateShareToken(5, 8, 'abc');
+	}
+
+	public function testUpdateShareToken_SameTokenReturnsEarly()
+	{
+		$form = new Form();
+		$form->setId('5');
+		$form->setOwnerId('currentUser');
+
+		$this->configService->expects($this->once())
+			->method('getAllowCustomPublicToken')
+			->willReturn(true);
+
+		$this->formsService->expects($this->once())
+			->method('getFormIfAllowed')
+			->with(5)
+			->willReturn($form);
+
+		$share = new Share();
+		$share->setId(8);
+		$share->setFormId(5);
+		$share->setShareType(IShare::TYPE_LINK);
+		$share->setShareWith('sameToken123');
+
+		$this->shareMapper->expects($this->once())
+			->method('findById')
+			->with(8)
+			->willReturn($share);
+
+		$this->shareMapper->expects($this->never())
+			->method('findPublicShareByHash');
+		$this->shareMapper->expects($this->never())
+			->method('update');
+		$this->formsService->expects($this->never())
+			->method('obtainFormLock');
+
+		$this->assertEquals(new DataResponse(8), $this->shareApiController->updateShareToken(5, 8, 'sameToken123'));
+	}
+
+	public function testUpdateShareToken_ForeignShare()
+	{
+		$form = new Form();
+		$form->setId('5');
+		$form->setOwnerId('currentUser');
+
+		$this->configService->expects($this->once())
+			->method('getAllowCustomPublicToken')
+			->willReturn(true);
+
+		$this->formsService->expects($this->once())
+			->method('getFormIfAllowed')
+			->with(5)
+			->willReturn($form);
+
+		$share = new Share();
+		$share->setId(8);
+		$share->setFormId(6);
+		$share->setShareType(IShare::TYPE_LINK);
+		$share->setShareWith('abcdefgh');
+
+		$this->shareMapper->expects($this->once())
+			->method('findById')
+			->with(8)
+			->willReturn($share);
+
+		$this->expectException(OCSBadRequestException::class);
+		$this->shareApiController->updateShareToken(5, 8, 'customtoken123');
+	}
+
+	public function testUpdateShareToken_ShareNotFound()
+	{
+		$form = new Form();
+		$form->setId('5');
+		$form->setOwnerId('currentUser');
+
+		$this->configService->expects($this->once())
+			->method('getAllowCustomPublicToken')
+			->willReturn(true);
+
+		$this->formsService->expects($this->once())
+			->method('getFormIfAllowed')
+			->with(5)
+			->willReturn($form);
+
+		$this->shareMapper->expects($this->once())
+			->method('findById')
+			->with(8)
+			->willThrowException(new DoesNotExistException('missing'));
+
+		$this->expectException(OCSNotFoundException::class);
+		$this->shareApiController->updateShareToken(5, 8, 'customtoken123');
+	}
+
+	public function testUpdateShareToken_ArchivedForm()
+	{
+		$form = new Form();
+		$form->setId('5');
+		$form->setOwnerId('currentUser');
+
+		$this->configService->expects($this->once())
+			->method('getAllowCustomPublicToken')
+			->willReturn(true);
+
+		$this->formsService->expects($this->once())
+			->method('getFormIfAllowed')
+			->with(5)
+			->willReturn($form);
+		$this->formsService->expects($this->once())
+			->method('isFormArchived')
+			->with($form)
+			->willReturn(true);
+
+		$this->shareMapper->expects($this->never())
+			->method('findById');
+
+		$this->expectException(OCSForbiddenException::class);
+		$this->shareApiController->updateShareToken(5, 8, 'customtoken123');
+	}
 }

--- a/tests/Unit/Controller/ShareApiControllerTest.php
+++ b/tests/Unit/Controller/ShareApiControllerTest.php
@@ -1023,6 +1023,38 @@ class ShareApiControllerTest extends TestCase {
 		$this->shareApiController->updateShare(5, 8, ['token' => 'tokenabcd']);
 	}
 
+	public function testUpdateShareToken_NonStringToken() {
+		$form = new Form();
+		$form->setId('5');
+		$form->setOwnerId('currentUser');
+
+		$this->configService->expects($this->once())
+			->method('getAllowCustomPublicToken')
+			->willReturn(true);
+
+		$this->formsService->expects($this->once())
+			->method('getFormIfAllowed')
+			->with(5)
+			->willReturn($form);
+
+		$share = new Share();
+		$share->setId(8);
+		$share->setFormId(5);
+		$share->setShareType(IShare::TYPE_LINK);
+		$share->setShareWith('abcdefgh');
+
+		$this->shareMapper->expects($this->once())
+			->method('findById')
+			->with(8)
+			->willReturn($share);
+
+		$this->shareMapper->expects($this->never())
+			->method('findPublicShareByHash');
+
+		$this->expectException(OCSBadRequestException::class);
+		$this->shareApiController->updateShare(5, 8, ['token' => 123]);
+	}
+
 	public function testUpdateShareToken_ForbiddenForNonLinkShare() {
 		$form = new Form();
 		$form->setId('5');

--- a/tests/Unit/Controller/ShareApiControllerTest.php
+++ b/tests/Unit/Controller/ShareApiControllerTest.php
@@ -995,6 +995,26 @@ class ShareApiControllerTest extends TestCase {
 	}
 
 	public function testUpdateShareToken_CustomTokensDisabled() {
+		$form = new Form();
+		$form->setId('5');
+		$form->setOwnerId('currentUser');
+
+		$this->formsService->expects($this->once())
+			->method('getFormIfAllowed')
+			->with(5)
+			->willReturn($form);
+
+		$share = new Share();
+		$share->setId(8);
+		$share->setFormId(5);
+		$share->setShareType(IShare::TYPE_LINK);
+		$share->setShareWith('abcdefgh');
+
+		$this->shareMapper->expects($this->once())
+			->method('findById')
+			->with(8)
+			->willReturn($share);
+
 		$this->configService->expects($this->once())
 			->method('getAllowCustomPublicToken')
 			->willReturn(false);
@@ -1208,7 +1228,7 @@ class ShareApiControllerTest extends TestCase {
 		$form->setId('5');
 		$form->setOwnerId('currentUser');
 
-		$this->configService->expects($this->once())
+		$this->configService->expects($this->never())
 			->method('getAllowCustomPublicToken')
 			->willReturn(true);
 
@@ -1237,7 +1257,7 @@ class ShareApiControllerTest extends TestCase {
 		$form->setId('5');
 		$form->setOwnerId('currentUser');
 
-		$this->configService->expects($this->once())
+		$this->configService->expects($this->never())
 			->method('getAllowCustomPublicToken')
 			->willReturn(true);
 
@@ -1260,7 +1280,7 @@ class ShareApiControllerTest extends TestCase {
 		$form->setId('5');
 		$form->setOwnerId('currentUser');
 
-		$this->configService->expects($this->once())
+		$this->configService->expects($this->never())
 			->method('getAllowCustomPublicToken')
 			->willReturn(true);
 

--- a/tests/Unit/Controller/ShareApiControllerTest.php
+++ b/tests/Unit/Controller/ShareApiControllerTest.php
@@ -952,4 +952,155 @@ class ShareApiControllerTest extends TestCase {
 		$this->expectException(NoSuchFormException::class);
 		$this->shareApiController->updateShare(7331, 1337, [Constants::PERMISSION_SUBMIT]);
 	}
+
+	public function testUpdateShareToken() {
+		$form = new Form();
+		$form->setId('5');
+		$form->setOwnerId('currentUser');
+
+		$this->configService->expects($this->once())
+			->method('getAllowCustomPublicToken')
+			->willReturn(true);
+
+		$this->formsService->expects($this->once())
+			->method('getFormIfAllowed')
+			->with(5)
+			->willReturn($form);
+
+		$share = new Share();
+		$share->setId(8);
+		$share->setFormId(5);
+		$share->setShareType(IShare::TYPE_LINK);
+		$share->setShareWith('abcdefgh');
+		$share->setPermissions([Constants::PERMISSION_SUBMIT]);
+
+		$this->shareMapper->expects($this->once())
+			->method('findById')
+			->with(8)
+			->willReturn($share);
+
+		$this->shareMapper->expects($this->once())
+			->method('findPublicShareByHash')
+			->with('tokenabcd')
+			->willThrowException(new DoesNotExistException('Not found'));
+
+		$this->shareMapper->expects($this->once())
+			->method('update')
+			->willReturnCallback(function (Share $updatedShare) {
+				$this->assertSame('tokenabcd', $updatedShare->getShareWith());
+				return $updatedShare;
+			});
+
+		$this->assertEquals(new DataResponse(8), $this->shareApiController->updateShareToken(5, 8, 'tokenabcd'));
+	}
+
+	public function testUpdateShareToken_CustomTokensDisabled() {
+		$this->configService->expects($this->once())
+			->method('getAllowCustomPublicToken')
+			->willReturn(false);
+
+		$this->expectException(OCSForbiddenException::class);
+		$this->shareApiController->updateShareToken(5, 8, 'tokenabcd');
+	}
+
+	public function testUpdateShareToken_ForbiddenForNonLinkShare() {
+		$form = new Form();
+		$form->setId('5');
+		$form->setOwnerId('currentUser');
+
+		$this->configService->expects($this->once())
+			->method('getAllowCustomPublicToken')
+			->willReturn(true);
+
+		$this->formsService->expects($this->once())
+			->method('getFormIfAllowed')
+			->with(5)
+			->willReturn($form);
+
+		$share = new Share();
+		$share->setId(8);
+		$share->setFormId(5);
+		$share->setShareType(IShare::TYPE_USER);
+		$share->setShareWith('user1');
+
+		$this->shareMapper->expects($this->once())
+			->method('findById')
+			->with(8)
+			->willReturn($share);
+
+		$this->expectException(OCSForbiddenException::class);
+		$this->shareApiController->updateShareToken(5, 8, 'tokenabcd');
+	}
+
+	public function testUpdateShareToken_DuplicateHash() {
+		$form = new Form();
+		$form->setId('5');
+		$form->setOwnerId('currentUser');
+
+		$this->configService->expects($this->once())
+			->method('getAllowCustomPublicToken')
+			->willReturn(true);
+
+		$this->formsService->expects($this->once())
+			->method('getFormIfAllowed')
+			->with(5)
+			->willReturn($form);
+
+		$currentShare = new Share();
+		$currentShare->setId(8);
+		$currentShare->setFormId(5);
+		$currentShare->setShareType(IShare::TYPE_LINK);
+		$currentShare->setShareWith('abcdefgh');
+
+		$existingShare = new Share();
+		$existingShare->setId(9);
+		$existingShare->setFormId(5);
+		$existingShare->setShareType(IShare::TYPE_LINK);
+		$existingShare->setShareWith('tokenabcd');
+
+		$this->shareMapper->expects($this->once())
+			->method('findById')
+			->with(8)
+			->willReturn($currentShare);
+
+		$this->shareMapper->expects($this->once())
+			->method('findPublicShareByHash')
+			->with('tokenabcd')
+			->willReturn($existingShare);
+
+		$this->expectException(OCSBadRequestException::class);
+		$this->shareApiController->updateShareToken(5, 8, 'tokenabcd');
+	}
+
+	public function testUpdateShareToken_InvalidToken() {
+		$form = new Form();
+		$form->setId('5');
+		$form->setOwnerId('currentUser');
+
+		$this->configService->expects($this->once())
+			->method('getAllowCustomPublicToken')
+			->willReturn(true);
+
+		$this->formsService->expects($this->once())
+			->method('getFormIfAllowed')
+			->with(5)
+			->willReturn($form);
+
+		$share = new Share();
+		$share->setId(8);
+		$share->setFormId(5);
+		$share->setShareType(IShare::TYPE_LINK);
+		$share->setShareWith('abcdefgh');
+
+		$this->shareMapper->expects($this->once())
+			->method('findById')
+			->with(8)
+			->willReturn($share);
+
+		$this->shareMapper->expects($this->never())
+			->method('update');
+
+		$this->expectException(OCSBadRequestException::class);
+		$this->shareApiController->updateShareToken(5, 8, 'invalid-token');
+	}
 }

--- a/tests/Unit/Controller/ShareApiControllerTest.php
+++ b/tests/Unit/Controller/ShareApiControllerTest.php
@@ -1104,8 +1104,7 @@ class ShareApiControllerTest extends TestCase {
 		$this->shareApiController->updateShareToken(5, 8, 'invalid-token');
 	}
 
-	public function testUpdateShareToken_WhitespaceToken()
-	{
+	public function testUpdateShareToken_WhitespaceToken() {
 		$form = new Form();
 		$form->setId('5');
 		$form->setOwnerId('currentUser');
@@ -1137,8 +1136,7 @@ class ShareApiControllerTest extends TestCase {
 		$this->shareApiController->updateShareToken(5, 8, ' customtoken ');
 	}
 
-	public function testUpdateShareToken_TooShortToken()
-	{
+	public function testUpdateShareToken_TooShortToken() {
 		$form = new Form();
 		$form->setId('5');
 		$form->setOwnerId('currentUser');
@@ -1170,8 +1168,7 @@ class ShareApiControllerTest extends TestCase {
 		$this->shareApiController->updateShareToken(5, 8, 'abc');
 	}
 
-	public function testUpdateShareToken_SameTokenReturnsEarly()
-	{
+	public function testUpdateShareToken_SameTokenReturnsEarly() {
 		$form = new Form();
 		$form->setId('5');
 		$form->setOwnerId('currentUser');
@@ -1206,8 +1203,7 @@ class ShareApiControllerTest extends TestCase {
 		$this->assertEquals(new DataResponse(8), $this->shareApiController->updateShareToken(5, 8, 'sameToken123'));
 	}
 
-	public function testUpdateShareToken_ForeignShare()
-	{
+	public function testUpdateShareToken_ForeignShare() {
 		$form = new Form();
 		$form->setId('5');
 		$form->setOwnerId('currentUser');
@@ -1236,8 +1232,7 @@ class ShareApiControllerTest extends TestCase {
 		$this->shareApiController->updateShareToken(5, 8, 'customtoken123');
 	}
 
-	public function testUpdateShareToken_ShareNotFound()
-	{
+	public function testUpdateShareToken_ShareNotFound() {
 		$form = new Form();
 		$form->setId('5');
 		$form->setOwnerId('currentUser');
@@ -1260,8 +1255,7 @@ class ShareApiControllerTest extends TestCase {
 		$this->shareApiController->updateShareToken(5, 8, 'customtoken123');
 	}
 
-	public function testUpdateShareToken_ArchivedForm()
-	{
+	public function testUpdateShareToken_ArchivedForm() {
 		$form = new Form();
 		$form->setId('5');
 		$form->setOwnerId('currentUser');

--- a/tests/Unit/Controller/ShareApiControllerTest.php
+++ b/tests/Unit/Controller/ShareApiControllerTest.php
@@ -991,7 +991,7 @@ class ShareApiControllerTest extends TestCase {
 				return $updatedShare;
 			});
 
-		$this->assertEquals(new DataResponse(8), $this->shareApiController->updateShareToken(5, 8, 'tokenabcd'));
+		$this->assertEquals(new DataResponse(8), $this->shareApiController->updateShare(5, 8, ['token' => 'tokenabcd']));
 	}
 
 	public function testUpdateShareToken_CustomTokensDisabled() {
@@ -1000,7 +1000,7 @@ class ShareApiControllerTest extends TestCase {
 			->willReturn(false);
 
 		$this->expectException(OCSForbiddenException::class);
-		$this->shareApiController->updateShareToken(5, 8, 'tokenabcd');
+		$this->shareApiController->updateShare(5, 8, ['token' => 'tokenabcd']);
 	}
 
 	public function testUpdateShareToken_ForbiddenForNonLinkShare() {
@@ -1029,7 +1029,7 @@ class ShareApiControllerTest extends TestCase {
 			->willReturn($share);
 
 		$this->expectException(OCSForbiddenException::class);
-		$this->shareApiController->updateShareToken(5, 8, 'tokenabcd');
+		$this->shareApiController->updateShare(5, 8, ['token' => 'tokenabcd']);
 	}
 
 	public function testUpdateShareToken_DuplicateHash() {
@@ -1069,7 +1069,7 @@ class ShareApiControllerTest extends TestCase {
 			->willReturn($existingShare);
 
 		$this->expectException(OCSBadRequestException::class);
-		$this->shareApiController->updateShareToken(5, 8, 'tokenabcd');
+		$this->shareApiController->updateShare(5, 8, ['token' => 'tokenabcd']);
 	}
 
 	public function testUpdateShareToken_InvalidToken() {
@@ -1101,7 +1101,7 @@ class ShareApiControllerTest extends TestCase {
 			->method('update');
 
 		$this->expectException(OCSBadRequestException::class);
-		$this->shareApiController->updateShareToken(5, 8, 'invalid-token');
+		$this->shareApiController->updateShare(5, 8, ['token' => 'invalid-token']);
 	}
 
 	public function testUpdateShareToken_WhitespaceToken() {
@@ -1133,7 +1133,7 @@ class ShareApiControllerTest extends TestCase {
 			->method('findPublicShareByHash');
 
 		$this->expectException(OCSBadRequestException::class);
-		$this->shareApiController->updateShareToken(5, 8, ' customtoken ');
+		$this->shareApiController->updateShare(5, 8, ['token' => ' customtoken ']);
 	}
 
 	public function testUpdateShareToken_TooShortToken() {
@@ -1165,7 +1165,7 @@ class ShareApiControllerTest extends TestCase {
 			->method('findPublicShareByHash');
 
 		$this->expectException(OCSBadRequestException::class);
-		$this->shareApiController->updateShareToken(5, 8, 'abc');
+		$this->shareApiController->updateShare(5, 8, ['token' => 'abc']);
 	}
 
 	public function testUpdateShareToken_SameTokenReturnsEarly() {
@@ -1200,7 +1200,7 @@ class ShareApiControllerTest extends TestCase {
 		$this->formsService->expects($this->never())
 			->method('obtainFormLock');
 
-		$this->assertEquals(new DataResponse(8), $this->shareApiController->updateShareToken(5, 8, 'sameToken123'));
+		$this->assertEquals(new DataResponse(8), $this->shareApiController->updateShare(5, 8, ['token' => 'sameToken123']));
 	}
 
 	public function testUpdateShareToken_ForeignShare() {
@@ -1229,7 +1229,7 @@ class ShareApiControllerTest extends TestCase {
 			->willReturn($share);
 
 		$this->expectException(OCSBadRequestException::class);
-		$this->shareApiController->updateShareToken(5, 8, 'customtoken123');
+		$this->shareApiController->updateShare(5, 8, ['token' => 'customtoken123']);
 	}
 
 	public function testUpdateShareToken_ShareNotFound() {
@@ -1252,7 +1252,7 @@ class ShareApiControllerTest extends TestCase {
 			->willThrowException(new DoesNotExistException('missing'));
 
 		$this->expectException(OCSNotFoundException::class);
-		$this->shareApiController->updateShareToken(5, 8, 'customtoken123');
+		$this->shareApiController->updateShare(5, 8, ['token' => 'customtoken123']);
 	}
 
 	public function testUpdateShareToken_ArchivedForm() {
@@ -1277,6 +1277,6 @@ class ShareApiControllerTest extends TestCase {
 			->method('findById');
 
 		$this->expectException(OCSForbiddenException::class);
-		$this->shareApiController->updateShareToken(5, 8, 'customtoken123');
+		$this->shareApiController->updateShare(5, 8, ['token' => 'customtoken123']);
 	}
 }

--- a/tests/Unit/Service/ConfigServiceTest.php
+++ b/tests/Unit/Service/ConfigServiceTest.php
@@ -62,6 +62,7 @@ class ConfigServiceTest extends TestCase {
 				'strConfig' => [
 					'allowPermitAll' => 'false',
 					'allowPublicLink' => 'false',
+					'allowCustomPublicShareTokens' => 'true',
 					'allowShowToAll' => 'false',
 					'creationAllowedGroups' => '["group1", "group2", "nonExisting"]',
 					'restrictCreation' => 'true',
@@ -73,6 +74,7 @@ class ConfigServiceTest extends TestCase {
 				'expected' => [
 					'allowPermitAll' => false,
 					'allowPublicLink' => false,
+					'allowCustomPublicShareTokens' => true,
 					'allowShowToAll' => false,
 					'creationAllowedGroups' => [
 						[
@@ -136,6 +138,7 @@ class ConfigServiceTest extends TestCase {
 				'expected' => [
 					'allowPermitAll' => true,
 					'allowPublicLink' => true,
+					'allowCustomPublicShareTokens' => false,
 					'allowShowToAll' => true,
 					'creationAllowedGroups' => [],
 					'restrictCreation' => false,


### PR DESCRIPTION
This adds admin-gated custom tokens for public Forms share links. By default the feature is disabled, so existing instances keep the current random-token behavior. When enabled by an admin, form owners can edit the token of an existing public link directly in the sharing sidebar, save it explicitly, and the old URL becomes invalid immediately.

It also adds the necessary backend support for token updates, keeps public-link routing compatible with custom tokens, and includes tests plus API documentation updates.