### PR TITLE
docs(api): complete truncated questionId description

### DIFF
--- a/docs/API_v3.md
+++ b/docs/API_v3.md
@@ -438,7 +438,7 @@ Update a single or multiple properties of a question-object.
   | Parameter | Type | Description |
   |-----------|---------|-------------|
   | _formId_ | Integer | ID of the form to request |
-  | _questionId_ | Integer | Id of the
+  | _questionId_ | Integer | ID of the question to update |
 - Parameters:
   | Parameter | Type | Description |
   |-----------|---------|-------------|


### PR DESCRIPTION
The `_questionId_` row in the "Update question properties" table of `docs/API_v3.md` ends mid-sentence:

```
| _questionId_ | Integer | Id of the
```

The missing trailing pipe also breaks the markdown table rendering for that row.

Completed the sentence and aligned wording and capitalisation with the surrounding tables, which use "ID of the question to delete", "ID of the question to clone" and "ID of the option to update".

🤖 Generated with [Claude Code](https://claude.com/claude-code)