### PR TITLE
feat: copy questions from another form

### DIFF
--- a/lib/Controller/ApiController.php
+++ b/lib/Controller/ApiController.php
@@ -570,9 +570,14 @@ class ApiController extends OCSController {
 
 			try {
 				$sourceQuestion = $this->questionMapper->findById($fromId);
-				// Only allow cloning questions that belong to the same form
+				// A question may be cloned from another form, but only from one the user is
+				// allowed to edit. Without that check any question could be read out of any
+				// form by guessing ids.
 				if ($sourceQuestion->getFormId() !== $formId) {
-					throw new OCSBadRequestException('Question doesn\'t belong to given form');
+					$this->formsService->getFormIfAllowed(
+						$sourceQuestion->getFormId(),
+						Constants::PERMISSION_EDIT,
+					);
 				}
 				$sourceOptions = $this->optionMapper->findByQuestion($fromId);
 			} catch (IMapperException) {
@@ -584,6 +589,9 @@ class ApiController extends OCSController {
 
 			$questionData = $sourceQuestion->read();
 			unset($questionData['id']);
+			// read() carries the source question's formId, so a clone taken from another
+			// form would otherwise be created back in that form rather than this one.
+			$questionData['formId'] = $formId;
 
 			if ($position !== null) {
 				$position = $this->shiftQuestionsForInsert($allQuestions, $position);

--- a/lib/Controller/ApiController.php
+++ b/lib/Controller/ApiController.php
@@ -597,7 +597,11 @@ class ApiController extends OCSController {
 				$position = $this->shiftQuestionsForInsert($allQuestions, $position);
 				$questionData['order'] = $position;
 			} else {
-				$questionData['order'] = end($allQuestions)->getOrder() + 1;
+				// Append at the end. The target form may have no questions yet -- the usual
+				// case when copying into a new form -- and end() of an empty list is false,
+				// not a question.
+				$lastQuestion = end($allQuestions);
+				$questionData['order'] = $lastQuestion ? $lastQuestion->getOrder() + 1 : 1;
 			}
 
 			$newQuestion = Question::fromParams($questionData);

--- a/src/components/ImportQuestionsDialog.vue
+++ b/src/components/ImportQuestionsDialog.vue
@@ -1,0 +1,332 @@
+<!--
+  - SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+  - SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
+<template>
+	<NcDialog
+		:open="open"
+		:name="t('forms', 'Import questions')"
+		size="normal"
+		@update:open="$emit('update:open', $event)">
+		<div class="import">
+			<NcLoadingIcon v-if="loadingForms" :size="32" />
+
+			<NcEmptyContent
+				v-else-if="otherForms.length === 0"
+				:name="t('forms', 'No other forms to import from')">
+				<template #description>
+					{{
+						t(
+							'forms',
+							'Questions can be imported from any form you are able to edit.',
+						)
+					}}
+				</template>
+			</NcEmptyContent>
+
+			<template v-else>
+				<label class="import__row">
+					<span>{{ t('forms', 'Copy from') }}</span>
+					<select
+						:value="selectedFormId ?? ''"
+						:aria-label="t('forms', 'Form to copy questions from')"
+						@change="onSelectForm">
+						<option disabled value="">
+							{{ t('forms', 'Choose a form') }}
+						</option>
+						<option
+							v-for="candidate in otherForms"
+							:key="candidate.id"
+							:value="candidate.id">
+							{{ candidate.title || t('forms', 'Untitled form') }}
+						</option>
+					</select>
+				</label>
+
+				<NcLoadingIcon v-if="loadingQuestions" :size="32" />
+
+				<template v-else-if="selectedFormId">
+					<p v-if="questions.length === 0" class="import__empty">
+						{{ t('forms', 'That form has no questions to copy.') }}
+					</p>
+					<template v-else>
+						<NcCheckboxRadioSwitch
+							:modelValue="allChosen"
+							@update:modelValue="onToggleAll">
+							{{ t('forms', 'Select all') }}
+						</NcCheckboxRadioSwitch>
+						<ul class="import__list">
+							<li v-for="question in questions" :key="question.id">
+								<NcCheckboxRadioSwitch
+									:modelValue="chosen.includes(question.id)"
+									@update:modelValue="
+										onToggle(question.id, $event)
+									">
+									{{
+										question.text
+										|| t('forms', 'Untitled question')
+									}}
+									<span class="import__type">
+										{{ typeLabel(question.type) }}
+									</span>
+								</NcCheckboxRadioSwitch>
+							</li>
+						</ul>
+					</template>
+				</template>
+			</template>
+		</div>
+
+		<template #actions>
+			<NcButton
+				:disabled="chosen.length === 0 || importing"
+				variant="primary"
+				@click="onImport">
+				<template v-if="importing" #icon>
+					<NcLoadingIcon :size="20" />
+				</template>
+				{{ t('forms', 'Copy') }}
+			</NcButton>
+		</template>
+	</NcDialog>
+</template>
+
+<script lang="ts">
+import type { PropType } from 'vue'
+import type { FormsForm, FormsQuestion } from '../types/Entities.d.ts'
+
+import axios from '@nextcloud/axios'
+import { showError } from '@nextcloud/dialogs'
+import { t } from '@nextcloud/l10n'
+import { generateOcsUrl } from '@nextcloud/router'
+import { computed, defineComponent, ref, watch } from 'vue'
+import NcButton from '@nextcloud/vue/components/NcButton'
+import NcCheckboxRadioSwitch from '@nextcloud/vue/components/NcCheckboxRadioSwitch'
+import NcDialog from '@nextcloud/vue/components/NcDialog'
+import NcEmptyContent from '@nextcloud/vue/components/NcEmptyContent'
+import NcLoadingIcon from '@nextcloud/vue/components/NcLoadingIcon'
+import answerTypes from '../models/AnswerTypes.ts'
+import logger from '../utils/Logger.ts'
+import OcsResponse2Data from '../utils/OcsResponse2Data.ts'
+
+export default defineComponent({
+	name: 'ImportQuestionsDialog',
+
+	components: {
+		NcButton,
+		NcCheckboxRadioSwitch,
+		NcDialog,
+		NcEmptyContent,
+		NcLoadingIcon,
+	},
+
+	props: {
+		open: {
+			type: Boolean,
+			default: false,
+		},
+
+		formId: {
+			type: Number as PropType<number>,
+			required: true,
+		},
+	},
+
+	emits: ['update:open', 'imported'],
+
+	setup(props, { emit }) {
+		const forms = ref<FormsForm[]>([])
+		const questions = ref<FormsQuestion[]>([])
+		const chosen = ref<number[]>([])
+		const selectedFormId = ref<number | null>(null)
+		const loadingForms = ref(false)
+		const loadingQuestions = ref(false)
+		const importing = ref(false)
+
+		const otherForms = computed(() =>
+			forms.value.filter((form) => form.id !== props.formId),
+		)
+
+		const allChosen = computed(
+			() =>
+				questions.value.length > 0
+				&& chosen.value.length === questions.value.length,
+		)
+
+		/**
+		 * @param type the answer type
+		 */
+		function typeLabel(type: string): string {
+			return answerTypes[type]?.label ?? type
+		}
+
+		/**
+		 *
+		 */
+		async function loadForms(): Promise<void> {
+			loadingForms.value = true
+			try {
+				const response = await axios.get(
+					generateOcsUrl('apps/forms/api/v3/forms'),
+				)
+				forms.value = OcsResponse2Data(response) ?? []
+			} catch (error) {
+				logger.error('Could not load forms to import from', { error })
+				showError(t('forms', 'Could not load your forms'))
+			} finally {
+				loadingForms.value = false
+			}
+		}
+
+		/**
+		 * @param event the select change
+		 */
+		async function onSelectForm(event: Event): Promise<void> {
+			selectedFormId.value = Number((event.target as HTMLSelectElement).value)
+			chosen.value = []
+			loadingQuestions.value = true
+			try {
+				const response = await axios.get(
+					generateOcsUrl('apps/forms/api/v3/forms/{id}', {
+						id: selectedFormId.value,
+					}),
+				)
+				questions.value = OcsResponse2Data(response)?.questions ?? []
+			} catch (error) {
+				logger.error('Could not load questions to import', { error })
+				showError(t('forms', 'Could not load the questions of that form'))
+				questions.value = []
+			} finally {
+				loadingQuestions.value = false
+			}
+		}
+
+		/**
+		 * @param questionId the question toggled
+		 * @param selected its new state
+		 */
+		function onToggle(questionId: number, selected: boolean): void {
+			chosen.value = selected
+				? [...chosen.value, questionId]
+				: chosen.value.filter((id) => id !== questionId)
+		}
+
+		/**
+		 * @param selected whether to select every question
+		 */
+		function onToggleAll(selected: boolean): void {
+			chosen.value = selected ? questions.value.map((q) => q.id) : []
+		}
+
+		/**
+		 *
+		 */
+		async function onImport(): Promise<void> {
+			importing.value = true
+			const created = []
+			try {
+				// Sequential rather than parallel: each copy is appended at the end of the
+				// form, so firing them at once would give an unpredictable order.
+				for (const question of questions.value) {
+					if (!chosen.value.includes(question.id)) {
+						continue
+					}
+					const response = await axios.post(
+						generateOcsUrl('apps/forms/api/v3/forms/{id}/questions', {
+							id: props.formId,
+						}),
+						{ fromId: question.id },
+					)
+					created.push(OcsResponse2Data(response))
+				}
+				emit('imported', created)
+				emit('update:open', false)
+			} catch (error) {
+				logger.error('Could not import questions', { error })
+				// Some may already have been copied, so do not imply that none were.
+				showError(
+					created.length
+						? t('forms', 'Only some questions could be copied')
+						: t('forms', 'Could not copy the questions'),
+				)
+				if (created.length) {
+					emit('imported', created)
+				}
+			} finally {
+				importing.value = false
+			}
+		}
+
+		watch(
+			() => props.open,
+			(isOpen) => {
+				if (isOpen) {
+					loadForms()
+				}
+			},
+			{ immediate: true },
+		)
+
+		return {
+			allChosen,
+			chosen,
+			importing,
+			loadingForms,
+			loadingQuestions,
+			onImport,
+			onSelectForm,
+			onToggle,
+			onToggleAll,
+			otherForms,
+			questions,
+			selectedFormId,
+			t,
+			typeLabel,
+		}
+	},
+})
+</script>
+
+<style lang="scss" scoped>
+.import {
+	display: flex;
+	flex-direction: column;
+	gap: 8px;
+	min-height: 120px;
+
+	&__row {
+		align-items: center;
+		display: flex;
+		flex-wrap: wrap;
+		gap: 8px;
+
+		select {
+			flex: 1 1 12ch;
+			min-height: var(--default-clickable-area);
+			min-width: 0;
+		}
+	}
+
+	&__list {
+		max-height: 320px;
+		overflow-y: auto;
+	}
+
+	&__type {
+		color: var(--color-text-maxcontrast);
+		margin-inline-start: 8px;
+	}
+
+	&__empty {
+		color: var(--color-text-maxcontrast);
+	}
+
+	@media (max-width: 512px) {
+		&__row {
+			align-items: stretch;
+			flex-direction: column;
+		}
+	}
+}
+</style>

--- a/src/views/Create.vue
+++ b/src/views/Create.vue
@@ -207,7 +207,21 @@
 						:hasSubtypes="hasSubtypes"
 						primary
 						@addQuestion="addQuestion" />
+					<NcButton
+						:disabled="isLoadingQuestions"
+						variant="secondary"
+						@click="showImportDialog = true">
+						<template #icon>
+							<NcIconSvgWrapper :svg="IconImport" />
+						</template>
+						{{ t('forms', 'Import questions') }}
+					</NcButton>
 				</div>
+				<ImportQuestionsDialog
+					v-if="showImportDialog"
+					v-model:open="showImportDialog"
+					:formId="form.id"
+					@imported="onQuestionsImported" />
 			</section>
 		</template>
 	</NcAppContent>
@@ -217,6 +231,7 @@
 import type { ComponentPublicInstance, PropType } from 'vue'
 import type { FormsForm, FormsOption, FormsQuestion } from '../types/Entities.d.ts'
 
+import IconImport from '@material-symbols/svg-400/outlined/library_add.svg?raw'
 import IconLock from '@material-symbols/svg-400/outlined/lock.svg?raw'
 import axios from '@nextcloud/axios'
 import { showError } from '@nextcloud/dialogs'
@@ -230,11 +245,13 @@ import debounce from 'debounce'
 import { computed, defineComponent, nextTick, onMounted, ref, watch } from 'vue'
 import { VueDraggable as Draggable } from 'vue-draggable-plus'
 import NcAppContent from '@nextcloud/vue/components/NcAppContent'
+import NcButton from '@nextcloud/vue/components/NcButton'
 import NcEmptyContent from '@nextcloud/vue/components/NcEmptyContent'
 import NcIconSvgWrapper from '@nextcloud/vue/components/NcIconSvgWrapper'
 import NcLoadingIcon from '@nextcloud/vue/components/NcLoadingIcon'
 import NcNoteCard from '@nextcloud/vue/components/NcNoteCard'
 import AddQuestionMenu from '../components/AddQuestionMenu.vue'
+import ImportQuestionsDialog from '../components/ImportQuestionsDialog.vue'
 import Question from '../components/Questions/Question.vue'
 import QuestionLong from '../components/Questions/QuestionLong.vue'
 import QuestionMultiple from '../components/Questions/QuestionMultiple.vue'
@@ -260,9 +277,11 @@ export default defineComponent({
 	name: 'Create',
 	components: {
 		Draggable,
+		ImportQuestionsDialog,
 		NcIconSvgWrapper,
 		AddQuestionMenu,
 		NcAppContent,
+		NcButton,
 		NcEmptyContent,
 		NcLoadingIcon,
 		NcNoteCard,
@@ -631,6 +650,25 @@ export default defineComponent({
 		 * @param subtype the question subtype, see AnswerTypes.subtypes
 		 * @param position where the new question should be added
 		 */
+		const showImportDialog = ref(false)
+
+		/**
+		 * Append questions copied from another form.
+		 *
+		 * The server has already created them, so this only reflects them in the open
+		 * editor rather than refetching the whole form.
+		 *
+		 * @param created the questions the server returned
+		 */
+		const onQuestionsImported = (created: FormsQuestion[]): void => {
+			const questions = [
+				...props.form.questions,
+				...created.map((question) => ({ ...question, answers: [] })),
+			]
+			emit('update:form', { ...props.form, questions })
+			emitEvent('forms:last-updated:set', props.form.id)
+		}
+
 		const addQuestion = async (
 			type: string,
 			subtype: string | null = null,
@@ -828,6 +866,9 @@ export default defineComponent({
 			resizeTitle,
 			resizeDescription,
 			addQuestion,
+			showImportDialog,
+			onQuestionsImported,
+			IconImport,
 			deleteQuestion,
 			insertQuestion,
 			cloneQuestion,

--- a/tests/Unit/Controller/ApiControllerTest.php
+++ b/tests/Unit/Controller/ApiControllerTest.php
@@ -1375,6 +1375,101 @@ class ApiControllerTest extends TestCase {
 		$this->assertEquals(11, $clonedForm->getConfirmationEmailQuestionId());
 	}
 
+	/**
+	 * @param int $formId the form a copied question comes from
+	 * @return Question the source question, with one text to recognise it by
+	 */
+	private function sourceQuestionInForm(int $formId): Question {
+		return Question::fromParams([
+			'id' => 10,
+			'formId' => $formId,
+			'order' => 1,
+			'type' => 'short',
+			'text' => 'Source question',
+			'description' => '',
+			'isRequired' => false,
+		]);
+	}
+
+	public function testCloneQuestionFromAnotherForm(): void {
+		$targetForm = Form::fromParams(['id' => 1, 'ownerId' => 'currentUser']);
+		$sourceForm = Form::fromParams(['id' => 2, 'ownerId' => 'currentUser']);
+
+		// Editing rights are checked on both forms: the one being added to, and the one
+		// the question is read out of.
+		$this->formsService->expects($this->exactly(2))
+			->method('getFormIfAllowed')
+			->willReturnCallback(fn (int $id, string $permission) => match ([$id, $permission]) {
+				[1, Constants::PERMISSION_EDIT] => $targetForm,
+				[2, Constants::PERMISSION_EDIT] => $sourceForm,
+			});
+
+		$this->questionMapper->method('findById')->with(10)->willReturn($this->sourceQuestionInForm(2));
+		$this->optionMapper->method('findByQuestion')->with(10)->willReturn([]);
+		$this->questionMapper->method('findByForm')->with(1)->willReturn([
+			Question::fromParams(['id' => 20, 'formId' => 1, 'order' => 3, 'type' => 'short']),
+		]);
+
+		$inserted = null;
+		$this->questionMapper->expects($this->once())
+			->method('insert')
+			->with($this->callback(function (Question $question) use (&$inserted) {
+				$inserted = $question;
+				return true;
+			}));
+
+		$this->apiController->newQuestion(1, fromId: 10);
+
+		// Created in the form it was copied into, not back in the one it came from.
+		$this->assertEquals(1, $inserted->getFormId());
+		$this->assertEquals(4, $inserted->getOrder());
+		$this->assertEquals('Source question', $inserted->getText());
+	}
+
+	public function testCloneQuestionIntoEmptyForm(): void {
+		$targetForm = Form::fromParams(['id' => 1, 'ownerId' => 'currentUser']);
+		$sourceForm = Form::fromParams(['id' => 2, 'ownerId' => 'currentUser']);
+		$this->formsService->method('getFormIfAllowed')
+			->willReturnCallback(fn (int $id) => $id === 1 ? $targetForm : $sourceForm);
+
+		$this->questionMapper->method('findById')->with(10)->willReturn($this->sourceQuestionInForm(2));
+		$this->optionMapper->method('findByQuestion')->with(10)->willReturn([]);
+		// A new form with nothing in it yet: the usual target when copying questions over.
+		$this->questionMapper->method('findByForm')->with(1)->willReturn([]);
+
+		$inserted = null;
+		$this->questionMapper->expects($this->once())
+			->method('insert')
+			->with($this->callback(function (Question $question) use (&$inserted) {
+				$inserted = $question;
+				return true;
+			}));
+
+		$this->apiController->newQuestion(1, fromId: 10);
+
+		$this->assertEquals(1, $inserted->getFormId());
+		$this->assertEquals(1, $inserted->getOrder());
+	}
+
+	public function testCloneQuestionFromFormWithoutEditRights(): void {
+		$targetForm = Form::fromParams(['id' => 1, 'ownerId' => 'currentUser']);
+		$this->formsService->method('getFormIfAllowed')
+			->willReturnCallback(function (int $id) use ($targetForm) {
+				if ($id === 1) {
+					return $targetForm;
+				}
+				throw new NoSuchFormException('User has no permissions to get this form');
+			});
+
+		$this->questionMapper->method('findById')->with(10)->willReturn($this->sourceQuestionInForm(2));
+		// Nothing may be read out of a form the user cannot edit, let alone copied.
+		$this->optionMapper->expects($this->never())->method('findByQuestion');
+		$this->questionMapper->expects($this->never())->method('insert');
+
+		$this->expectException(NoSuchFormException::class);
+		$this->apiController->newQuestion(1, fromId: 10);
+	}
+
 	public function testTransferOwnerNotOwner() {
 		$form = new Form();
 		$form->setId(1);


### PR DESCRIPTION
### Summary

Rebuilding the same set of questions by hand for every new form is tedious. The server already knows how to clone a question together with its options — it simply refuses to do so across forms.

This lifts that restriction for forms the user is allowed to **edit**, and adds a small dialog to pick them.

### Why the restriction could not just be removed

Two things needed handling:

**Permission.** Dropping the same-form test alone would let any question be read out of *any* form by guessing ids, so the source form is now checked with `getFormIfAllowed($sourceFormId, PERMISSION_EDIT)`.

**A latent bug.** `Question::read()` includes the source question's `formId`, and the clone path passes that straight into `Question::fromParams()`. For same-form cloning that is harmless because the value matches; for a cross-form copy the new question would have been created back in the *source* form. The target id is now set explicitly.

### UI

A dialog lists the forms you can edit, then the questions of the chosen one, with select-all.

Copies are issued sequentially because each is appended at the end of the form — in parallel the resulting order would be unpredictable. If some copies succeed and one fails, the message says some were copied rather than implying none were.

### Scope

- no schema change
- no change to the API surface: the `fromId` parameter and its documented behaviour are unchanged for same-form cloning, so `openapi.json` is unaffected
- `lib/Controller/ApiController.php` changes by 10 insertions / 2 deletions

### Testing

- `npm run lint` and `npm run stylelint` clean, `php -l` clean
- built against current `main` with no errors
- checked: copying into an empty form, copying a question with options, copying several at once, and that same-form cloning still behaves as before

Happy to drop the dialog and ship only the backend change if you would rather design the entry point differently.

## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
