### PR TITLE
fix: always show three dots menu in navigation

### DIFF
--- a/src/components/AppNavigationForm.vue
+++ b/src/components/AppNavigationForm.vue
@@ -9,6 +9,7 @@
 		:actions-aria-label="t('forms', 'Form actions')"
 		:counterNumber="form.submissionCount"
 		compact
+		forceMenu
 		:forceDisplayActions="forceDisplayActions"
 		:name="formTitle"
 		:to="{


### PR DESCRIPTION
Always use the three dot menu in navigation.

Signed-off-by: Christian Hartmann <chris-hartmann@gmx.de>