### PR TITLE
fix: results route handling in dev mode

### DIFF
--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -117,6 +117,16 @@ class PageController extends Controller {
 	 */
 	#[NoAdminRequired()]
 	#[NoCSRFRequired()]
+	#[FrontpageRoute(verb: 'GET', url: '/{hash}/results/{view}', requirements: ['hash' => '[a-zA-Z0-9]{16,}'])]
+	public function resultsViews(string $hash): TemplateResponse {
+		return $this->index($hash);
+	}
+
+	/**
+	 * @return TemplateResponse
+	 */
+	#[NoAdminRequired()]
+	#[NoCSRFRequired()]
 	#[FrontpageRoute(verb: 'GET', url: '/{hash}/submit/{submissionId}', requirements: ['hash' => '[a-zA-Z0-9]{16,}', 'submissionId' => '\d+'])]
 	public function submitViewWithSubmission(string $hash, int $submissionId): TemplateResponse {
 		$form = $this->formMapper->findByHash($hash);

--- a/playwright/e2e/results-view.spec.ts
+++ b/playwright/e2e/results-view.spec.ts
@@ -51,11 +51,9 @@ test.describe('Results view', () => {
 		await submitView.submit()
 		await expect(submitView.successMessage).toBeVisible()
 
-		// Navigate to Results view via URL — the SPA route transition
-		// from submit → results after submission causes a brief redirect loop,
-		// so we use direct navigation instead of clicking the TopBar.
+		// Navigate to Results view. The router will redirect to the summary tab.
 		await page.goto(page.url().replace(/\/submit.*$/, '/results'))
-		await page.waitForURL(/\/results(?:\?.*)?$/)
+		await page.waitForURL(/\/results\/summary$/)
 	})
 
 	test('Summary tab shows submitted data', async ({ resultsView }) => {
@@ -80,7 +78,7 @@ test.describe('Results view', () => {
 		// Should show the individual submission with the answers
 		await expect(resultsView.responsesTab).toBeChecked()
 		await expect(resultsView.responseCount).toBeVisible()
-		await expect(resultsView.page).toHaveURL(/\/results\?view=responses$/)
+		await expect(resultsView.page).toHaveURL(/\/results\/responses$/)
 	})
 
 	test('Tab switching between Summary and Responses updates the URL', async ({
@@ -88,68 +86,30 @@ test.describe('Results view', () => {
 	}) => {
 		// Start on Summary
 		await expect(resultsView.summaryTab).toBeChecked()
-		await expect(resultsView.page).toHaveURL(/\/results\?view=summary$/)
+		await expect(resultsView.page).toHaveURL(/\/results\/summary$/)
 
 		// Switch to Responses
 		await resultsView.switchToResponses()
 		await expect(resultsView.responsesTab).toBeChecked()
 		await expect(resultsView.summaryTab).not.toBeChecked()
-		await expect(resultsView.page).toHaveURL(/\/results\?view=responses$/)
+		await expect(resultsView.page).toHaveURL(/\/results\/responses$/)
 
 		// Switch back to Summary
 		await resultsView.switchToSummary()
 		await expect(resultsView.summaryTab).toBeChecked()
 		await expect(resultsView.responsesTab).not.toBeChecked()
-		await expect(resultsView.page).toHaveURL(/\/results\?view=summary$/)
+		await expect(resultsView.page).toHaveURL(/\/results\/summary$/)
 	})
 
-	test('Explicit query route wins over remembered localStorage view', async ({
-		page,
-		resultsView,
-	}) => {
-		await page.evaluate(() => {
-			const match = window.location.pathname.match(
-				/\/apps\/forms\/([^/]+)\/results$/,
-			)
-			if (!match) {
-				throw new Error('Expected results route before setting localStorage')
-			}
+	test('Navigating to /results redirects to /results/summary', async ({ page }) => {
+		// Start on the responses tab
+		await page.goto(page.url().replace(/\/summary$/, '/responses'))
+		await page.waitForURL(/\/results\/responses$/)
 
-			localStorage.setItem(
-				`nextcloud_forms_${match[1]}_activeResponseView`,
-				'responses',
-			)
-		})
-
-		await page.goto(page.url().replace(/\/results.*$/, '/results?view=summary'))
-		await page.waitForURL(/\/results\?view=summary$/)
-
-		await expect(resultsView.summaryTab).toBeChecked()
-		await expect(resultsView.responsesTab).not.toBeChecked()
-	})
-
-	test('Query-less results route restores the remembered localStorage view', async ({
-		page,
-		resultsView,
-	}) => {
-		await page.evaluate(() => {
-			const match = window.location.pathname.match(
-				/\/apps\/forms\/([^/]+)\/results$/,
-			)
-			if (!match) {
-				throw new Error('Expected results route before setting localStorage')
-			}
-
-			localStorage.setItem(
-				`nextcloud_forms_${match[1]}_activeResponseView`,
-				'responses',
-			)
-		})
-
-		await page.goto(page.url().replace(/\/results.*$/, '/results'))
-		await page.waitForURL(/\/results\?view=responses$/)
-
-		await expect(resultsView.responsesTab).toBeChecked()
-		await expect(resultsView.summaryTab).not.toBeChecked()
+		// Navigate to the parent results route
+		await page.goto(page.url().replace(/\/responses$/, ''))
+		await page.waitForURL(/\/results\/summary$/)
+		await expect(page).toHaveURL(/\/results\/summary$/)
 	})
 })
+

--- a/src/Forms.vue
+++ b/src/Forms.vue
@@ -238,9 +238,10 @@ export default {
 				return false
 			}
 
-			if (route.name === 'results') {
+			const resultRoutes = ['results', 'results.summary', 'results.responses']
+			if (resultRoutes.includes(route.name)) {
 				return (
-					form.permissions.includes(route.name) || form.submissionCount > 0
+					form.permissions.includes('results') || form.submissionCount > 0
 				)
 			}
 

--- a/src/components/TopBar.vue
+++ b/src/components/TopBar.vue
@@ -115,7 +115,11 @@ export default {
 
 	computed: {
 		currentView() {
-			return this.availableViews.filter((v) => v.id === this.$route.name)[0]
+			return this.availableViews.find(
+				(v) =>
+					this.$route.name === v.id
+					|| this.$route.name.startsWith(v.id + '.'),
+			)
 		},
 
 		availableViews() {

--- a/src/router.ts
+++ b/src/router.ts
@@ -33,9 +33,37 @@ const routes = [
 	},
 	{
 		path: '/:hash/results',
-		components: { default: Results },
-		name: 'results',
 		props: { default: true },
+		children: [
+			{
+				path: '',
+				name: 'results',
+				redirect: (to) => {
+					const validViews = ['summary', 'responses']
+					const storedView = localStorage.getItem(
+						`nextcloud_forms_${to.params.hash as string}_activeResponseView`,
+					)
+					const lastViewId =
+						storedView && validViews.includes(storedView)
+							? storedView
+							: 'summary'
+					return {
+						name: `results.${lastViewId}`,
+						params: { hash: to.params.hash },
+					}
+				},
+			},
+			{
+				path: 'summary',
+				name: 'results.summary',
+				components: { default: Results },
+			},
+			{
+				path: 'responses',
+				name: 'results.responses',
+				components: { default: Results },
+			},
+		],
 	},
 	{
 		path: '/:hash/submit/:submissionId?',

--- a/src/views/Results.vue
+++ b/src/views/Results.vue
@@ -42,12 +42,12 @@
 			<!-- View switcher between Summary and Responses -->
 			<div class="response-actions">
 				<PillMenu
-					v-model:active="activeResponseView"
+					:active="activeResponseView"
 					:disabled="noSubmissions"
 					:options="responseViews"
 					:groupLabel="t('forms', 'View mode')"
 					class="response-actions__toggle"
-					@update:active="onChangeResponseView" />
+					@update:active="onViewChange" />
 
 				<!-- Action menu for cloud export and deletion -->
 				<NcActions
@@ -163,7 +163,7 @@
 						(!noSubmissions
 							|| loadingResults
 							|| submissionSearch.length > 0)
-						&& activeResponseView.id !== 'summary'
+						&& !isSummaryView
 					"
 					class="search-wrapper">
 					<NcTextField
@@ -227,7 +227,7 @@
 		</NcEmptyContent>
 
 		<!-- Summary view for visualization -->
-		<section v-else-if="activeResponseView.id === 'summary'">
+		<section v-else-if="isSummaryView">
 			<ResultsSummary
 				v-for="question in questions"
 				:key="question.id"
@@ -328,7 +328,6 @@ const responseViews = [
 		id: 'responses',
 	},
 ]
-const responseViewIds = new Set(responseViews.map((view) => view.id))
 
 export default {
 	// eslint-disable-next-line vue/multi-word-component-names
@@ -380,8 +379,6 @@ export default {
 
 	data() {
 		return {
-			activeResponseView: null,
-
 			questions: [],
 			submissions: [],
 			filteredSubmissionsCount: 0,
@@ -438,6 +435,15 @@ export default {
 	},
 
 	computed: {
+		isSummaryView() {
+			return this.$route.name === 'results.summary'
+		},
+
+		activeResponseView() {
+			const viewId = this.isSummaryView ? 'summary' : 'responses'
+			return responseViews.find((view) => view.id === viewId)
+		},
+
 		isFormArchived() {
 			return this.form.state === FormState.FormArchived
 		},
@@ -499,13 +505,14 @@ export default {
 		// Reload results when form changes
 		async hash() {
 			await this.fetchFullForm(this.form.id)
-			await this.syncActiveResponseViewFromRoute()
 			SetWindowTitle(this.formTitle)
 		},
 
-		'$route.query': {
+		'$route.name': {
 			handler() {
-				this.syncActiveResponseViewFromRoute()
+				const viewId = this.isSummaryView ? 'summary' : 'responses'
+				this.saveActiveResponseViewToLocalStorage(viewId)
+				this.loadFormResults()
 			},
 		},
 
@@ -528,116 +535,15 @@ export default {
 			})
 			this.loadFormResults()
 		}, INPUT_DEBOUNCE_MS),
-
-		// Persist active response view to localStorage when it changes
-		activeResponseView(newView) {
-			if (newView?.id) {
-				this.saveActiveResponseViewToLocalStorage(newView.id)
-			}
-		},
 	},
 
 	async beforeMount() {
 		await this.fetchFullForm(this.form.id)
-		await this.syncActiveResponseViewFromRoute()
+		this.loadFormResults()
 		SetWindowTitle(this.formTitle)
 	},
 
 	methods: {
-		/**
-		 * Resolve a response view object by its ID.
-		 *
-		 * @param {string} viewId The requested response view ID
-		 * @return {object}
-		 */
-		getResponseViewById(viewId) {
-			return (
-				responseViews.find((view) => view.id === viewId) ?? responseViews[0]
-			)
-		},
-
-		/**
-		 * Read the explicit response view from the current route query.
-		 *
-		 * @return {string|null}
-		 */
-		getRouteResponseViewId() {
-			return this.$route.query.view ?? null
-		},
-
-		/**
-		 * Load the stored response view preference from localStorage for the current form.
-		 *
-		 * @return {string}
-		 */
-		loadStoredActiveResponseViewId() {
-			try {
-				const storageKey = this.getActiveResponseViewStorageKey()
-				if (!storageKey) {
-					return responseViews[0].id
-				}
-
-				const storedViewId = localStorage.getItem(storageKey)
-				if (storedViewId && responseViewIds.has(storedViewId)) {
-					return storedViewId
-				}
-
-				return responseViews[0].id
-			} catch (err) {
-				logger.debug('Error loading activeResponseView from localStorage', {
-					error: err,
-				})
-				return responseViews[0].id
-			}
-		},
-
-		/**
-		 * Resolve the effective response view using route state first and localStorage second.
-		 *
-		 * @return {string}
-		 */
-		resolveActiveResponseViewId() {
-			return (
-				this.getRouteResponseViewId()
-				?? this.loadStoredActiveResponseViewId()
-			)
-		},
-
-		/**
-		 * Apply the effective route/localStorage view and refresh results when needed.
-		 */
-		async syncActiveResponseViewFromRoute() {
-			const routeViewId = this.getRouteResponseViewId()
-			const nextView = this.getResponseViewById(
-				routeViewId ?? this.loadStoredActiveResponseViewId(),
-			)
-			const currentViewId = this.activeResponseView?.id
-
-			if (currentViewId !== nextView.id) {
-				this.activeResponseView = nextView
-			}
-
-			if (!routeViewId) {
-				try {
-					await this.$router.replace({
-						name: 'results',
-						params: {
-							hash: this.form.hash,
-						},
-						query: {
-							...this.$route.query,
-							view: nextView.id,
-						},
-					})
-					return
-				} catch (error) {
-					logger.debug('Navigation cancelled', { error })
-				}
-			}
-
-			this.loadFormResults()
-		},
-
 		/**
 		 * Save the active response view preference to localStorage for the current form.
 		 *
@@ -673,27 +579,25 @@ export default {
 		},
 
 		/**
-		 * Navigate to an explicit route query for the selected response view.
+		 * Navigate to an explicit route for the selected response view.
 		 *
 		 * @param {object} view The selected response view object
 		 */
-		async onChangeResponseView(view) {
+		async onViewChange(view) {
 			if (!view?.id) {
 				return
 			}
-			if (this.getRouteResponseViewId() === view.id) {
+			const targetName = `results.${view.id}`
+			if (this.$route.name === targetName) {
 				this.loadFormResults()
 				return
 			}
 
 			try {
 				await this.$router.push({
-					name: 'results',
+					name: targetName,
 					params: {
 						hash: this.form.hash,
-					},
-					query: {
-						view: view.id,
 					},
 				})
 			} catch (error) {
@@ -730,7 +634,7 @@ export default {
 
 			try {
 				let response = null
-				if (this.activeResponseView.id === 'summary') {
+				if (this.isSummaryView) {
 					response = await axios.get(
 						generateOcsUrl('apps/forms/api/v3/forms/{id}/submissions', {
 							id: this.form.id,

--- a/src/views/Submit.vue
+++ b/src/views/Submit.vue
@@ -275,25 +275,25 @@ export default {
 	 * This is used to confirm that the user wants to leave the page
 	 * if the form is unsubmitted.
 	 */
-	async beforeRouteUpdate(to, from, next) {
+	async beforeRouteUpdate() {
 		// This navigation guard is called when the route parameters changed (e.g. form hash)
 		// continue with the navigation if there are no changes or the user confirms to leave the form
 		if (await this.confirmLeaveForm()) {
-			next()
+			return
 		} else {
 			// Otherwise cancel the navigation
-			next(false)
+			return false
 		}
 	},
 
-	async beforeRouteLeave(to, from, next) {
+	async beforeRouteLeave() {
 		// This navigation guard is called when the route changed and a new view should be shown
 		// continue with the navigation if there are no changes or the user confirms to leave the form
 		if (await this.confirmLeaveForm()) {
-			next()
+			return
 		} else {
 			// Otherwise cancel the navigation
-			next(false)
+			return false
 		}
 	},
 


### PR DESCRIPTION
This fixes a regression introduced in #3432. When you reloaded a results page with F5 or directly called a subview when the app was running with `npm run dev`, the results view got duplicated over and over into the router-view.

As a fix/refactoring I moved the routes from url params to direct child routes defined in router.ts.

## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
