### PR TITLE
fix(activity): throw UnknownActivityException for unknown events

### DIFF
--- a/lib/Activity/Provider.php
+++ b/lib/Activity/Provider.php
@@ -11,6 +11,7 @@ use Exception;
 
 use OCA\Forms\Db\FormMapper;
 use OCA\Forms\Service\CirclesService;
+use OCP\Activity\Exceptions\UnknownActivityException;
 use OCP\Activity\IEvent;
 use OCP\Activity\IEventMerger;
 use OCP\Activity\IProvider;
@@ -44,12 +45,12 @@ class Provider implements IProvider {
 	 * @param IEvent $event
 	 * @param IEvent|null $previousEvent
 	 * @return IEvent
-	 * @throws \InvalidArgumentException
+	 * @throws UnknownActivityException
 	 */
 	public function parse($language, IEvent $event, ?IEvent $previousEvent = null): IEvent {
 		// Throw Exception, if not our activity. Necessary for workflow of Activity-App.
 		if ($event->getApp() !== $this->appName) {
-			throw new \InvalidArgumentException();
+			throw new UnknownActivityException();
 		}
 		$l10n = $this->l10nFactory->get($this->appName, $language);
 
@@ -72,7 +73,7 @@ class Provider implements IProvider {
 	 * Provide the translated string with placeholders
 	 * @param $subject The events subject
 	 * @return string
-	 * @throws \InvalidArgumentException
+	 * @throws UnknownActivityException
 	 */
 	public function getSubjectString(IL10N $l10n, string $subject): string {
 		switch ($subject) {
@@ -90,7 +91,7 @@ class Provider implements IProvider {
 
 			default:
 				$this->logger->warning('Some unknown activity has been found: ' . $subject);
-				throw new \InvalidArgumentException();
+				throw new UnknownActivityException();
 		}
 	}
 

--- a/tests/Unit/Activity/ProviderTest.php
+++ b/tests/Unit/Activity/ProviderTest.php
@@ -12,6 +12,7 @@ use OCA\Forms\Activity\Provider;
 use OCA\Forms\Db\Form;
 use OCA\Forms\Db\FormMapper;
 use OCA\Forms\Service\CirclesService;
+use OCP\Activity\Exceptions\UnknownActivityException;
 use OCP\Activity\IEvent;
 use OCP\Activity\IEventMerger;
 use OCP\AppFramework\Db\DoesNotExistException;
@@ -113,7 +114,7 @@ class ProviderTest extends TestCase {
 			->method('getApp')
 			->willReturn('someOtherApp');
 
-		$this->expectException(\InvalidArgumentException::class);
+		$this->expectException(UnknownActivityException::class);
 		$this->provider->parse('de_DE', $event);
 	}
 
@@ -220,7 +221,7 @@ class ProviderTest extends TestCase {
 		$l10n->expects($this->never())
 			->method('t');
 
-		$this->expectException(\InvalidArgumentException::class);
+		$this->expectException(UnknownActivityException::class);
 		$this->provider->getSubjectString($l10n, 'someUnknownSubject');
 	}
 


### PR DESCRIPTION
## Summary

The Activity manager loops over every registered provider and expects each one to throw if the event isn't theirs. We were doing that with `\InvalidArgumentException`, which has been deprecated for this purpose since NC 30. Swapped to `\OCP\Activity\Exceptions\UnknownActivityException` so "not my event" is distinguishable from a real parser bug.

see: https://github.com/nextcloud/server/pull/59609