### PR TITLE
feat: add question at position

### DIFF
--- a/docs/API_v3.md
+++ b/docs/API_v3.md
@@ -370,6 +370,7 @@ Returns the questions and options of the given form (without submissions).
   |-----------|---------|----------|-------------|
   | _type_ | [QuestionType](DataStructure.md#question-types) | | The question-type of the new question |
   | _text_ | String | yes | _Optional_ The text of the new question. |
+  | _position_ | Integer | yes | _(optional)_ 1-based position to insert the new question. When omitted the question is appended at the end. |
 - Response: The new question object.
 
 ```
@@ -506,6 +507,10 @@ Creates a clone of a question with all its options.
   |-----------|---------|-------------|
   | _formId_ | Integer | ID of the form containing the question |
   | _questionId_ | Integer | ID of the question to clone |
+- Parameters:
+  | Parameter | Type | Optional | Description |
+  |-----------|---------|----------|-------------|
+  | _position_ | Integer | yes | _(optional)_ 1-based position to insert the cloned question. When omitted the clone is appended at the end. |
 - Response: Returns cloned question object with the new ID set.
 
 ```

--- a/lib/Controller/ApiController.php
+++ b/lib/Controller/ApiController.php
@@ -485,6 +485,7 @@ class ApiController extends OCSController {
 	 * @param FormsQuestionGridCellType $subtype the new question subtype
 	 * @param string $text the new question title
 	 * @param ?int $fromId (optional) id of the question that should be cloned
+	 * @param ?int $position (optional) the position of the new question
 	 * @return DataResponse<Http::STATUS_CREATED, FormsQuestion, array{}>
 	 * @throws OCSBadRequestException Invalid type
 	 * @throws OCSBadRequestException Datetime question type no longer supported
@@ -499,7 +500,7 @@ class ApiController extends OCSController {
 	#[NoAdminRequired()]
 	#[BruteForceProtection(action: 'form')]
 	#[ApiRoute(verb: 'POST', url: '/api/v3/forms/{formId}/questions')]
-	public function newQuestion(int $formId, ?string $type = null, ?string $subtype = null, string $text = '', ?int $fromId = null): DataResponse {
+	public function newQuestion(int $formId, ?string $type = null, ?string $subtype = null, string $text = '', ?int $fromId = null, ?int $position = null): DataResponse {
 		$form = $this->formsService->getFormIfAllowed($formId, Constants::PERMISSION_EDIT);
 		$this->formsService->obtainFormLock($form);
 
@@ -526,13 +527,20 @@ class ApiController extends OCSController {
 				throw new OCSBadRequestException('Datetime question type no longer supported');
 			}
 
-			// Retrieve all active questions sorted by Order. Takes the order of the last array-element and adds one.
+			// Retrieve all active questions sorted by Order.
 			$questions = $this->questionMapper->findByForm($formId);
-			$lastQuestion = array_pop($questions);
-			if ($lastQuestion) {
-				$questionOrder = $lastQuestion->getOrder() + 1;
+
+			if ($position !== null) {
+				$position = $this->shiftQuestionsForInsert($questions, $position);
+				$questionOrder = $position;
 			} else {
-				$questionOrder = 1;
+				// Append at the end
+				$lastQuestion = array_pop($questions);
+				if ($lastQuestion) {
+					$questionOrder = $lastQuestion->getOrder() + 1;
+				} else {
+					$questionOrder = 1;
+				}
 			}
 
 			$question = new Question();
@@ -574,7 +582,13 @@ class ApiController extends OCSController {
 
 			$questionData = $sourceQuestion->read();
 			unset($questionData['id']);
-			$questionData['order'] = end($allQuestions)->getOrder() + 1;
+
+			if ($position !== null) {
+				$position = $this->shiftQuestionsForInsert($allQuestions, $position);
+				$questionData['order'] = $position;
+			} else {
+				$questionData['order'] = end($allQuestions)->getOrder() + 1;
+			}
 
 			$newQuestion = Question::fromParams($questionData);
 			$this->questionMapper->insert($newQuestion);
@@ -1999,5 +2013,37 @@ class ApiController extends OCSController {
 		$form->setLockedUntil(null);
 		$this->formMapper->update($form);
 		return new DataResponse($form->getOwnerId());
+	}
+
+	/**
+	 * Shift existing question orders to make room for an insertion at $position.
+	 * Normalizes the given $position to the valid range and updates all questions
+	 * with order >= $position by incrementing their order by one.
+	 *
+	 * @param Question[] $questions
+	 * @param int $position 1-based desired position
+	 * @return int normalized position
+	 */
+	private function shiftQuestionsForInsert(array $questions, int $position): int {
+		$maxOrder = 0;
+		if (count($questions) > 0) {
+			$maxOrder = end($questions)->getOrder();
+		}
+		if ($position < 1) {
+			$position = 1;
+		}
+		if ($position > $maxOrder + 1) {
+			$position = $maxOrder + 1;
+		}
+
+		for ($i = count($questions) - 1; $i >= 0; $i--) {
+			$q = $questions[$i];
+			if ($q->getOrder() >= $position) {
+				$q->setOrder($q->getOrder() + 1);
+				$this->questionMapper->update($q);
+			}
+		}
+
+		return $position;
 	}
 }

--- a/openapi.json
+++ b/openapi.json
@@ -1686,6 +1686,13 @@
                                         "nullable": true,
                                         "default": null,
                                         "description": "(optional) id of the question that should be cloned"
+                                    },
+                                    "position": {
+                                        "type": "integer",
+                                        "format": "int64",
+                                        "nullable": true,
+                                        "default": null,
+                                        "description": "(optional) the position of the new question"
                                     }
                                 }
                             }

--- a/src/components/AddQuestionMenu.vue
+++ b/src/components/AddQuestionMenu.vue
@@ -1,0 +1,146 @@
+<!--
+  - SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+  - SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
+<template>
+	<NcActions
+		v-model:open="openLocal"
+		:container="container"
+		:menuName="menuName"
+		:aria-label="ariaLabel"
+		:variant="variant"
+		:primary="primary">
+		<template #icon>
+			<NcLoadingIcon v-if="isLoadingQuestions" :size="20" />
+			<NcIconSvgWrapper v-else :svg="IconPlus" />
+		</template>
+
+		<template v-if="!activeQuestionType">
+			<NcActionButton
+				v-for="(answer, type) in answerTypesFilter"
+				:key="answer.label"
+				:closeAfterClick="!hasSubtypes(answer)"
+				:disabled="isLoadingQuestions"
+				:isMenu="hasSubtypes(answer)"
+				class="question-menu__question"
+				@click="onPrimaryClick(answer, type, position)">
+				<template #icon>
+					<NcIconSvgWrapper :svg="answer.icon" />
+				</template>
+				{{ answer.label }}
+			</NcActionButton>
+		</template>
+
+		<template v-else>
+			<NcActionButton
+				:disabled="isLoadingQuestions"
+				class="question-menu__question"
+				@click="activeQuestionType = null">
+				<template #icon>
+					<NcIconSvgWrapper :svg="IconChevronLeft" />
+				</template>
+				{{ t('forms', 'Grid') }}
+			</NcActionButton>
+			<NcActionSeparator />
+
+			<NcActionButton
+				v-for="(answer, type) in answerTypesFilter[activeQuestionType]
+					.subtypes"
+				:key="'subtype-' + answer.label"
+				closeAfterClick
+				:disabled="isLoadingQuestions"
+				class="question-menu__question"
+				@click="onSubtypeClick(activeQuestionType, type, position)">
+				<template #icon>
+					<NcIconSvgWrapper :svg="answer.icon" />
+				</template>
+				{{ answer.label }}
+			</NcActionButton>
+		</template>
+	</NcActions>
+</template>
+
+<script>
+import IconPlus from '@material-symbols/svg-400/outlined/add.svg?raw'
+import IconChevronLeft from '@material-symbols/svg-400/outlined/chevron_left.svg?raw'
+import NcActionButton from '@nextcloud/vue/components/NcActionButton'
+import NcActions from '@nextcloud/vue/components/NcActions'
+import NcActionSeparator from '@nextcloud/vue/components/NcActionSeparator'
+import NcIconSvgWrapper from '@nextcloud/vue/components/NcIconSvgWrapper'
+import NcLoadingIcon from '@nextcloud/vue/components/NcLoadingIcon'
+
+export default {
+	name: 'AddQuestionMenu',
+
+	components: {
+		NcActions,
+		NcActionButton,
+		NcActionSeparator,
+		NcIconSvgWrapper,
+		NcLoadingIcon,
+	},
+
+	props: {
+		open: { type: Boolean, default: false },
+		container: { type: String, default: 'body' },
+		menuName: { type: String, default: null },
+		ariaLabel: { type: String, default: null },
+		variant: { type: String, default: null },
+		primary: { type: Boolean, default: false },
+		position: { type: Number, default: null },
+		isLoadingQuestions: { type: Boolean, default: false },
+		answerTypesFilter: { type: Object, required: true },
+		hasSubtypes: { type: Function, required: true },
+	},
+
+	emits: ['update:open', 'addQuestion'],
+
+	setup() {
+		return {
+			IconChevronLeft,
+			IconPlus,
+		}
+	},
+
+	data() {
+		return {
+			activeQuestionType: null,
+			openLocal: this.open,
+		}
+	},
+
+	watch: {
+		open(v) {
+			this.openLocal = v
+		},
+
+		openLocal(v) {
+			this.$emit('update:open', v)
+			if (!v) this.activeQuestionType = null
+		},
+	},
+
+	methods: {
+		onPrimaryClick(answer, type, position) {
+			if (this.hasSubtypes(answer)) {
+				this.activeQuestionType = type
+				return
+			}
+			this.$emit('addQuestion', type, null, position)
+			this.openLocal = false
+		},
+
+		onSubtypeClick(type, subtype, position) {
+			this.$emit('addQuestion', type, subtype, position)
+			this.openLocal = false
+		},
+	},
+}
+</script>
+
+<style scoped>
+.question-menu__question {
+	min-width: 200px;
+}
+</style>

--- a/src/components/Questions/Question.vue
+++ b/src/components/Questions/Question.vue
@@ -157,6 +157,8 @@
 
 		<!-- Question content -->
 		<slot />
+		<!-- Insert question menu -->
+		<slot name="insert" />
 	</li>
 </template>
 

--- a/src/components/Questions/QuestionColor.vue
+++ b/src/components/Questions/QuestionColor.vue
@@ -35,6 +35,9 @@
 				</NcButton>
 			</div>
 		</div>
+		<template #insert>
+			<slot name="insert" />
+		</template>
 	</Question>
 </template>
 

--- a/src/components/Questions/QuestionDate.vue
+++ b/src/components/Questions/QuestionDate.vue
@@ -98,6 +98,9 @@
 				rangeSeparator=" - "
 				@update:modelValue="onValueChange" />
 		</div>
+		<template #insert>
+			<slot name="insert" />
+		</template>
 	</Question>
 </template>
 

--- a/src/components/Questions/QuestionDropdown.vue
+++ b/src/components/Questions/QuestionDropdown.vue
@@ -50,38 +50,38 @@
 				v-else
 				v-model="choices"
 				class="question__content"
-				:animation="200"
+				:animation="300"
 				direction="vertical"
 				handle=".option__drag-handle"
 				invertSwap
-				tag="transition-group"
-				:componentData="{
-					name: isDragging
-						? 'no-external-transition-on-drag'
-						: 'options-list-transition',
-				}"
+				target=".sort-target"
 				@change="saveOptionsOrder('choice')"
-				@start="isDragging = true"
-				@end="isDragging = false">
-				<AnswerInput
-					v-for="(answer, index) in choices"
-					:key="answer.local ? 'option-local' : answer.id"
-					ref="input"
-					:answer="answer"
-					:formId="formId"
-					isDropdown
-					:index="index"
-					:isUnique="!isMultiple"
-					:maxIndex="options.length - 1"
-					:maxOptionLength="maxStringLengths.optionText"
-					optionType="choice"
-					@createAnswer="onCreateAnswer"
-					@update:answer="updateAnswer"
-					@delete="deleteOption"
-					@focusNext="focusNextInput"
-					@moveUp="onOptionMoveUp(index, OptionType.Choice)"
-					@moveDown="onOptionMoveDown(index, OptionType.Choice)"
-					@tabbedOut="checkValidOption" />
+				@start="onDragStart"
+				@end="onDragEnd">
+				<TransitionGroup
+					tag="ul"
+					:name="isDragging ? undefined : 'options-list-transition'"
+					class="sort-target">
+					<AnswerInput
+						v-for="(answer, index) in choices"
+						:key="answer.local ? 'option-local' : answer.id"
+						ref="input"
+						:answer="answer"
+						:formId="formId"
+						isDropdown
+						:index="index"
+						:isUnique="!isMultiple"
+						:maxIndex="options.length - 1"
+						:maxOptionLength="maxStringLengths.optionText"
+						optionType="choice"
+						@createAnswer="onCreateAnswer"
+						@update:answer="updateAnswer"
+						@delete="deleteOption"
+						@focusNext="focusNextInput"
+						@moveUp="onOptionMoveUp(index, OptionType.Choice)"
+						@moveDown="onOptionMoveDown(index, OptionType.Choice)"
+						@tabbedOut="checkValidOption" />
+				</TransitionGroup>
 			</Draggable>
 		</template>
 
@@ -89,6 +89,9 @@
 		<OptionInputDialog
 			v-model:open="isOptionDialogShown"
 			@multipleAnswers="handleMultipleOptions" />
+		<template #insert>
+			<slot name="insert" />
+		</template>
 	</Question>
 </template>
 
@@ -181,6 +184,16 @@ export default {
 	},
 
 	methods: {
+		onDragStart() {
+			this.isDragging = true
+		},
+
+		onDragEnd() {
+			this.$nextTick(() => {
+				this.isDragging = false
+			})
+		},
+
 		onInput(option) {
 			if (Array.isArray(option)) {
 				this.$emit('update:values', [
@@ -225,7 +238,7 @@ export default {
 .options-list-transition-enter-from,
 .options-list-transition-leave-to {
 	opacity: 0;
-	transform: translateX(44px);
+	transform: translateX(var(--default-clickable-area));
 }
 
 /* ensure leaving items are taken out of layout flow so that moving

--- a/src/components/Questions/QuestionFile.vue
+++ b/src/components/Questions/QuestionFile.vue
@@ -141,6 +141,9 @@
 				</li>
 			</ul>
 		</div>
+		<template #insert>
+			<slot name="insert" />
+		</template>
 	</Question>
 </template>
 

--- a/src/components/Questions/QuestionGrid.vue
+++ b/src/components/Questions/QuestionGrid.vue
@@ -96,78 +96,81 @@
 				<Draggable
 					v-model="columns"
 					class="question__content"
-					:animation="200"
+					:animation="300"
 					direction="vertical"
 					handle=".option__drag-handle"
 					invertSwap
-					tag="transition-group"
-					:componentData="{
-						name: isDragging
-							? 'no-external-transition-on-drag'
-							: 'options-list-transition',
-					}"
+					target=".sort-target"
 					@change="saveOptionsOrder('column')"
-					@start="isDragging = true"
-					@end="isDragging = false">
+					@start="onDragStart"
+					@end="onDragEnd">
 					<!-- Column input edit -->
-					<AnswerInput
-						v-for="(answer, index) in columns"
-						:key="answer.local ? 'option-local' : answer.id"
-						ref="input"
-						:answer="answer"
-						:formId="formId"
-						:index="index"
-						:isUnique="isUnique"
-						:maxIndex="columns.length - 2"
-						:maxOptionLength="maxStringLengths.optionText"
-						optionType="column"
-						@createAnswer="onCreateAnswer"
-						@update:answer="updateAnswer"
-						@delete="deleteOption"
-						@focusNext="focusNextInput"
-						@moveUp="onOptionMoveUp(index, 'column')"
-						@moveDown="onOptionMoveDown(index, 'column')"
-						@tabbedOut="checkValidOption('column')" />
+					<TransitionGroup
+						tag="ul"
+						:name="isDragging ? undefined : 'options-list-transition'"
+						class="sort-target">
+						<AnswerInput
+							v-for="(answer, index) in columns"
+							:key="answer.local ? 'option-local' : answer.id"
+							ref="input"
+							:answer="answer"
+							:formId="formId"
+							:index="index"
+							:isUnique="isUnique"
+							:maxIndex="columns.length - 2"
+							:maxOptionLength="maxStringLengths.optionText"
+							optionType="column"
+							@createAnswer="onCreateAnswer"
+							@update:answer="updateAnswer"
+							@delete="deleteOption"
+							@focusNext="focusNextInput"
+							@moveUp="onOptionMoveUp(index, 'column')"
+							@moveDown="onOptionMoveDown(index, 'column')"
+							@tabbedOut="checkValidOption('column')" />
+					</TransitionGroup>
 				</Draggable>
 
 				<div>{{ t('forms', 'Rows') }}</div>
 				<Draggable
 					v-model="rows"
 					class="question__content"
-					:animation="200"
+					:animation="300"
 					direction="vertical"
 					handle=".option__drag-handle"
 					invertSwap
-					tag="transition-group"
-					:componentData="{
-						name: isDragging
-							? 'no-external-transition-on-drag'
-							: 'options-list-transition',
-					}"
+					target=".sort-target"
 					@change="saveOptionsOrder('row')"
-					@start="isDragging = true"
-					@end="isDragging = false">
-					<!-- Row input edit -->
-					<AnswerInput
-						v-for="(answer, index) in rows"
-						:key="answer.local ? 'option-local' : answer.id"
-						ref="input"
-						:answer="answer"
-						:formId="formId"
-						:index="index"
-						:isUnique="isUnique"
-						:maxIndex="rows.length - 2"
-						:maxOptionLength="maxStringLengths.optionText"
-						optionType="row"
-						@createAnswer="onCreateAnswer"
-						@update:answer="updateAnswer"
-						@delete="deleteOption"
-						@focusNext="focusNextInput"
-						@moveUp="onOptionMoveUp(index, 'row')"
-						@moveDown="onOptionMoveDown(index, 'row')"
-						@tabbedOut="checkValidOption('row')" />
+					@start="onDragStart"
+					@end="onDragEnd">
+					<TransitionGroup
+						tag="ul"
+						:name="isDragging ? undefined : 'options-list-transition'"
+						class="sort-target">
+						<!-- Row input edit -->
+						<AnswerInput
+							v-for="(answer, index) in rows"
+							:key="answer.local ? 'option-local' : answer.id"
+							ref="input"
+							:answer="answer"
+							:formId="formId"
+							:index="index"
+							:isUnique="isUnique"
+							:maxIndex="rows.length - 2"
+							:maxOptionLength="maxStringLengths.optionText"
+							optionType="row"
+							@createAnswer="onCreateAnswer"
+							@update:answer="updateAnswer"
+							@delete="deleteOption"
+							@focusNext="focusNextInput"
+							@moveUp="onOptionMoveUp(index, 'row')"
+							@moveDown="onOptionMoveDown(index, 'row')"
+							@tabbedOut="checkValidOption('row')" />
+					</TransitionGroup>
 				</Draggable>
 			</template>
+		</template>
+		<template #insert>
+			<slot name="insert" />
 		</template>
 	</Question>
 </template>
@@ -289,6 +292,16 @@ export default {
 			return true
 		},
 
+		onDragStart() {
+			this.isDragging = true
+		},
+
+		onDragEnd() {
+			this.$nextTick(() => {
+				this.isDragging = false
+			})
+		},
+
 		onChangeCheckboxRadio(rowId, value) {
 			const values = { ...this.values }
 			values[rowId] = value
@@ -408,7 +421,7 @@ export default {
 .options-list-transition-enter-from,
 .options-list-transition-leave-to {
 	opacity: 0;
-	transform: translateX(44px);
+	transform: translateX(var(--default-clickable-area));
 }
 
 /* ensure leaving items are taken out of layout flow so that moving

--- a/src/components/Questions/QuestionLinearScale.vue
+++ b/src/components/Questions/QuestionLinearScale.vue
@@ -107,6 +107,9 @@
 				{{ optionsLabelHighest }}
 			</div>
 		</div>
+		<template #insert>
+			<slot name="insert" />
+		</template>
 	</Question>
 </template>
 

--- a/src/components/Questions/QuestionLong.vue
+++ b/src/components/Questions/QuestionLong.vue
@@ -27,6 +27,9 @@
 				@keypress="autoSizeText"
 				@keydown.ctrl.enter="onKeydownCtrlEnter" />
 		</div>
+		<template #insert>
+			<slot name="insert" />
+		</template>
 	</Question>
 </template>
 

--- a/src/components/Questions/QuestionMultiple.vue
+++ b/src/components/Questions/QuestionMultiple.vue
@@ -121,37 +121,37 @@
 				v-else
 				v-model="choices"
 				class="question__content"
-				:animation="200"
+				:animation="300"
 				direction="vertical"
 				handle=".option__drag-handle"
 				invertSwap
-				tag="transition-group"
-				:componentData="{
-					name: isDragging
-						? 'no-external-transition-on-drag'
-						: 'options-list-transition',
-				}"
+				target=".sort-target"
 				@change="saveOptionsOrder('choice')"
-				@start="isDragging = true"
-				@end="isDragging = false">
-				<AnswerInput
-					v-for="(answer, index) in choices"
-					:key="answer.local ? 'option-local' : answer.id"
-					ref="input"
-					:answer="answer"
-					:formId="formId"
-					:index="index"
-					:isUnique="isUnique"
-					:maxIndex="options.length - 1"
-					:maxOptionLength="maxStringLengths.optionText"
-					optionType="choice"
-					@createAnswer="onCreateAnswer"
-					@update:answer="updateAnswer"
-					@delete="deleteOption"
-					@focusNext="focusNextInput"
-					@moveUp="onOptionMoveUp(index, OptionType.Choice)"
-					@moveDown="onOptionMoveDown(index, OptionType.Choice)"
-					@tabbedOut="checkValidOption" />
+				@start="onDragStart"
+				@end="onDragEnd">
+				<TransitionGroup
+					tag="ul"
+					:name="isDragging ? undefined : 'options-list-transition'"
+					class="sort-target">
+					<AnswerInput
+						v-for="(answer, index) in choices"
+						:key="answer.local ? 'option-local' : answer.id"
+						ref="input"
+						:answer="answer"
+						:formId="formId"
+						:index="index"
+						:isUnique="isUnique"
+						:maxIndex="options.length - 1"
+						:maxOptionLength="maxStringLengths.optionText"
+						optionType="choice"
+						@createAnswer="onCreateAnswer"
+						@update:answer="updateAnswer"
+						@delete="deleteOption"
+						@focusNext="focusNextInput"
+						@moveUp="onOptionMoveUp(index, OptionType.Choice)"
+						@moveDown="onOptionMoveDown(index, OptionType.Choice)"
+						@tabbedOut="checkValidOption" />
+				</TransitionGroup>
 			</Draggable>
 			<li
 				v-if="allowOtherAnswer"
@@ -176,6 +176,9 @@
 		<OptionInputDialog
 			v-model:open="isOptionDialogShown"
 			@multipleAnswers="handleMultipleOptions" />
+		<template #insert>
+			<slot name="insert" />
+		</template>
 	</Question>
 </template>
 
@@ -384,6 +387,16 @@ export default {
 
 			this.errorMessage = null
 			return true
+		},
+
+		onDragStart() {
+			this.isDragging = true
+		},
+
+		onDragEnd() {
+			this.$nextTick(() => {
+				this.isDragging = false
+			})
 		},
 
 		/**
@@ -659,7 +672,7 @@ export default {
 .options-list-transition-enter-from,
 .options-list-transition-leave-to {
 	opacity: 0;
-	transform: translateX(44px);
+	transform: translateX(var(--default-clickable-area));
 }
 
 /* ensure leaving items are taken out of layout flow so that moving

--- a/src/components/Questions/QuestionRanking.vue
+++ b/src/components/Questions/QuestionRanking.vue
@@ -39,7 +39,7 @@
 					v-if="unrankedOptions.length > 0"
 					v-model="unrankedOptions"
 					class="ranking-unranked__pool"
-					:animation="200"
+					:animation="300"
 					:group="'ranking_' + id"
 					@end="emitValues">
 					<button
@@ -63,55 +63,63 @@
 				<Draggable
 					v-model="rankedOptions"
 					class="ranking-ranked__list"
-					:animation="200"
+					:animation="300"
 					:group="'ranking_' + id"
+					target=".sort-target"
 					direction="vertical"
 					handle=".ranking-item__drag-handle"
 					@end="onRankingEnd">
-					<div
-						v-for="(option, index) in rankedOptions"
-						:key="option.id"
-						class="ranking-item"
-						role="listitem">
-						<NcActions
-							:id="`ranking-${option.id}-drag`"
-							:container="`#ranking-${option.id}-drag`"
-							:aria-label="t('forms', 'Move option actions')"
-							class="ranking-item__drag-handle"
-							variant="tertiary-no-background">
-							<template #icon>
-								<NcIconSvgWrapper :svg="IconDragIndicator" />
-							</template>
-							<NcActionButton
-								ref="buttonOptionUp"
-								:disabled="index === 0"
-								@click="onMoveUp(index)">
+					<TransitionGroup
+						tag="ul"
+						:name="isDragging ? undefined : 'options-list-transition'"
+						class="sort-target">
+						<li
+							v-for="(option, index) in rankedOptions"
+							:key="option.id"
+							class="ranking-item"
+							role="listitem">
+							<NcActions
+								:id="`ranking-${option.id}-drag`"
+								:container="`#ranking-${option.id}-drag`"
+								:aria-label="t('forms', 'Move option actions')"
+								class="ranking-item__drag-handle"
+								variant="tertiary-no-background">
 								<template #icon>
-									<NcIconSvgWrapper :svg="IconArrowUp" />
+									<NcIconSvgWrapper :svg="IconDragIndicator" />
 								</template>
-								{{ t('forms', 'Move option up') }}
-							</NcActionButton>
-							<NcActionButton
-								ref="buttonOptionDown"
-								:disabled="index === rankedOptions.length - 1"
-								@click="onMoveDown(index)">
+								<NcActionButton
+									ref="buttonOptionUp"
+									:disabled="index === 0"
+									@click="onMoveUp(index)">
+									<template #icon>
+										<NcIconSvgWrapper :svg="IconArrowUp" />
+									</template>
+									{{ t('forms', 'Move option up') }}
+								</NcActionButton>
+								<NcActionButton
+									ref="buttonOptionDown"
+									:disabled="index === rankedOptions.length - 1"
+									@click="onMoveDown(index)">
+									<template #icon>
+										<NcIconSvgWrapper :svg="IconArrowDown" />
+									</template>
+									{{ t('forms', 'Move option down') }}
+								</NcActionButton>
+							</NcActions>
+							<span class="ranking-item__position"
+								>{{ index + 1 }}.</span
+							>
+							<span class="ranking-item__text">{{ option.text }}</span>
+							<NcButton
+								variant="tertiary"
+								:ariaLabel="t('forms', 'Remove from ranking')"
+								@click="unrankOption(option)">
 								<template #icon>
-									<NcIconSvgWrapper :svg="IconArrowDown" />
+									<NcIconSvgWrapper :svg="IconClose" />
 								</template>
-								{{ t('forms', 'Move option down') }}
-							</NcActionButton>
-						</NcActions>
-						<span class="ranking-item__position">{{ index + 1 }}.</span>
-						<span class="ranking-item__text">{{ option.text }}</span>
-						<NcButton
-							variant="tertiary"
-							:ariaLabel="t('forms', 'Remove from ranking')"
-							@click="unrankOption(option)">
-							<template #icon>
-								<NcIconSvgWrapper :svg="IconClose" />
-							</template>
-						</NcButton>
-					</div>
+							</NcButton>
+						</li>
+					</TransitionGroup>
 				</Draggable>
 				<p v-if="rankedOptions.length === 0" class="ranking-ranked__empty">
 					{{ t('forms', 'Tap options above to rank them') }}
@@ -128,38 +136,38 @@
 				v-else
 				v-model="choices"
 				class="question__content"
-				:animation="200"
+				:animation="300"
 				direction="vertical"
 				handle=".option__drag-handle"
 				invertSwap
-				tag="transition-group"
-				:componentData="{
-					name: isDragging
-						? 'no-external-transition-on-drag'
-						: 'options-list-transition',
-				}"
+				target=".sort-target"
 				@change="saveOptionsOrder('choice')"
-				@start="isDragging = true"
-				@end="isDragging = false">
-				<AnswerInput
-					v-for="(answer, index) in choices"
-					:key="answer.local ? 'option-local' : answer.id"
-					ref="input"
-					:answer="answer"
-					:formId="formId"
-					:index="index"
-					:isUnique="true"
-					:maxIndex="options.length - 1"
-					:maxOptionLength="maxStringLengths.optionText"
-					:isRanking="true"
-					optionType="choice"
-					@createAnswer="onCreateAnswer"
-					@update:answer="updateAnswer"
-					@delete="deleteOption"
-					@focusNext="focusNextInput"
-					@moveUp="onOptionMoveUp(index, OptionType.Choice)"
-					@moveDown="onOptionMoveDown(index, OptionType.Choice)"
-					@tabbedOut="checkValidOption" />
+				@start="onDragStart"
+				@end="onDragEnd">
+				<TransitionGroup
+					tag="ul"
+					:name="isDragging ? undefined : 'options-list-transition'"
+					class="sort-target">
+					<AnswerInput
+						v-for="(answer, index) in choices"
+						:key="answer.local ? 'option-local' : answer.id"
+						ref="input"
+						:answer="answer"
+						:formId="formId"
+						:index="index"
+						:isUnique="true"
+						:maxIndex="options.length - 1"
+						:maxOptionLength="maxStringLengths.optionText"
+						:isRanking="true"
+						optionType="choice"
+						@createAnswer="onCreateAnswer"
+						@update:answer="updateAnswer"
+						@delete="deleteOption"
+						@focusNext="focusNextInput"
+						@moveUp="onOptionMoveUp(index, OptionType.Choice)"
+						@moveDown="onOptionMoveDown(index, OptionType.Choice)"
+						@tabbedOut="checkValidOption" />
+				</TransitionGroup>
 			</Draggable>
 		</template>
 
@@ -167,6 +175,9 @@
 		<OptionInputDialog
 			v-model:open="isOptionDialogShown"
 			@multipleAnswers="handleMultipleOptions" />
+		<template #insert>
+			<slot name="insert" />
+		</template>
 	</Question>
 </template>
 
@@ -286,6 +297,16 @@ export default {
 
 			this.errorMessage = null
 			return true
+		},
+
+		onDragStart() {
+			this.isDragging = true
+		},
+
+		onDragEnd() {
+			this.$nextTick(() => {
+				this.isDragging = false
+			})
 		},
 
 		/**

--- a/src/components/Questions/QuestionShort.vue
+++ b/src/components/Questions/QuestionShort.vue
@@ -68,6 +68,9 @@
 				</NcActionInput>
 			</NcActions>
 		</div>
+		<template #insert>
+			<slot name="insert" />
+		</template>
 	</Question>
 </template>
 

--- a/src/views/Create.vue
+++ b/src/views/Create.vue
@@ -116,108 +116,103 @@
 				<!-- Questions list -->
 				<Draggable
 					v-model="form.questions"
-					:animation="200"
-					tag="transition-group"
-					:componentData="{
-						name: isDragging
-							? 'no-external-transition-on-drag'
-							: 'question-list',
-					}"
+					:animation="300"
+					target=".sort-target"
+					direction="vertical"
+					invertSwap
 					handle=".question__drag-handle"
 					@change="onQuestionOrderChange"
-					@start="isDragging = true"
-					@end="isDragging = false">
-					<component
-						:is="answerTypes[question.type].component"
-						v-for="(question, index) in form.questions"
-						:key="question.id"
-						:ref="setQuestionRef"
-						v-bind="form.questions[index]"
-						:canMoveDown="index < form.questions.length - 1"
-						:canMoveUp="index > 0"
-						:answerType="answerTypes[question.type]"
-						:index="index + 1"
-						:maxStringLengths="maxStringLengths"
-						@update:text="(val) => (form.questions[index].text = val)"
-						@update:description="
-							(val) => (form.questions[index].description = val)
-						"
-						@update:isRequired="
-							(val) => (form.questions[index].isRequired = val)
-						"
-						@update:name="(val) => (form.questions[index].name = val)"
-						@update:extraSettings="
-							(val) => (form.questions[index].extraSettings = val)
-						"
-						@update:options="
-							(val) => (form.questions[index].options = val)
-						"
-						@clone="cloneQuestion(question)"
-						@delete="deleteQuestion(question.id)"
-						@moveDown="onMoveDown(index)"
-						@moveUp="onMoveUp(index)" />
+					@start="onDragStart"
+					@end="onDragEnd">
+					<TransitionGroup
+						tag="ul"
+						:name="isDragging ? undefined : 'question-list'"
+						class="sort-target">
+						<component
+							:is="answerTypes[question.type].component"
+							v-for="(question, index) in form.questions"
+							:key="question.id"
+							:ref="(el) => setQuestionRef(el, question)"
+							v-bind="form.questions[index]"
+							:canMoveDown="index < form.questions.length - 1"
+							:canMoveUp="index > 0"
+							:answerType="answerTypes[question.type]"
+							:index="index + 1"
+							:maxStringLengths="maxStringLengths"
+							@update:text="
+								(val) => (form.questions[index].text = val)
+							"
+							@update:description="
+								(val) => (form.questions[index].description = val)
+							"
+							@update:isRequired="
+								(val) => (form.questions[index].isRequired = val)
+							"
+							@update:name="
+								(val) => (form.questions[index].name = val)
+							"
+							@update:extraSettings="
+								(val) => (form.questions[index].extraSettings = val)
+							"
+							@update:options="
+								(val) => (form.questions[index].options = val)
+							"
+							@clone="cloneQuestion(question, index)"
+							@delete="deleteQuestion(question.id)"
+							@moveDown="onMoveDown(index)"
+							@moveUp="onMoveUp(index)">
+							<template
+								v-if="index < form.questions.length - 1"
+								#insert>
+								<div
+									class="question-insert"
+									:class="[
+										{
+											'is-open':
+												insertMenuOpenedIndex === index,
+										},
+										{
+											'is-mobile': isMobile,
+										},
+									]">
+									<AddQuestionMenu
+										:menuName="t('forms', 'Insert question')"
+										:aria-label="
+											t(
+												'forms',
+												'Insert question after question {index}',
+												{ index: index + 1 },
+											)
+										"
+										variant="tertiary"
+										:position="index"
+										:isLoadingQuestions="isLoadingQuestions"
+										:answerTypesFilter="answerTypesFilter"
+										:hasSubtypes="hasSubtypes"
+										@update:open="
+											(v) =>
+												(insertMenuOpenedIndex = v
+													? index
+													: null)
+										"
+										@addQuestion="addQuestion" />
+								</div>
+							</template>
+						</component>
+					</TransitionGroup>
 				</Draggable>
 
 				<!-- Add new questions menu -->
 				<div class="question-menu">
-					<NcActions
+					<AddQuestionMenu
 						v-model:open="questionMenuOpened"
 						:menuName="t('forms', 'Add a question')"
 						:aria-label="t('forms', 'Add a question')"
-						primary>
-						<template #icon>
-							<NcLoadingIcon v-if="isLoadingQuestions" :size="20" />
-							<NcIconSvgWrapper v-else :svg="IconPlus" />
-						</template>
-
-						<template v-if="!activeQuestionType">
-							<NcActionButton
-								v-for="(answer, type) in answerTypesFilter"
-								:key="answer.label"
-								:closeAfterClick="!hasSubtypes(answer)"
-								:disabled="isLoadingQuestions"
-								:isMenu="hasSubtypes(answer)"
-								class="question-menu__question"
-								@click="
-									hasSubtypes(answer)
-										? (activeQuestionType = type)
-										: addQuestion(type)
-								">
-								<template #icon>
-									<NcIconSvgWrapper :svg="answer.icon" />
-								</template>
-								{{ answer.label }}
-							</NcActionButton>
-						</template>
-
-						<template v-else>
-							<NcActionButton
-								:disabled="isLoadingQuestions"
-								class="question-menu__question"
-								@click="activeQuestionType = null">
-								<template #icon>
-									<NcIconSvgWrapper :svg="IconChevronLeft" />
-								</template>
-								{{ t('forms', 'Grid') }}
-							</NcActionButton>
-							<NcActionSeparator />
-
-							<NcActionButton
-								v-for="(answer, type) in answerTypesFilter[
-									activeQuestionType
-								].subtypes"
-								:key="'subtype-' + answer.label"
-								closeAfterClick
-								:disabled="isLoadingQuestions"
-								class="question-menu__question"
-								@click="addQuestion(activeQuestionType, type)">
-								<template #icon>
-									<NcIconSvgWrapper :svg="answer.icon" />
-								</template>
-								{{ answer.label }}
-							</NcActionButton>
-						</template>
-					</NcActions>
+						:isLoadingQuestions="isLoadingQuestions"
+						:answerTypesFilter="answerTypesFilter"
+						:hasSubtypes="hasSubtypes"
+						primary
+						@addQuestion="addQuestion" />
 				</div>
 			</section>
 		</template>
@@ -225,8 +220,6 @@
 </template>
 
 <script>
-import IconPlus from '@material-symbols/svg-400/outlined/add.svg?raw'
-import IconChevronLeft from '@material-symbols/svg-400/outlined/chevron_left.svg?raw'
 import IconLock from '@material-symbols/svg-400/outlined/lock.svg?raw'
 import axios from '@nextcloud/axios'
 import { showError } from '@nextcloud/dialogs'
@@ -234,16 +227,15 @@ import { emit } from '@nextcloud/event-bus'
 import { loadState } from '@nextcloud/initial-state'
 import moment from '@nextcloud/moment'
 import { generateOcsUrl } from '@nextcloud/router'
+import { useIsMobile } from '@nextcloud/vue'
 import debounce from 'debounce'
 import { VueDraggable as Draggable } from 'vue-draggable-plus'
-import NcActionButton from '@nextcloud/vue/components/NcActionButton'
-import NcActions from '@nextcloud/vue/components/NcActions'
-import NcActionSeparator from '@nextcloud/vue/components/NcActionSeparator'
 import NcAppContent from '@nextcloud/vue/components/NcAppContent'
 import NcEmptyContent from '@nextcloud/vue/components/NcEmptyContent'
 import NcIconSvgWrapper from '@nextcloud/vue/components/NcIconSvgWrapper'
 import NcLoadingIcon from '@nextcloud/vue/components/NcLoadingIcon'
 import NcNoteCard from '@nextcloud/vue/components/NcNoteCard'
+import AddQuestionMenu from '../components/AddQuestionMenu.vue'
 import Question from '../components/Questions/Question.vue'
 import QuestionLong from '../components/Questions/QuestionLong.vue'
 import QuestionMultiple from '../components/Questions/QuestionMultiple.vue'
@@ -264,9 +256,7 @@ export default {
 	components: {
 		Draggable,
 		NcIconSvgWrapper,
-		NcActionButton,
-		NcActionSeparator,
-		NcActions,
+		AddQuestionMenu,
 		NcAppContent,
 		NcEmptyContent,
 		NcLoadingIcon,
@@ -282,9 +272,8 @@ export default {
 
 	setup() {
 		return {
-			IconChevronLeft,
 			IconLock,
-			IconPlus,
+			isMobile: useIsMobile(),
 		}
 	},
 
@@ -299,7 +288,12 @@ export default {
 			maxStringLengths: loadState('forms', 'maxStringLengths'),
 			questionMenuOpened: false,
 			activeQuestionType: null,
-			questionRefs: [],
+			questionRefsMap: {},
+
+			// when set to a number, the next created question will be inserted at this index
+			insertMenuOpenedIndex: null,
+			// controls per-question insert menu visibility
+			insertMenuOpened: false,
 		}
 	},
 
@@ -395,19 +389,27 @@ export default {
 		},
 	},
 
-	beforeUpdate() {
-		this.questionRefs = []
-	},
-
 	mounted() {
 		this.fetchFullForm(this.form.id)
 		SetWindowTitle(this.formTitle)
 	},
 
 	methods: {
-		setQuestionRef(el) {
+		onDragStart() {
+			this.isDragging = true
+		},
+
+		onDragEnd() {
+			this.$nextTick(() => {
+				this.isDragging = false
+			})
+		},
+
+		setQuestionRef(el, question) {
 			if (el) {
-				this.questionRefs.push(el)
+				this.questionRefsMap[question.id] = el
+			} else {
+				delete this.questionRefsMap[question.id]
 			}
 		},
 
@@ -485,41 +487,30 @@ export default {
 		 *
 		 * @param {string} type the question type, see AnswerTypes
 		 * @param {string|null} subtype the question subtype, see AnswerTypes.subtypes
+		 * @param {number|null} position where the new question should be added
 		 */
-		async addQuestion(type, subtype = null) {
+		async addQuestion(type, subtype = null, position = null) {
 			this.activeQuestionType = null
 			const text = ''
 			this.isLoadingQuestions = true
 
 			try {
+				const body = { type, text, subtype }
+				if (position !== null) {
+					// position: current question position + 2 (0-based index: +1, next position: +1)
+					body.position = position + 2
+				}
+
 				const response = await axios.post(
 					generateOcsUrl('apps/forms/api/v3/forms/{id}/questions', {
 						id: this.form.id,
 					}),
-					{
-						type,
-						text,
-						subtype,
-					},
+					body,
 				)
 				const question = OcsResponse2Data(response)
 
-				// Add newly created question
-				this.form.questions.push({
-					text,
-					type,
-					answers: [],
-					...question,
-				})
-
-				// Focus newly added question
-				this.$nextTick(() => {
-					const lastQuestion =
-						this.questionRefs[this.questionRefs.length - 1]
-					lastQuestion?.focus()
-				})
-
-				emit('forms:last-updated:set', this.form.id)
+				// Delegate insertion & focus handling to helper
+				this.insertQuestion(question, { text, type, answers: [] }, position)
 			} catch (error) {
 				logger.error('Error while adding new question', { error })
 				showError(
@@ -565,36 +556,68 @@ export default {
 			}
 		},
 
+		insertQuestion(questionData, defaultFields = {}, position = null) {
+			const newQuestionObj = {
+				...defaultFields,
+				...questionData,
+			}
+
+			let insertAt = null
+			if (
+				questionData
+				&& questionData.order !== undefined
+				&& questionData.order !== null
+			) {
+				insertAt = Number(questionData.order) - 1
+			} else if (position !== null) {
+				insertAt = position
+			}
+
+			if (insertAt !== null && insertAt <= this.form.questions.length) {
+				this.form.questions.splice(insertAt, 0, newQuestionObj)
+				this.$nextTick(() => {
+					// Prefer ref by id when available, fallback to positional refs
+					this.questionRefsMap[newQuestionObj.id]?.focus()
+				})
+			} else {
+				this.form.questions.push(newQuestionObj)
+				this.$nextTick(() => {
+					this.questionRefsMap[newQuestionObj.id]?.focus()
+				})
+			}
+
+			emit('forms:last-updated:set', this.form.id)
+		},
+
 		/**
 		 * Clone a question
 		 *
 		 * @param {number} id the question id to clone in the current form
+		 * @param {number} position where the cloned question should be added
 		 */
-		async cloneQuestion({ id }) {
+		async cloneQuestion({ id }, position) {
 			this.isLoadingQuestions = true
 
 			try {
-				const response = await axios.post(
-					generateOcsUrl(
-						'apps/forms/api/v3/forms/{id}/questions?fromId={questionId}',
-						{
-							id: this.form.id,
-							questionId: id,
-						},
-					),
+				const url = generateOcsUrl(
+					'apps/forms/api/v3/forms/{id}/questions?fromId={questionId}',
+					{
+						id: this.form.id,
+						questionId: id,
+					},
 				)
+
+				const body = {}
+				if (position !== null) {
+					// position: current question position + 2 (0-based index: +1, next position: +1)
+					body.position = position + 2
+				}
+
+				const response = await axios.post(url, body)
 				const question = OcsResponse2Data(response)
 
-				this.form.questions.push({
-					answers: [],
-					...question,
-				})
-
-				this.$nextTick(() => {
-					const lastQuestion =
-						this.questionRefs[this.questionRefs.length - 1]
-					lastQuestion?.focus()
-				})
+				// Delegate insertion & focus handling to helper
+				this.insertQuestion(question, { answers: [] })
 			} catch (error) {
 				logger.error(`Error while duplicating question ${id}`, {
 					error,
@@ -632,12 +655,6 @@ export default {
 	},
 }
 </script>
-
-<style lang="scss">
-.question-list-move {
-	transition: all 0.2s ease;
-}
-</style>
 
 <style lang="scss" scoped>
 .emptycontent {
@@ -736,5 +753,46 @@ export default {
 			margin-inline-start: var(--default-clickable-area);
 		}
 	}
+}
+
+.question-list-move,
+.question-list-enter-active,
+.question-list-leave-active {
+	transition: all var(--animation-slow) ease;
+}
+
+.question-list-enter-from,
+.question-list-leave-to {
+	opacity: 0;
+	transform: translateX(var(--clickable-area-large));
+}
+
+/* ensure leaving items are taken out of layout flow so that moving
+   animations can be calculated correctly. */
+.question-list-leave-active {
+	position: absolute;
+}
+
+.question-insert {
+	/* closer to the question above */
+	position: relative;
+	margin-block-end: -34px;
+	inset-block-end: -16px;
+	margin-inline-start: -12px;
+	width: calc(100% - var(--default-clickable-area));
+	display: flex;
+	justify-content: center;
+	opacity: 0;
+	transition: opacity 0.12s ease;
+}
+
+.question-insert.is-mobile {
+	opacity: 0.3;
+}
+
+.question:hover > .question-insert,
+.question-insert:focus-within,
+.question-insert.is-open {
+	opacity: 1;
 }
 </style>


### PR DESCRIPTION
This closes #2873 by adding a new NcActions menu between existing questions. You can then choose to insert a new question or copy the question above. The menu is visually hidden and only shown when your focusing the question above. It's accessible with the keyboard, too.

Inserting a new question re-uses the existing menu for adding new questions.

https://github.com/user-attachments/assets/2ea1de97-67d1-4ba9-9ab4-51d4aba8d3b5

Mobile view (button in 0.3 opacity as no hover available):

<img width="400" height="490" alt="image" src="https://github.com/user-attachments/assets/acca20f6-1f5d-40f4-88de-df702dbc3277" />
