### PR TITLE
confirmation mail: preserve line breaks

### DIFF
--- a/lib/BackgroundJob/SendConfirmationMailJob.php
+++ b/lib/BackgroundJob/SendConfirmationMailJob.php
@@ -31,7 +31,9 @@ class SendConfirmationMailJob extends QueuedJob {
 	public function run($argument): void {
 		$recipient = $argument['recipient'];
 		$subject = $argument['subject'];
-		$body = $argument['body'];
+		$plainBody = $argument['body'];
+		#Escape html and add html line breaks
+		$htmlBody = nl2br(htmlspecialchars($plainBody));
 		$formId = $argument['formId'];
 		$submissionId = $argument['submissionId'];
 
@@ -40,7 +42,7 @@ class SendConfirmationMailJob extends QueuedJob {
 			$emailTemplate->setSubject($subject);
 			$emailTemplate->addHeader();
 			$emailTemplate->addHeading($subject);
-			$emailTemplate->addBodyText($body);
+			$emailTemplate->addBodyText($htmlBody, $plainBody);
 			$emailTemplate->addFooter();
 
 			$message = $this->mailer->createMessage();


### PR DESCRIPTION
Preserve line breaks in confirmations mails. Because addBodyText would escape the `<br />`-tags we need to deliver seperate html and plaintext bodys

Issue: [@3389](https://github.com/nextcloud/forms/issues/3389)


## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
- [x] The content of this PR was proudly created by human mind 
