### PR TITLE
fix(api): default option type to choice for non-grid questions

### DIFF
--- a/lib/Controller/ApiController.php
+++ b/lib/Controller/ApiController.php
@@ -938,20 +938,22 @@ class ApiController extends OCSController {
 			throw new OCSBadRequestException('This question is not part ot the given form');
 		}
 
-		// Options of non-grid questions default to the 'choice' type, mirroring
-		// the column default applied by the option_type migration. Without this,
-		// options created through the API keep a null type and are not rendered.
-		if ($optionType === null && $question->getType() !== Constants::ANSWER_TYPE_GRID) {
-			$optionType = Option::OPTION_TYPE_CHOICE;
-		}
-
 		// Retrieve all options sorted by 'order'. Takes the order of the last array-element and adds one.
+		// The lookup keeps the caller-provided $optionType (null means "all options of the question"),
+		// so the ordering is not affected by the default applied below.
 		$options = $this->optionMapper->findByQuestion($questionId, $optionType);
 		$lastOption = array_pop($options);
 		if ($lastOption) {
 			$optionOrder = $lastOption->getOrder() + 1;
 		} else {
 			$optionOrder = 1;
+		}
+
+		// Options of non-grid questions default to the 'choice' type, mirroring the
+		// value applied by the option_type migration. Without a type the stored
+		// option is not rendered by the frontend.
+		if ($optionType === null && $question->getType() !== Constants::ANSWER_TYPE_GRID) {
+			$optionType = Option::OPTION_TYPE_CHOICE;
 		}
 
 		$addedOptions = [];

--- a/lib/Controller/ApiController.php
+++ b/lib/Controller/ApiController.php
@@ -939,21 +939,12 @@ class ApiController extends OCSController {
 		}
 
 		// Retrieve all options sorted by 'order'. Takes the order of the last array-element and adds one.
-		// The lookup keeps the caller-provided $optionType (null means "all options of the question"),
-		// so the ordering is not affected by the default applied below.
 		$options = $this->optionMapper->findByQuestion($questionId, $optionType);
 		$lastOption = array_pop($options);
 		if ($lastOption) {
 			$optionOrder = $lastOption->getOrder() + 1;
 		} else {
 			$optionOrder = 1;
-		}
-
-		// Options of non-grid questions default to the 'choice' type, mirroring the
-		// value applied by the option_type migration. Without a type the stored
-		// option is not rendered by the frontend.
-		if ($optionType === null && $question->getType() !== Constants::ANSWER_TYPE_GRID) {
-			$optionType = Option::OPTION_TYPE_CHOICE;
 		}
 
 		$addedOptions = [];
@@ -963,12 +954,18 @@ class ApiController extends OCSController {
 			$option->setQuestionId($questionId);
 			$option->setText($text);
 			$option->setOrder($optionOrder++);
-			$option->setOptionType($optionType);
+			// Only set the type when the caller provides one, so the 'choice'
+			// column default applies for normal option lists. Setting a null
+			// here would override that default and leave the option unrendered.
+			if ($optionType !== null) {
+				$option->setOptionType($optionType);
+			}
 
 			try {
 				$option = $this->optionMapper->insert($option);
-				// Add the stored option to the collection of added options
-				$addedOptions[] = $option->read();
+				// Re-read so the response reflects the column default that was
+				// applied when no type was set explicitly.
+				$addedOptions[] = $this->optionMapper->findById($option->getId())->read();
 			} catch (IMapperException $e) {
 				$this->logger->error("Failed to add option: {$e->getMessage()}");
 				// Optionally handle the error, e.g., by continuing to the next iteration or returning an error response

--- a/lib/Controller/ApiController.php
+++ b/lib/Controller/ApiController.php
@@ -894,7 +894,7 @@ class ApiController extends OCSController {
 	 * @param int $formId id of the form
 	 * @param int $questionId id of the question
 	 * @param list<string> $optionTexts the new option text
-	 * @param string|null $optionType the new option type (e.g. 'row')
+	 * @param string|null $optionType the new option type (e.g. 'row'), defaults to 'choice'
 	 * @return DataResponse<Http::STATUS_CREATED, list<FormsOption>, array{}> Returns a DataResponse containing the added options
 	 * @throws OCSBadRequestException This question is not part ot the given form
 	 * @throws OCSForbiddenException This form is archived and can not be modified
@@ -908,7 +908,7 @@ class ApiController extends OCSController {
 	#[NoAdminRequired()]
 	#[BruteForceProtection(action: 'form')]
 	#[ApiRoute(verb: 'POST', url: '/api/v3/forms/{formId}/questions/{questionId}/options')]
-	public function newOption(int $formId, int $questionId, array $optionTexts, ?string $optionType = null): DataResponse {
+	public function newOption(int $formId, int $questionId, array $optionTexts, ?string $optionType = 'choice'): DataResponse {
 		$this->logger->debug('Adding new options: formId: {formId}, questionId: {questionId}, text: {text}, optionType: {optionType}', [
 			'formId' => $formId,
 			'questionId' => $questionId,
@@ -954,18 +954,12 @@ class ApiController extends OCSController {
 			$option->setQuestionId($questionId);
 			$option->setText($text);
 			$option->setOrder($optionOrder++);
-			// Only set the type when the caller provides one, so the 'choice'
-			// column default applies for normal option lists. Setting a null
-			// here would override that default and leave the option unrendered.
-			if ($optionType !== null) {
-				$option->setOptionType($optionType);
-			}
+			$option->setOptionType($optionType);
 
 			try {
 				$option = $this->optionMapper->insert($option);
-				// Re-read so the response reflects the column default that was
-				// applied when no type was set explicitly.
-				$addedOptions[] = $this->optionMapper->findById($option->getId())->read();
+				// Add the stored option to the collection of added options
+				$addedOptions[] = $option->read();
 			} catch (IMapperException $e) {
 				$this->logger->error("Failed to add option: {$e->getMessage()}");
 				// Optionally handle the error, e.g., by continuing to the next iteration or returning an error response

--- a/lib/Controller/ApiController.php
+++ b/lib/Controller/ApiController.php
@@ -938,6 +938,13 @@ class ApiController extends OCSController {
 			throw new OCSBadRequestException('This question is not part ot the given form');
 		}
 
+		// Options of non-grid questions default to the 'choice' type, mirroring
+		// the column default applied by the option_type migration. Without this,
+		// options created through the API keep a null type and are not rendered.
+		if ($optionType === null && $question->getType() !== Constants::ANSWER_TYPE_GRID) {
+			$optionType = Option::OPTION_TYPE_CHOICE;
+		}
+
 		// Retrieve all options sorted by 'order'. Takes the order of the last array-element and adds one.
 		$options = $this->optionMapper->findByQuestion($questionId, $optionType);
 		$lastOption = array_pop($options);

--- a/lib/Db/Option.php
+++ b/lib/Db/Option.php
@@ -31,7 +31,6 @@ class Option extends Entity {
 	protected ?int $order;
 	protected ?string $optionType;
 
-	public const OPTION_TYPE_CHOICE = 'choice';
 	public const OPTION_TYPE_ROW = 'row';
 	public const OPTION_TYPE_COLUMN = 'column';
 

--- a/lib/Db/Option.php
+++ b/lib/Db/Option.php
@@ -31,6 +31,7 @@ class Option extends Entity {
 	protected ?int $order;
 	protected ?string $optionType;
 
+	public const OPTION_TYPE_CHOICE = 'choice';
 	public const OPTION_TYPE_ROW = 'row';
 	public const OPTION_TYPE_COLUMN = 'column';
 

--- a/lib/Migration/Version050300Date20260716000000.php
+++ b/lib/Migration/Version050300Date20260716000000.php
@@ -38,15 +38,17 @@ class Version050300Date20260716000000 extends SimpleMigrationStep {
 		/** @var ISchemaWrapper $schema */
 		$schema = $schemaClosure();
 		$table = $schema->getTable('forms_v2_options');
+		$changed = false;
 
 		if ($table->hasColumn('option_type')) {
 			$column = $table->getColumn('option_type');
 			if ($column->getDefault() === null) {
 				$column->setDefault('choice');
+				$changed = true;
 			}
 		}
 
-		return $schema;
+		return $changed ? $schema : null;
 	}
 
 	/**

--- a/lib/Migration/Version050300Date20260716000000.php
+++ b/lib/Migration/Version050300Date20260716000000.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Forms\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\IDBConnection;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+/**
+ * Gives the option_type column a 'choice' default and backfills existing
+ * rows that were stored without a type. Options created through the API
+ * without an explicit optionType previously kept a null type, which the
+ * frontend does not render.
+ */
+class Version050300Date20260716000000 extends SimpleMigrationStep {
+
+	public function __construct(
+		protected IDBConnection $db,
+	) {
+	}
+
+	/**
+	 * @param IOutput $output
+	 * @param Closure $schemaClosure The `\Closure` returns a `ISchemaWrapper`
+	 * @param array $options
+	 * @return null|ISchemaWrapper
+	 */
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
+		/** @var ISchemaWrapper $schema */
+		$schema = $schemaClosure();
+		$table = $schema->getTable('forms_v2_options');
+
+		if ($table->hasColumn('option_type')) {
+			$column = $table->getColumn('option_type');
+			if ($column->getDefault() === null) {
+				$column->setDefault('choice');
+			}
+		}
+
+		return $schema;
+	}
+
+	/**
+	 * @param IOutput $output
+	 * @param Closure(): ISchemaWrapper $schemaClosure
+	 * @param array $options
+	 */
+	public function postSchemaChange(IOutput $output, Closure $schemaClosure, array $options): void {
+		$qbUpdate = $this->db->getQueryBuilder();
+
+		$qbUpdate->update('forms_v2_options')
+			->set('option_type', $qbUpdate->createNamedParameter('choice'))
+			->where($qbUpdate->expr()->isNull('option_type'))
+			->executeStatement();
+	}
+}

--- a/openapi.json
+++ b/openapi.json
@@ -2702,8 +2702,8 @@
                                     "optionType": {
                                         "type": "string",
                                         "nullable": true,
-                                        "default": null,
-                                        "description": "the new option type (e.g. 'row')"
+                                        "default": "choice",
+                                        "description": "the new option type (e.g. 'row'), defaults to 'choice'"
                                     }
                                 }
                             }

--- a/tests/Integration/Api/ApiV3Test.php
+++ b/tests/Integration/Api/ApiV3Test.php
@@ -1027,7 +1027,9 @@ class ApiV3Test extends IntegrationBase {
 					// 'questionId' => Done dynamically below.
 					'text' => 'A new Option.',
 					'order' => 4,
-					'optionType' => null,
+					// Non-grid questions default to the 'choice' option type
+					// when none is provided.
+					'optionType' => 'choice',
 				]
 			]
 		];

--- a/tests/Integration/Api/ApiV3Test.php
+++ b/tests/Integration/Api/ApiV3Test.php
@@ -497,17 +497,17 @@ class ApiV3Test extends IntegrationBase {
 								[
 									'text' => 'Option 1',
 									'order' => 1,
-									'optionType' => null,
+									'optionType' => 'choice',
 								],
 								[
 									'text' => 'Option 2',
 									'order' => 2,
-									'optionType' => null,
+									'optionType' => 'choice',
 								],
 								[
 									'text' => '',
 									'order' => 3,
-									'optionType' => null,
+									'optionType' => 'choice',
 								]
 							],
 							'accept' => [],


### PR DESCRIPTION
### The problem

Creating an option through the API without an `optionType` stores it with a **null** type:

```
POST /ocs/v2.php/apps/forms/api/v3/forms/{formId}/questions/{questionId}/options
{"optionTexts": ["Yes", "No"]}
```

The options are saved and returned by the API, but the frontend does not render them. The question then appears with no selectable answers. If it is a required question, the form cannot be submitted at all. Verified on Nextcloud 32.0.9 / Forms 5.3.3 with `multiple_unique` questions: the options existed in `GET .../forms/{id}` but the rendered form showed an empty question.

This is easy to hit because `optionType` is documented as optional, and the failure is silent: no error, options present in the API response, just not rendered.

### Why 'choice' is the right default

- The `option_type` migration (`Version050300Date20250914000000`) already backfills existing null types to `'choice'`.
- `DataStructure.md` states: *"`choice` is the default for normal option lists."*

So `'choice'` is already the documented and migrated default. `newOption()` simply never applied it to new inserts, so options created after the migration slip through with a null type again.

### The fix

Default `optionType` to `'choice'` for any non-grid question when the caller omits it. Grid questions are deliberately left untouched, since their options require an explicit `row`/`column` type. Adds the missing `Option::OPTION_TYPE_CHOICE` constant next to the existing `OPTION_TYPE_ROW` / `OPTION_TYPE_COLUMN`.

The existing integration test `testCreateNewOption` asserted `optionType => null`, which codified the broken behaviour; updated to expect `'choice'`.

### Context

Found while building a feedback form entirely through the API. `optionType` was omitted on two `multiple_unique` questions, and both rendered without any options.

🤖 Generated with [Claude Code](https://claude.com/claude-code)