### PR TITLE
refactor: remove duplicate computed prop from Ranking

### DIFF
--- a/src/components/Questions/QuestionRanking.vue
+++ b/src/components/Questions/QuestionRanking.vue
@@ -255,10 +255,6 @@ export default {
 	},
 
 	computed: {
-		contentValid() {
-			return this.answerType.validate(this)
-		},
-
 		shiftDragHandle() {
 			return !this.readOnly && this.options.length !== 0 && !this.isLastEmpty
 		},


### PR DESCRIPTION
This removes contentValid() from QuestionRanking. It's already defined in QuestionMultipleMixin: https://github.com/nextcloud/forms/blob/5612eefdfa4b7db4bd54f957576f00d0e13ff2fd/src/mixins/QuestionMultipleMixin.ts#L32-L34