### PR TITLE
Base form expiration on server time

### DIFF
--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -29,6 +29,7 @@ use OCP\AppFramework\Http\Response;
 use OCP\AppFramework\Http\Template\PublicTemplateResponse;
 use OCP\AppFramework\Http\TemplateResponse;
 use OCP\AppFramework\Services\IInitialState;
+use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\Comments\ICommentsManager;
 use OCP\IL10N;
 use OCP\IRequest;
@@ -57,6 +58,7 @@ class PageController extends Controller {
 		private readonly IUrlGenerator $urlGenerator,
 		private readonly IUserManager $userManager,
 		private readonly IUserSession $userSession,
+		private readonly ITimeFactory $timeFactory,
 	) {
 		parent::__construct($appName, $request);
 	}
@@ -76,6 +78,7 @@ class PageController extends Controller {
 		$this->insertHeaderOnIos();
 		$this->initialState->provideInitialState('maxStringLengths', Constants::MAX_STRING_LENGTHS);
 		$this->initialState->provideInitialState('appConfig', $this->configService->getAppConfig());
+		$this->initialState->provideInitialState('serverTime', $this->timeFactory->getTime());
 
 		if (isset($hash)) {
 			try {
@@ -228,6 +231,7 @@ class PageController extends Controller {
 		$this->initialState->provideInitialState('isLoggedIn', $this->userSession->isLoggedIn());
 		$this->initialState->provideInitialState('shareHash', $hash);
 		$this->initialState->provideInitialState('maxStringLengths', Constants::MAX_STRING_LENGTHS);
+		$this->initialState->provideInitialState('serverTime', $this->timeFactory->getTime());
 		return $this->provideTemplate(self::TEMPLATE_MAIN, $form, ['id-app-navigation' => null]);
 	}
 

--- a/src/components/AppNavigationForm.vue
+++ b/src/components/AppNavigationForm.vue
@@ -126,6 +126,7 @@ import FormsIcon from '../../img/forms-dark.svg?raw'
 import { FormState } from '../models/Constants.ts'
 import { PERMISSION_TYPES } from '../models/Permissions.ts'
 import logger from '../utils/Logger.ts'
+import { getCurrentServerTime } from '../utils/ServerTime.ts'
 
 type NavigationTarget = 'submit' | 'formRoot'
 
@@ -212,7 +213,9 @@ export default defineComponent({
 		 * Check if form is expired
 		 */
 		isExpired(): boolean {
-			return Boolean(this.form.expires && moment().unix() > this.form.expires)
+			return Boolean(
+				this.form.expires && getCurrentServerTime() > this.form.expires,
+			)
 		},
 
 		/**

--- a/src/components/SidebarTabs/SettingsSidebarTab.vue
+++ b/src/components/SidebarTabs/SettingsSidebarTab.vue
@@ -294,6 +294,7 @@ import TransferOwnership from './TransferOwnership.vue'
 import svgLockOpen from '../../../img/lock_open.svg?raw'
 import { useShareTypes } from '../../composables/useShareTypes.ts'
 import { FormState } from '../../models/Constants.ts'
+import { getCurrentServerTime } from '../../utils/ServerTime.ts'
 
 const formsAppName = 'forms'
 
@@ -466,7 +467,7 @@ export default defineComponent({
 		},
 
 		isExpired(): boolean {
-			return this.form.expires && moment().unix() > this.form.expires
+			return this.form.expires && getCurrentServerTime() > this.form.expires
 		},
 
 		expirationDate(): Date {

--- a/src/utils/ServerTime.ts
+++ b/src/utils/ServerTime.ts
@@ -1,0 +1,25 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { loadState } from '@nextcloud/initial-state'
+
+const formsAppName = 'forms'
+const serverTimeAtLoad = loadState(
+	formsAppName,
+	'serverTime',
+	Math.floor(Date.now() / 1000),
+) as number
+const monotonicTimeAtLoad = performance.now()
+
+/**
+ * Get the current Unix timestamp relative to the server clock.
+ *
+ * A monotonic timer keeps the value independent of client clock changes after
+ * the page has loaded.
+ */
+export function getCurrentServerTime(): number {
+	const elapsedSeconds = (performance.now() - monotonicTimeAtLoad) / 1000
+	return Math.floor(serverTimeAtLoad + elapsedSeconds)
+}

--- a/src/views/Create.vue
+++ b/src/views/Create.vue
@@ -246,6 +246,7 @@ import answerTypes from '../models/AnswerTypes.ts'
 import { FormState, INPUT_DEBOUNCE_MS } from '../models/Constants.ts'
 import logger from '../utils/Logger.ts'
 import OcsResponse2Data from '../utils/OcsResponse2Data.ts'
+import { getCurrentServerTime } from '../utils/ServerTime.ts'
 import SetWindowTitle from '../utils/SetWindowTitle.ts'
 
 const formsAppName = 'forms'
@@ -351,7 +352,9 @@ export default defineComponent({
 		 * Check if form is expired
 		 */
 		isExpired(): boolean {
-			return this.form.expires > 0 && moment().unix() > this.form.expires
+			return (
+				this.form.expires > 0 && getCurrentServerTime() > this.form.expires
+			)
 		},
 
 		/**

--- a/src/views/Submit.vue
+++ b/src/views/Submit.vue
@@ -255,6 +255,7 @@ import {
 import { PERMISSION_TYPES } from '../models/Permissions.ts'
 import logger from '../utils/Logger.ts'
 import OcsResponse2Data from '../utils/OcsResponse2Data.ts'
+import { getCurrentServerTime } from '../utils/ServerTime.ts'
 import SetWindowTitle from '../utils/SetWindowTitle.ts'
 
 const formsAppName = 'forms'
@@ -461,7 +462,9 @@ export default defineComponent({
 		 * Check if form is expired
 		 */
 		isExpired(): boolean {
-			return this.form.expires > 0 && moment().unix() > this.form.expires
+			return (
+				this.form.expires > 0 && getCurrentServerTime() > this.form.expires
+			)
 		},
 
 		isArchived(): boolean {

--- a/tests/Unit/Controller/PageControllerTest.php
+++ b/tests/Unit/Controller/PageControllerTest.php
@@ -18,6 +18,7 @@ use OCP\Accounts\IAccountManager;
 use OCP\AppFramework\Http\ContentSecurityPolicy;
 use OCP\AppFramework\Http\TemplateResponse;
 use OCP\AppFramework\Services\IInitialState;
+use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\Comments\ICommentsManager;
 use OCP\IL10N;
 use OCP\IRequest;
@@ -43,6 +44,7 @@ class PageControllerTest extends TestCase {
 	private IURLGenerator|MockObject $urlGenerator;
 	private IUserManager|MockObject $userManager;
 	private IUserSession|MockObject $userSession;
+	private ITimeFactory|MockObject $timeFactory;
 
 	public function setUp(): void {
 		parent::setUp();
@@ -60,6 +62,7 @@ class PageControllerTest extends TestCase {
 		$this->urlGenerator = $this->createMock(IURLGenerator::class);
 		$this->userManager = $this->createMock(IUserManager::class);
 		$this->userSession = $this->createMock(IUserSession::class);
+		$this->timeFactory = $this->createMock(ITimeFactory::class);
 
 		$this->pageController = new PageController(
 			'forms',
@@ -75,8 +78,25 @@ class PageControllerTest extends TestCase {
 			$this->l10n,
 			$this->urlGenerator,
 			$this->userManager,
-			$this->userSession
+			$this->userSession,
+			$this->timeFactory
 		);
+	}
+
+	public function testIndexProvidesServerTime(): void {
+		$providedState = [];
+		$this->timeFactory->expects($this->once())
+			->method('getTime')
+			->willReturn(1234567890);
+		$this->initialState->expects($this->exactly(3))
+			->method('provideInitialState')
+			->willReturnCallback(function (string $key, mixed $value) use (&$providedState): void {
+				$providedState[$key] = $value;
+			});
+
+		$this->pageController->index();
+
+		$this->assertSame(1234567890, $providedState['serverTime']);
 	}
 
 	public function testSetEmbeddedCSP() {


### PR DESCRIPTION
## Summary

- expose the server Unix timestamp through Nextcloud initial state on internal and public form pages
- derive current server time with `performance.now()`, keeping expiration checks independent of the client's wall clock even if it changes after page load
- use the server-relative time in every frontend form-expiration decision point
- add a controller unit test that verifies the server timestamp is provided

## Rationale

The backend already decides expiration with server time, but the frontend compared `form.expires` with `moment().unix()`. A client clock set in the future could therefore hide a form that the server still considers active. Anchoring a monotonic timer to the server timestamp keeps the UI consistent with backend authorization without repeated network requests.

## Validation

- Prettier check on all touched frontend files
- ESLint on all touched frontend files
- `git diff --check`
- PHP unit and clean production-build coverage delegated to CI because PHP is unavailable locally and the Windows npm install had incomplete package extraction

Fixes #3598