### PR TITLE
Fix copypasting from responses page resulting in wrong paragraph/newline placement

### DIFF
--- a/src/components/Results/Submission.vue
+++ b/src/components/Results/Submission.vue
@@ -4,7 +4,7 @@
 -->
 
 <template>
-	<div class="section submission">
+	<div class="section submission" @copy="onCopy">
 		<div class="submission-head">
 			<h3 dir="auto">
 				{{ submission.userDisplayName }}
@@ -244,6 +244,74 @@ export default {
 	methods: {
 		onDelete() {
 			this.$emit('delete')
+		},
+
+		onCopy(event) {
+			if (!event.clipboardData) return
+
+			const selection = window.getSelection()
+			if (!selection || selection.isCollapsed) return
+
+			const fragment = selection.getRangeAt(0).cloneContents()
+			const text = this.serializeNode(fragment).trim()
+
+			if (!text) return
+
+			event.clipboardData.setData('text/plain', text)
+			event.preventDefault()
+		},
+
+		serializeNode(node) {
+			if (node.nodeType === Node.TEXT_NODE) {
+				return node.textContent
+			}
+
+			if (
+				node.nodeType !== Node.ELEMENT_NODE
+				&& node.nodeType !== Node.DOCUMENT_FRAGMENT_NODE
+			) {
+				return ''
+			}
+
+			const tag = node.tagName?.toLowerCase()
+
+			if (tag && ['svg', 'script', 'style'].includes(tag)) return ''
+			if (tag === 'br') return '\n'
+
+			const children = Array.from(node.childNodes)
+				.map((child) => this.serializeNode(child))
+				.join('')
+
+			// Answer blocks get a blank line before them as visual separator
+			if (tag === 'div' && node.classList?.contains('answer')) {
+				const trimmed = children.replace(/\s+$/, '')
+				return trimmed ? '\n' + trimmed + '\n' : ''
+			}
+
+			const isBlock =
+				tag
+				&& [
+					'div',
+					'p',
+					'h1',
+					'h2',
+					'h3',
+					'h4',
+					'h5',
+					'h6',
+					'li',
+					'td',
+					'tr',
+					'th',
+					'dt',
+					'dd',
+				].includes(tag)
+			if (isBlock) {
+				const trimmed = children.replace(/\s+$/, '')
+				return trimmed ? trimmed + '\n' : ''
+			}
+
+			return children
 		},
 	},
 }


### PR DESCRIPTION
Fix #975, as it is a recurring annoyance I have. :D 

I often copy individual submissions directly from the responses/results view of a form, without going through the structured process of creating a spreadsheet or exporting it.

While the visual styling of the responses looks good, what comes out when copying it and pasting it as plain text has empty lines in the wrong places.

Visually it looks like this on the responses/results page:
```
admin
Monday, May 11, 2026 2:21 PM

Short answer question title
Just testing a reply

Long text question title
Testing a reply for the long text

Checkbox question title
I love the Forms app
```

But when copy-pasting it from the page into a text editor, it comes out like this:
```
admin

Monday, May 11, 2026 2:21 PM
Short answer question title

Just testing a reply
Long text question title

Testing a reply for the long text
Checkbox question title

I love the Forms app
```

Before | After
-|-
<img width="1010" height="647" alt="Screenshot From 2026-05-11 14-22-23" src="https://github.com/user-attachments/assets/1f0491dd-6984-4fe7-b80e-70e1467db749" />|<img width="1662" height="716" alt="Screenshot From 2026-05-11 16-07-54" src="https://github.com/user-attachments/assets/e2649638-69bb-478d-8abb-c0130a090587" />


---

AI-assisted: Claude Code (Sonnet 4.6)

The key insight: browsers give h1–h6 elements a special extra newline in clipboard text regardless of CSS. The new serializeNode method walks the actual DOM selection and treats all
  block elements — including headings — uniformly (one newline each). The .answer div gets a leading \n to produce the blank line separator between questions, matching the visual
  layout.

  This means:
  - Whole submission copy → same nicely formatted output as before
  - Partial copy (e.g. half a question title + half its answer) → exactly that text, no extra blank line
  - Single answer copy → just that question title + answer
  - The exact character boundaries of what the user selected are respected throughout