### PR TITLE
fix: show correct window title in edit mode

### DIFF
--- a/src/views/Create.vue
+++ b/src/views/Create.vue
@@ -765,7 +765,7 @@ export default defineComponent({
 		watch(
 			() => props.form.title,
 			() => {
-				SetWindowTitle(viewForm.formTitle)
+				SetWindowTitle(viewForm.formTitle.value)
 			},
 		)
 
@@ -783,7 +783,7 @@ export default defineComponent({
 		// Lifecycle
 		onMounted(() => {
 			viewForm.fetchFullForm(props.form.id)
-			SetWindowTitle(viewForm.formTitle)
+			SetWindowTitle(viewForm.formTitle.value)
 		})
 
 		return {


### PR DESCRIPTION
This fixes a regression in Create.vue. SetWindowTitle was set to the ref instead of the value and thus showed `[object Object]`.

## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
