### PR TITLE
fix: remove invalid characters constant and use filename validator for sanitization

### DIFF
--- a/lib/Constants.php
+++ b/lib/Constants.php
@@ -229,19 +229,6 @@ class Constants {
 		self::ANSWER_GRID_TYPE_RADIO,
 	];
 
-	public const FILENAME_INVALID_CHARS = [
-		"\n",
-		'/',
-		'\\',
-		':',
-		'*',
-		'?',
-		'"',
-		'<',
-		'>',
-		'|',
-	];
-
 	/**
 	 * !! Keep in sync with src/mixins/ShareTypes.js !!
 	 */

--- a/lib/Helper/FilePathHelper.php
+++ b/lib/Helper/FilePathHelper.php
@@ -10,12 +10,14 @@ namespace OCA\Forms\Helper;
 use OCA\Forms\Constants;
 use OCA\Forms\Db\Form;
 use OCP\Files\Folder;
+use OCP\Files\IFilenameValidator;
 use OCP\Files\IRootFolder;
 use OCP\Files\NotFoundException;
 
 class FilePathHelper {
 	public function __construct(
 		private readonly IRootFolder $rootFolder,
+		private readonly IFilenameValidator $fileNameValidator,
 	) {
 	}
 
@@ -23,7 +25,7 @@ class FilePathHelper {
 	 * Normalize a filename by replacing invalid characters
 	 */
 	public function normalizeFileName(string $fileName): string {
-		return trim(str_replace(Constants::FILENAME_INVALID_CHARS, '-', $fileName));
+		return $this->fileNameValidator->sanitizeFilename($fileName, '-');
 	}
 
 	/**

--- a/tests/Unit/Controller/ShareApiControllerTest.php
+++ b/tests/Unit/Controller/ShareApiControllerTest.php
@@ -29,6 +29,7 @@ use OCP\AppFramework\OCS\OCSForbiddenException;
 use OCP\AppFramework\OCS\OCSNotFoundException;
 use OCP\Files\File;
 use OCP\Files\Folder;
+use OCP\Files\IFilenameValidator;
 use OCP\Files\IRootFolder;
 use OCP\IGroup;
 use OCP\IGroupManager;
@@ -61,6 +62,7 @@ class ShareApiControllerTest extends TestCase {
 	private CirclesService|MockObject $circlesService;
 	private FilePathHelper $filePathHelper;
 	private IRootFolder|MockObject $rootFolder;
+	private IFilenameValidator|MockObject $filenameValidator;
 	private IManager|MockObject $shareManager;
 
 	public function setUp(): void {
@@ -76,7 +78,10 @@ class ShareApiControllerTest extends TestCase {
 		$this->circlesService = $this->createMock(CirclesService::class);
 
 		$this->rootFolder = $this->createMock(IRootFolder::class);
-		$this->filePathHelper = new FilePathHelper($this->rootFolder);
+		$this->filenameValidator = $this->createMock(IFilenameValidator::class);
+		$this->filenameValidator->method('sanitizeFilename')
+			->willReturnCallback(static fn (string $fileName, string $replacement): string => str_replace(['/', '\\'], $replacement, trim($fileName)));
+		$this->filePathHelper = new FilePathHelper($this->rootFolder, $this->filenameValidator);
 		$this->shareManager = $this->createMock(IManager::class);
 
 		$this->shareApiController = new ShareApiController(

--- a/tests/Unit/Helper/FilePathHelperTest.php
+++ b/tests/Unit/Helper/FilePathHelperTest.php
@@ -11,6 +11,7 @@ use OCA\Forms\Constants;
 use OCA\Forms\Db\Form;
 use OCA\Forms\Helper\FilePathHelper;
 use OCP\Files\Folder;
+use OCP\Files\IFilenameValidator;
 use OCP\Files\IRootFolder;
 use OCP\Files\NotFoundException;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -18,12 +19,16 @@ use Test\TestCase;
 
 class FilePathHelperTest extends TestCase {
 	private FilePathHelper $filePathHelper;
+	private IFilenameValidator|MockObject $filenameValidator;
 	private IRootFolder|MockObject $rootFolder;
 
 	public function setUp(): void {
 		parent::setUp();
 		$this->rootFolder = $this->createMock(IRootFolder::class);
-		$this->filePathHelper = new FilePathHelper($this->rootFolder);
+		$this->filenameValidator = $this->createMock(IFilenameValidator::class);
+		$this->filenameValidator->method('sanitizeFilename')
+			->willReturnCallback(static fn (string $fileName, string $replacement): string => str_replace(['/', '\\'], $replacement, trim($fileName)));
+		$this->filePathHelper = new FilePathHelper($this->rootFolder, $this->filenameValidator);
 	}
 
 	public function testNormalizeFileName() {

--- a/tests/Unit/Service/FormsServiceTest.php
+++ b/tests/Unit/Service/FormsServiceTest.php
@@ -49,6 +49,7 @@ use OCA\Forms\Service\FormsService;
 use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\Files\Folder;
+use OCP\Files\IFilenameValidator;
 use OCP\Files\IRootFolder;
 use OCP\Files\NotFoundException;
 use OCP\IGroup;
@@ -80,6 +81,7 @@ class FormsServiceTest extends TestCase {
 	private CirclesService|MockObject $circlesService;
 	private FilePathHelper|MockObject $filePathHelper;
 	private IRootFolder|MockObject $rootFolder;
+	private IFilenameValidator|MockObject $filenameValidator;
 	private IL10N|MockObject $l10n;
 	private LoggerInterface|MockObject $logger;
 
@@ -112,7 +114,10 @@ class FormsServiceTest extends TestCase {
 			->willReturn($user);
 
 		$this->rootFolder = $this->createMock(IRootFolder::class);
-		$this->filePathHelper = new FilePathHelper($this->rootFolder);
+		$this->filenameValidator = $this->createMock(IFilenameValidator::class);
+		$this->filenameValidator->method('sanitizeFilename')
+			->willReturnCallback(static fn (string $fileName, string $replacement): string => str_replace(['/', '\\', "\n"], $replacement, trim($fileName)));
+		$this->filePathHelper = new FilePathHelper($this->rootFolder, $this->filenameValidator);
 
 		$this->l10n = $this->createMock(IL10N::class);
 		$this->l10n->expects($this->any())


### PR DESCRIPTION
This fixes #3458. Now that we're at min version 32, we can use `sanitizeFilename()` from `OCP\Files\IFilenameValidator` to cleanup the names of uploaded files.