### PR TITLE
[main] ci(actions): Update workflow templates from organization template repository

### DIFF
--- a/.github/actions-lock.txt
+++ b/.github/actions-lock.txt
@@ -17,6 +17,6 @@ bbe9834ddb89207caf5e19d79ebb3672 phpunit-oci.yml
 4ca2c2c4b1a73182667bab908e57c185 phpunit-sqlite.yml
 d1821b8a816578070ed8fd018f321f6d pr-feedback.yml
 43878db2acac51746332618c9f731553 psalm-matrix.yml
-f1cca476c953f28e3eec6c11b5866634 rector-apply.yml
+6aa9eaa284ed1800168c96b97e90d582 rector-apply.yml
 2dbec18233063b42f4d8e03bbb43671c reuse.yml
 94c65e30a77686c079c6dfa54a008440 sync-workflow-templates.yml

--- a/.github/workflows/rector-apply.yml
+++ b/.github/workflows/rector-apply.yml
@@ -45,10 +45,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Remove nextcloud/ocp
-        run: |
-          composer remove nextcloud/ocp --dev --no-scripts
-
       - name: Install composer dependencies
         uses: ramsey/composer-install@65e4f84970763564f46a70b8a54b90d033b3bdda # 4.0.0
 


### PR DESCRIPTION
Automated update of all workflow templates from [nextcloud/.github](https://github.com/nextcloud/.github)
- 🆙 Updated [rector-apply.yml](https://github.com/nextcloud/.github/commits/master/workflow-templates/rector-apply.yml)