### PR TITLE
fix(api): correct misleading error message on empty keyValuePairs

### DIFF
--- a/lib/Controller/ApiController.php
+++ b/lib/Controller/ApiController.php
@@ -675,7 +675,7 @@ class ApiController extends OCSController {
 		// Don't allow empty array
 		if (count($keyValuePairs) === 0) {
 			$this->logger->info('Empty keyValuePairs, will not update.');
-			throw new OCSBadRequestException('This form is archived and can not be modified');
+			throw new OCSBadRequestException('Empty keyValuePairs, will not update.');
 		}
 
 		//Don't allow to change id or formId


### PR DESCRIPTION
### The problem

`ApiController::updateQuestion()` rejects an empty `keyValuePairs` array with:

> This form is archived and can not be modified

The form is not archived. The message has nothing to do with the actual cause, which sends callers looking in the wrong place.

### Reproduction

Against Nextcloud 32.0.9 / Forms 5.3.3, on a form that is **not** archived:

```
PATCH /ocs/v2.php/apps/forms/api/v3/forms/{formId}/questions/{questionId}
Content-Type: application/json

{"keyValuePairs":{}}
```

```
400 | This form is archived and can not be modified
```

### Why this looks like a copy-paste leftover

- The `logger->info()` call on the line directly above already says `Empty keyValuePairs, will not update.`
- The method's own `@throws` annotation documents this case as `Empty keyValuePairs, will not update`
- The sibling methods `updateForm()` and `updateOption()` both report it accurately
- The string matches the archived-form check ~20 lines further up verbatim

### Scope

Only the message string changes.

There is a related inconsistency I deliberately left alone: the docblock and both sibling methods use `OCSForbiddenException` (403) for this case, while `updateQuestion()` uses `OCSBadRequestException` (400). Aligning them would change the status code for existing clients, and 400 is arguably the more accurate one for an empty payload anyway. Happy to follow up in either direction if you have a preference.

### Context

Found while creating a form through the API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)