### PR TITLE
fix: cast allowComments to boolean

### DIFF
--- a/lib/Db/Form.php
+++ b/lib/Db/Form.php
@@ -215,7 +215,7 @@ class Form extends Entity {
 			'confirmationEmailSubject' => $this->getConfirmationEmailSubject(),
 			'confirmationEmailBody' => $this->getConfirmationEmailBody(),
 			'confirmationEmailQuestionId' => $this->getConfirmationEmailQuestionId(),
-			'allowComments' => $this->getAllowComments(),
+			'allowComments' => (bool)$this->getAllowComments(),
 		];
 	}
 }


### PR DESCRIPTION
This fixes an issue that Forms crashes on loading a newly created form. The db value for `allowComments` wasn't casted to `(bool)` and so it provided `null` as initial value. This couldn't be used as `modelValue` for the `NcCheckboxRadioSwitch` in the settings sidebar.

Signed-off-by: Christian Hartmann <chris-hartmann@gmx.de>