### PR TITLE
fix: save question reorder on drop instead of during drag

### DIFF
--- a/src/components/Questions/QuestionDropdown.vue
+++ b/src/components/Questions/QuestionDropdown.vue
@@ -55,7 +55,7 @@
 				handle=".option__drag-handle"
 				invertSwap
 				target=".sort-target"
-				@change="saveOptionsOrder('choice')"
+				@update="saveOptionsOrder('choice')"
 				@start="onDragStart"
 				@end="onDragEnd">
 				<TransitionGroup

--- a/src/components/Questions/QuestionDropdown.vue
+++ b/src/components/Questions/QuestionDropdown.vue
@@ -55,7 +55,7 @@
 				handle=".option__drag-handle"
 				invertSwap
 				target=".sort-target"
-				@update="saveOptionsOrder('choice')"
+				@update="dirtyOptionsType = 'choice'"
 				@start="onDragStart"
 				@end="onDragEnd">
 				<TransitionGroup

--- a/src/components/Questions/QuestionGrid.vue
+++ b/src/components/Questions/QuestionGrid.vue
@@ -101,7 +101,7 @@
 					handle=".option__drag-handle"
 					invertSwap
 					target=".sort-target"
-					@update="saveOptionsOrder('column')"
+					@update="dirtyOptionsType = 'column'"
 					@start="onDragStart"
 					@end="onDragEnd">
 					<!-- Column input edit -->
@@ -139,7 +139,7 @@
 					handle=".option__drag-handle"
 					invertSwap
 					target=".sort-target"
-					@update="saveOptionsOrder('row')"
+					@update="dirtyOptionsType = 'row'"
 					@start="onDragStart"
 					@end="onDragEnd">
 					<TransitionGroup

--- a/src/components/Questions/QuestionGrid.vue
+++ b/src/components/Questions/QuestionGrid.vue
@@ -101,7 +101,7 @@
 					handle=".option__drag-handle"
 					invertSwap
 					target=".sort-target"
-					@change="saveOptionsOrder('column')"
+					@update="saveOptionsOrder('column')"
 					@start="onDragStart"
 					@end="onDragEnd">
 					<!-- Column input edit -->
@@ -139,7 +139,7 @@
 					handle=".option__drag-handle"
 					invertSwap
 					target=".sort-target"
-					@change="saveOptionsOrder('row')"
+					@update="saveOptionsOrder('row')"
 					@start="onDragStart"
 					@end="onDragEnd">
 					<TransitionGroup

--- a/src/components/Questions/QuestionMultiple.vue
+++ b/src/components/Questions/QuestionMultiple.vue
@@ -126,7 +126,7 @@
 				handle=".option__drag-handle"
 				invertSwap
 				target=".sort-target"
-				@change="saveOptionsOrder('choice')"
+				@update="saveOptionsOrder('choice')"
 				@start="onDragStart"
 				@end="onDragEnd">
 				<TransitionGroup

--- a/src/components/Questions/QuestionMultiple.vue
+++ b/src/components/Questions/QuestionMultiple.vue
@@ -126,7 +126,7 @@
 				handle=".option__drag-handle"
 				invertSwap
 				target=".sort-target"
-				@update="saveOptionsOrder('choice')"
+				@update="dirtyOptionsType = 'choice'"
 				@start="onDragStart"
 				@end="onDragEnd">
 				<TransitionGroup

--- a/src/components/Questions/QuestionRanking.vue
+++ b/src/components/Questions/QuestionRanking.vue
@@ -141,7 +141,7 @@
 				handle=".option__drag-handle"
 				invertSwap
 				target=".sort-target"
-				@change="saveOptionsOrder('choice')"
+				@update="saveOptionsOrder('choice')"
 				@start="onDragStart"
 				@end="onDragEnd">
 				<TransitionGroup

--- a/src/components/Questions/QuestionRanking.vue
+++ b/src/components/Questions/QuestionRanking.vue
@@ -141,7 +141,7 @@
 				handle=".option__drag-handle"
 				invertSwap
 				target=".sort-target"
-				@update="saveOptionsOrder('choice')"
+				@update="dirtyOptionsType = 'choice'"
 				@start="onDragStart"
 				@end="onDragEnd">
 				<TransitionGroup

--- a/src/views/Create.vue
+++ b/src/views/Create.vue
@@ -121,7 +121,7 @@
 					direction="vertical"
 					invertSwap
 					handle=".question__drag-handle"
-					@change="onQuestionOrderChange"
+					@update="onQuestionOrderChange"
 					@start="onDragStart"
 					@end="onDragEnd">
 					<TransitionGroup


### PR DESCRIPTION
## Summary

Drag-and-drop reordering saved the wrong order to the backend, so reloading reverted to the old order. Two related causes:

1. **Questions and options** saved on the draggable's `change` event, which fires repeatedly *during* the drag (before the new order is committed) instead of once on release. Switched to `update`, which fires once on drop.
2. **Options** needed an extra fix: `saveOptionsOrder` reads the order from the `options` prop, which only updates after the reordered array round-trips through the parent. Saving synchronously on drop still read the stale order. The drag now sets the existing `dirtyOptionsType` flag so the debounced watcher saves once the new order has settled, the same path the move up/down buttons already use.

## Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [ ] Tests (unit, integration, api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation (manuals or wiki) has been updated or is not required
- [ ] Backports requested where applicable (ex: critical bugfixes)
- [ ] Labels added where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] Milestone added for target branch/version (ex: 32.x for `stable32`)
