### PR TITLE
fix: handle undefined optionsLimitMin in multiple choice questions

### DIFF
--- a/lib/Service/FormsService.php
+++ b/lib/Service/FormsService.php
@@ -131,7 +131,7 @@ class FormsService {
 				}
 
 				// Set `isRequired` if minimum options limit is set
-				if ($question['type'] === Constants::ANSWER_TYPE_MULTIPLE && $question['extraSettings']['optionsLimitMin'] > 0) {
+				if ($question['type'] === Constants::ANSWER_TYPE_MULTIPLE && ($question['extraSettings']['optionsLimitMin'] ?? 0) > 0) {
 					$question['isRequired'] = true;
 				}
 


### PR DESCRIPTION
This fixes #3489 by checking if the array key `optionsLimitMin` exists, otherwise we fall back to `0`