### PR TITLE
Re-check result permission in submission export

### DIFF
--- a/lib/Controller/ApiController.php
+++ b/lib/Controller/ApiController.php
@@ -1613,6 +1613,14 @@ class ApiController extends OCSController {
 	#[ApiRoute(verb: 'POST', url: '/api/v3/forms/{formId}/submissions/export')]
 	public function exportSubmissionsToCloud(int $formId, string $path, string $fileFormat = Constants::DEFAULT_FILE_FORMAT) {
 		$form = $this->formsService->getFormIfAllowed($formId, Constants::PERMISSION_RESULTS);
+
+		// canSeeResults() (used by getFormIfAllowed) also accepts submitters;
+		// exporting every submission needs the strict PERMISSION_RESULTS grant.
+		$permissions = $this->formsService->getPermissions($form);
+		if (!in_array(Constants::PERMISSION_RESULTS, $permissions, true)) {
+			throw new OCSForbiddenException('The current user has no permission to get the results for this form');
+		}
+
 		$file = $this->submissionService->writeFileToCloud($form, $path, $fileFormat);
 
 		return new DataResponse($file->getName());

--- a/tests/Unit/Controller/ApiControllerTest.php
+++ b/tests/Unit/Controller/ApiControllerTest.php
@@ -465,6 +465,28 @@ class ApiControllerTest extends TestCase {
 		$this->apiController->exportSubmissionsToCloud(1, '');
 	}
 
+	public function testExportSubmissionsToCloud_noExportPermissions() {
+		$form = new Form();
+		$form->setId(1);
+		$form->setOwnerId('someoneElse');
+
+		$this->formsService->expects($this->once())
+			->method('getFormIfAllowed')
+			->with(1, Constants::PERMISSION_RESULTS)
+			->willReturn($form);
+
+		$this->formsService->expects($this->once())
+			->method('getPermissions')
+			->with($form)
+			->willReturn([Constants::PERMISSION_SUBMIT]);
+
+		$this->submissionService->expects($this->never())
+			->method('writeFileToCloud');
+
+		$this->expectException(OCSForbiddenException::class);
+		$this->apiController->exportSubmissionsToCloud(1, '/', 'csv');
+	}
+
 	public function testCreateNewForm_notAllowed() {
 		$this->configService->expects($this->once())
 			->method('canCreateForms')


### PR DESCRIPTION
## Summary

- Add explicit `PERMISSION_RESULTS` share-level check to `exportSubmissionsToCloud`
- `getFormIfAllowed(PERMISSION_RESULTS)` uses the relaxed `canSeeResults()` gate which also accepts submitters; the export endpoint needs the same strict recheck `getSubmissions` and `getSubmission` already do (added in nextcloud/forms#3128)

