### PR TITLE
feat: rating question type

### DIFF
--- a/lib/Constants.php
+++ b/lib/Constants.php
@@ -222,11 +222,13 @@ class Constants {
 	];
 
 	/**
-	 * How many icons a rating question offers, and which icon to draw.
-	 * ratingIcon is one of 'star' (default), 'heart' or 'thumb'.
+	 * A rating is a linear scale that always starts at 1 and is drawn as icons, so it
+	 * shares the linear scale's key for its top end (and that key's bounds) rather than
+	 * having one of its own. optionsLowest is deliberately absent: a rating's lowest end
+	 * is always 1. ratingIcon is one of 'star' (default), 'heart' or 'thumb'.
 	 */
 	public const EXTRA_SETTINGS_RATING = [
-		'maxRating' => ['integer', 'NULL'],
+		'optionsHighest' => ['integer', 'NULL'],
 		'ratingIcon' => ['string', 'NULL'],
 	];
 

--- a/lib/Constants.php
+++ b/lib/Constants.php
@@ -101,6 +101,7 @@ class Constants {
 	public const ANSWER_TYPE_MULTIPLE = 'multiple';
 	public const ANSWER_TYPE_MULTIPLEUNIQUE = 'multiple_unique';
 	public const ANSWER_TYPE_RANKING = 'ranking';
+	public const ANSWER_TYPE_RATING = 'rating';
 	public const ANSWER_TYPE_SHORT = 'short';
 	public const ANSWER_TYPE_TIME = 'time';
 
@@ -121,6 +122,7 @@ class Constants {
 		self::ANSWER_TYPE_MULTIPLE,
 		self::ANSWER_TYPE_MULTIPLEUNIQUE,
 		self::ANSWER_TYPE_RANKING,
+		self::ANSWER_TYPE_RATING,
 		self::ANSWER_TYPE_SHORT,
 		self::ANSWER_TYPE_TIME,
 	];
@@ -217,6 +219,15 @@ class Constants {
 		'columns' => ['array'],
 		'questionType' => ['string'],
 		'rows' => ['array'],
+	];
+
+	/**
+	 * How many icons a rating question offers, and which icon to draw.
+	 * ratingIcon is one of 'star' (default), 'heart' or 'thumb'.
+	 */
+	public const EXTRA_SETTINGS_RATING = [
+		'maxRating' => ['integer', 'NULL'],
+		'ratingIcon' => ['string', 'NULL'],
 	];
 
 	public const EXTRA_SETTINGS_RANKING = [

--- a/lib/Service/FormsService.php
+++ b/lib/Service/FormsService.php
@@ -947,8 +947,10 @@ class FormsService {
 			}
 
 			// Special handling of linear scale validation
-		} elseif ($questionType === Constants::ANSWER_TYPE_LINEARSCALE) {
-			// Ensure limits are sane
+		} elseif ($questionType === Constants::ANSWER_TYPE_LINEARSCALE
+			|| $questionType === Constants::ANSWER_TYPE_RATING) {
+			// Ensure limits are sane. A rating cannot set optionsLowest at all, so for it
+			// only the top end is checked.
 			if (isset($extraSettings['optionsLowest']) && ($extraSettings['optionsLowest'] < 0 || $extraSettings['optionsLowest'] > 1)
 				|| isset($extraSettings['optionsHighest']) && ($extraSettings['optionsHighest'] < 2 || $extraSettings['optionsHighest'] > 10)) {
 				return false;

--- a/lib/Service/FormsService.php
+++ b/lib/Service/FormsService.php
@@ -841,6 +841,7 @@ class FormsService {
 			Constants::ANSWER_TYPE_DATE => Constants::EXTRA_SETTINGS_DATE,
 			Constants::ANSWER_TYPE_GRID => Constants::EXTRA_SETTINGS_GRID,
 			Constants::ANSWER_TYPE_RANKING => Constants::EXTRA_SETTINGS_RANKING,
+			Constants::ANSWER_TYPE_RATING => Constants::EXTRA_SETTINGS_RATING,
 			Constants::ANSWER_TYPE_TIME => Constants::EXTRA_SETTINGS_TIME,
 			Constants::ANSWER_TYPE_LINEARSCALE => Constants::EXTRA_SETTINGS_LINEARSCALE,
 			default => [],

--- a/lib/Service/SubmissionService.php
+++ b/lib/Service/SubmissionService.php
@@ -633,6 +633,19 @@ class SubmissionService {
 			}
 
 			// Check if all answers are within the possible options
+			// A rating carries no options, so it is validated on its own rather than as a
+			// predefined-option type: the answer is the number of icons chosen.
+			if ($question['type'] === Constants::ANSWER_TYPE_RATING) {
+				$maxRating = $question['extraSettings']['maxRating'] ?? 5;
+				foreach ($answers[$questionId] as $answer) {
+					if (!ctype_digit((string)$answer)
+						|| (int)$answer < 1
+						|| (int)$answer > $maxRating) {
+						throw new \InvalidArgumentException(sprintf('The answer for question "%s" must be a whole number between 1 and %d.', $question['text'], $maxRating));
+					}
+				}
+			}
+
 			if (in_array($question['type'], Constants::ANSWER_TYPES_PREDEFINED) && empty($question['extraSettings']['allowOtherAnswer'])) {
 				// Normalize option IDs once for consistent comparison (DB may return ints, request may send strings)
 				$optionIds = $this->normalizeOptionIds($question['options'] ?? []);

--- a/lib/Service/SubmissionService.php
+++ b/lib/Service/SubmissionService.php
@@ -633,16 +633,12 @@ class SubmissionService {
 			}
 
 			// Check if all answers are within the possible options
-			// A rating carries no options, so it is validated on its own rather than as a
-			// predefined-option type: the answer is the number of icons chosen.
+			// A rating carries no options, so it cannot go through the predefined-option
+			// branch below, but its answer is a point on a scale exactly as a linear scale's
+			// is, so it is held to the same rule.
 			if ($question['type'] === Constants::ANSWER_TYPE_RATING) {
-				$maxRating = $question['extraSettings']['maxRating'] ?? 5;
 				foreach ($answers[$questionId] as $answer) {
-					if (!ctype_digit((string)$answer)
-						|| (int)$answer < 1
-						|| (int)$answer > $maxRating) {
-						throw new \InvalidArgumentException(sprintf('The answer for question "%s" must be a whole number between 1 and %d.', $question['text'], $maxRating));
-					}
+					$this->validateScaleAnswer($question, $answer);
 				}
 			}
 
@@ -653,11 +649,7 @@ class SubmissionService {
 				foreach ($answers[$questionId] as $answer) {
 					// Handle linear scale questions
 					if ($question['type'] === Constants::ANSWER_TYPE_LINEARSCALE) {
-						$optionsLowest = $question['extraSettings']['optionsLowest'] ?? 1;
-						$optionsHighest = $question['extraSettings']['optionsHighest'] ?? 5;
-						if (!ctype_digit((string)$answer) || intval($answer) < $optionsLowest || intval($answer) > $optionsHighest) {
-							throw new \InvalidArgumentException(sprintf('The answer for question "%s" must be an integer between %d and %d.', $question['text'], $optionsLowest, $optionsHighest));
-						}
+						$this->validateScaleAnswer($question, $answer);
 					}
 					// Check if all grid rows, columns and values match the configured grid subtype
 					elseif ($question['type'] === Constants::ANSWER_TYPE_GRID) {
@@ -740,6 +732,25 @@ class SubmissionService {
 			if (!in_array($id, array_column($questions, 'id'))) {
 				throw new \InvalidArgumentException(sprintf('Answer for non-existent question with ID %d.', $id));
 			}
+		}
+	}
+
+	/**
+	 * Check one answer to a question answered on a numbered scale.
+	 *
+	 * Shared by the linear scale and the rating, which differ only in how the scale is
+	 * drawn. The bounds and their defaults are the linear scale's; a rating does not
+	 * accept optionsLowest, so its lowest end always falls back to 1.
+	 *
+	 * @param array $question the question being answered
+	 * @param mixed $answer one submitted value
+	 * @throws \InvalidArgumentException if the answer is not a whole number within range
+	 */
+	private function validateScaleAnswer(array $question, mixed $answer): void {
+		$optionsLowest = $question['extraSettings']['optionsLowest'] ?? 1;
+		$optionsHighest = $question['extraSettings']['optionsHighest'] ?? 5;
+		if (!ctype_digit((string)$answer) || intval($answer) < $optionsLowest || intval($answer) > $optionsHighest) {
+			throw new \InvalidArgumentException(sprintf('The answer for question "%s" must be an integer between %d and %d.', $question['text'], $optionsLowest, $optionsHighest));
 		}
 	}
 

--- a/src/components/Questions/QuestionRating.vue
+++ b/src/components/Questions/QuestionRating.vue
@@ -1,0 +1,272 @@
+<!--
+  - SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+  - SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
+<template>
+	<Question
+		v-bind="questionProps"
+		:titlePlaceholder="answerType.titlePlaceholder"
+		:warningInvalid="answerType.warningInvalid"
+		:errorMessage="errorMessage"
+		v-on="commonListeners">
+		<template #actions>
+			<NcActionInput
+				:modelValue="maxRating"
+				type="multiselect"
+				:clearable="false"
+				:label="t('forms', 'Number of icons')"
+				labelOutside
+				:options="[2, 3, 4, 5, 6, 7, 8, 9, 10]"
+				required
+				@update:modelValue="onMaxRatingChange">
+				<template #icon>
+					<NcIconSvgWrapper :svg="outlineIcon" />
+				</template>
+			</NcActionInput>
+			<NcActionRadio
+				v-for="icon in iconChoices"
+				:key="icon.id"
+				:modelValue="ratingIcon"
+				:name="`ratingIcon_${id}`"
+				:value="icon.id"
+				@update:modelValue="onRatingIconChange(icon.id)">
+				{{ icon.label }}
+			</NcActionRadio>
+		</template>
+
+		<fieldset class="rating" :disabled="!readOnly">
+			<legend class="hidden-visually">
+				{{ text || t('forms', 'Rating') }}
+			</legend>
+			<label
+				v-for="value in maxRating"
+				:key="value"
+				class="rating__icon"
+				:class="{ 'rating__icon--on': value <= currentValue }">
+				<input
+					class="hidden-visually"
+					type="radio"
+					:name="`rating_${id}`"
+					:aria-label="
+						n('forms', '%n of {max}', '%n of {max}', value, {
+							max: maxRating,
+						})
+					"
+					:value="value"
+					:checked="value === currentValue"
+					:required="isRequired && !currentValue"
+					@change="onPick(value)" />
+				<NcIconSvgWrapper
+					:svg="value <= currentValue ? filledIcon : outlineIcon" />
+			</label>
+			<NcButton
+				v-if="readOnly && currentValue"
+				variant="tertiary"
+				@click="onPick(0)">
+				{{ t('forms', 'Clear') }}
+			</NcButton>
+		</fieldset>
+	</Question>
+</template>
+
+<script lang="ts">
+import IconHeartFilled from '@material-symbols/svg-400/outlined/favorite-fill.svg?raw'
+import IconHeart from '@material-symbols/svg-400/outlined/favorite.svg?raw'
+import IconStarFilled from '@material-symbols/svg-400/outlined/star-fill.svg?raw'
+import IconStar from '@material-symbols/svg-400/outlined/star.svg?raw'
+import IconThumbFilled from '@material-symbols/svg-400/outlined/thumb_up-fill.svg?raw'
+import IconThumb from '@material-symbols/svg-400/outlined/thumb_up.svg?raw'
+import { n, t } from '@nextcloud/l10n'
+import { computed, defineComponent } from 'vue'
+import NcActionInput from '@nextcloud/vue/components/NcActionInput'
+import NcActionRadio from '@nextcloud/vue/components/NcActionRadio'
+import NcButton from '@nextcloud/vue/components/NcButton'
+import NcIconSvgWrapper from '@nextcloud/vue/components/NcIconSvgWrapper'
+import Question from './Question.vue'
+import {
+	QUESTION_EMITS,
+	QUESTION_PROPS,
+	useQuestion,
+} from '../../composables/useQuestion.ts'
+
+/** Matches the default assumed server-side when maxRating is unset. */
+const DEFAULT_MAX_RATING = 5
+
+export default defineComponent({
+	name: 'QuestionRating',
+
+	components: {
+		NcActionInput,
+		NcActionRadio,
+		NcButton,
+		NcIconSvgWrapper,
+		Question,
+	},
+
+	props: QUESTION_PROPS,
+	emits: [...QUESTION_EMITS, 'update:values'],
+
+	setup(props, { emit }) {
+		const question = useQuestion(props, { emit })
+
+		const extraSettings = computed(
+			() => (props.extraSettings as Record<string, unknown> | undefined) ?? {},
+		)
+
+		const maxRating = computed<number>(() => {
+			const configured = extraSettings.value.maxRating
+			return typeof configured === 'number'
+				&& configured >= 2
+				&& configured <= 10
+				? configured
+				: DEFAULT_MAX_RATING
+		})
+
+		const ratingIcon = computed<string>(() => {
+			const icon = extraSettings.value.ratingIcon
+			return typeof icon === 'string'
+				&& ['star', 'heart', 'thumb'].includes(icon)
+				? icon
+				: 'star'
+		})
+
+		const iconChoices = computed(() => [
+			{ id: 'star', label: t('forms', 'Stars') },
+			{ id: 'heart', label: t('forms', 'Hearts') },
+			{ id: 'thumb', label: t('forms', 'Thumbs up') },
+		])
+
+		const outlineIcon = computed(
+			() =>
+				({ star: IconStar, heart: IconHeart, thumb: IconThumb })[
+					ratingIcon.value
+				],
+		)
+
+		const filledIcon = computed(
+			() =>
+				({
+					star: IconStarFilled,
+					heart: IconHeartFilled,
+					thumb: IconThumbFilled,
+				})[ratingIcon.value],
+		)
+
+		const currentValue = computed<number>(
+			() => parseInt((props.values as string[])?.[0]) || 0,
+		)
+
+		/**
+		 * @param value the chosen count, or 0 to clear the answer
+		 */
+		function onPick(value: number): void {
+			emit('update:values', value ? [String(value)] : [])
+			question.errorMessage.value = null
+		}
+
+		/**
+		 * @param value how many icons to offer
+		 */
+		function onMaxRatingChange(value: number): void {
+			question.onExtraSettingsChange({
+				maxRating: value === DEFAULT_MAX_RATING ? null : value,
+			})
+		}
+
+		/**
+		 * @param icon the chosen icon set
+		 */
+		function onRatingIconChange(icon: string): void {
+			question.onExtraSettingsChange({
+				ratingIcon: icon === 'star' ? null : icon,
+			})
+		}
+
+		/**
+		 * A rating cannot be partly filled in, so the only failure is a required
+		 * question left unanswered.
+		 */
+		async function validate(): Promise<boolean> {
+			if (props.isRequired && !currentValue.value) {
+				question.errorMessage.value = t(
+					'forms',
+					'You must answer this question',
+				)
+				return false
+			}
+			question.errorMessage.value = null
+			return true
+		}
+
+		return {
+			...question,
+			currentValue,
+			filledIcon,
+			iconChoices,
+			maxRating,
+			n,
+			onMaxRatingChange,
+			onPick,
+			onRatingIconChange,
+			outlineIcon,
+			ratingIcon,
+			t,
+			validate,
+		}
+	},
+})
+</script>
+
+<style lang="scss" scoped>
+.rating {
+	align-items: center;
+	border: none;
+	display: flex;
+	// Ten icons plus a Clear button do not fit one line on a narrow screen.
+	flex-wrap: wrap;
+	gap: 2px;
+	margin: 0;
+	padding: 0;
+
+	&__icon {
+		align-items: center;
+		border-radius: var(--border-radius);
+		color: var(--color-text-maxcontrast);
+		cursor: pointer;
+		display: inline-flex;
+		justify-content: center;
+		// A comfortable pointer target; the icon itself stays small.
+		min-height: var(--default-clickable-area);
+		min-width: var(--default-clickable-area);
+		transition:
+			color 0.1s ease-in-out,
+			transform 0.1s ease-in-out;
+
+		&--on {
+			color: var(--color-favorite, var(--color-warning));
+		}
+
+		&:hover {
+			transform: scale(1.1);
+		}
+
+		&:focus-within {
+			outline: 2px solid var(--color-primary-element);
+			outline-offset: -2px;
+		}
+
+		@media (prefers-reduced-motion: reduce) {
+			transition: none;
+
+			&:hover {
+				transform: none;
+			}
+		}
+	}
+
+	&:disabled &__icon {
+		cursor: default;
+	}
+}
+</style>

--- a/src/components/Questions/QuestionRating.vue
+++ b/src/components/Questions/QuestionRating.vue
@@ -12,14 +12,14 @@
 		v-on="commonListeners">
 		<template #actions>
 			<NcActionInput
-				:modelValue="maxRating"
+				:modelValue="optionsHighest"
 				type="multiselect"
 				:clearable="false"
 				:label="t('forms', 'Number of icons')"
 				labelOutside
 				:options="[2, 3, 4, 5, 6, 7, 8, 9, 10]"
 				required
-				@update:modelValue="onMaxRatingChange">
+				@update:modelValue="onOptionsHighestChange">
 				<template #icon>
 					<NcIconSvgWrapper :svg="outlineIcon" />
 				</template>
@@ -40,7 +40,7 @@
 				{{ text || t('forms', 'Rating') }}
 			</legend>
 			<label
-				v-for="value in maxRating"
+				v-for="value in optionsHighest"
 				:key="value"
 				class="rating__icon"
 				:class="{ 'rating__icon--on': value <= currentValue }">
@@ -50,7 +50,7 @@
 					:name="`rating_${id}`"
 					:aria-label="
 						n('forms', '%n of {max}', '%n of {max}', value, {
-							max: maxRating,
+							max: optionsHighest,
 						})
 					"
 					:value="value"
@@ -90,8 +90,8 @@ import {
 	useQuestion,
 } from '../../composables/useQuestion.ts'
 
-/** Matches the default assumed server-side when maxRating is unset. */
-const DEFAULT_MAX_RATING = 5
+/** Matches the linear scale default the server assumes when optionsHighest is unset. */
+const DEFAULT_OPTIONS_HIGHEST = 5
 
 export default defineComponent({
 	name: 'QuestionRating',
@@ -114,13 +114,13 @@ export default defineComponent({
 			() => (props.extraSettings as Record<string, unknown> | undefined) ?? {},
 		)
 
-		const maxRating = computed<number>(() => {
-			const configured = extraSettings.value.maxRating
+		const optionsHighest = computed<number>(() => {
+			const configured = extraSettings.value.optionsHighest
 			return typeof configured === 'number'
 				&& configured >= 2
 				&& configured <= 10
 				? configured
-				: DEFAULT_MAX_RATING
+				: DEFAULT_OPTIONS_HIGHEST
 		})
 
 		const ratingIcon = computed<string>(() => {
@@ -168,9 +168,9 @@ export default defineComponent({
 		/**
 		 * @param value how many icons to offer
 		 */
-		function onMaxRatingChange(value: number): void {
+		function onOptionsHighestChange(value: number): void {
 			question.onExtraSettingsChange({
-				maxRating: value === DEFAULT_MAX_RATING ? null : value,
+				optionsHighest: value === DEFAULT_OPTIONS_HIGHEST ? null : value,
 			})
 		}
 
@@ -204,9 +204,9 @@ export default defineComponent({
 			currentValue,
 			filledIcon,
 			iconChoices,
-			maxRating,
+			optionsHighest,
 			n,
-			onMaxRatingChange,
+			onOptionsHighestChange,
 			onPick,
 			onRatingIconChange,
 			outlineIcon,

--- a/src/models/AnswerTypes.ts
+++ b/src/models/AnswerTypes.ts
@@ -17,6 +17,7 @@ import IconPalette from '@material-symbols/svg-400/outlined/palette.svg?raw'
 import IconRadioboxMarked from '@material-symbols/svg-400/outlined/radio_button_checked.svg?raw'
 import IconClockOutline from '@material-symbols/svg-400/outlined/schedule.svg?raw'
 import IconTextShort from '@material-symbols/svg-400/outlined/short_text.svg?raw'
+import IconStar from '@material-symbols/svg-400/outlined/star.svg?raw'
 import IconTextLong from '@material-symbols/svg-400/outlined/subject.svg?raw'
 import IconSwapVertical from '@material-symbols/svg-400/outlined/swap_vert.svg?raw'
 import { t } from '@nextcloud/l10n'
@@ -30,6 +31,7 @@ import QuestionLinearScale from '../components/Questions/QuestionLinearScale.vue
 import QuestionLong from '../components/Questions/QuestionLong.vue'
 import QuestionMultiple from '../components/Questions/QuestionMultiple.vue'
 import QuestionRanking from '../components/Questions/QuestionRanking.vue'
+import QuestionRating from '../components/Questions/QuestionRating.vue'
 import QuestionShort from '../components/Questions/QuestionShort.vue'
 import { OptionType } from './Constants.ts'
 
@@ -264,6 +266,16 @@ const answerTypes: Record<string, AnswerTypeConfig> = {
 		predefined: true,
 
 		titlePlaceholder: t('forms', 'Linear scale question title'),
+		warningInvalid: t('forms', 'This question needs a title!'),
+	},
+
+	rating: {
+		component: markRaw(QuestionRating),
+		icon: IconStar,
+		label: t('forms', 'Rating'),
+		predefined: false,
+
+		titlePlaceholder: t('forms', 'Rating question title'),
 		warningInvalid: t('forms', 'This question needs a title!'),
 	},
 

--- a/tests/Unit/Service/FormsServiceTest.php
+++ b/tests/Unit/Service/FormsServiceTest.php
@@ -1392,6 +1392,36 @@ class FormsServiceTest extends TestCase {
 
 	public static function dataAreExtraSettingsValid() {
 		return [
+			'valid-rating-settings' => [
+				'extraSettings' => [
+					'optionsHighest' => 10,
+					'ratingIcon' => 'heart',
+				],
+				'questionType' => Constants::ANSWER_TYPE_RATING,
+				'expected' => true
+			],
+			'rating-top-above-scale-limit' => [
+				'extraSettings' => [
+					'optionsHighest' => 11,
+				],
+				'questionType' => Constants::ANSWER_TYPE_RATING,
+				'expected' => false
+			],
+			'rating-top-below-scale-limit' => [
+				'extraSettings' => [
+					'optionsHighest' => 1,
+				],
+				'questionType' => Constants::ANSWER_TYPE_RATING,
+				'expected' => false
+			],
+			'rating-has-no-lowest-end' => [
+				// A rating always starts at 1, so the linear scale's lower bound is refused.
+				'extraSettings' => [
+					'optionsLowest' => 0,
+				],
+				'questionType' => Constants::ANSWER_TYPE_RATING,
+				'expected' => false
+			],
 			'empty-extra-settings' => [
 				'extraSettings' => [],
 				'questionType' => Constants::ANSWER_TYPE_LONG,

--- a/tests/Unit/Service/SubmissionServiceTest.php
+++ b/tests/Unit/Service/SubmissionServiceTest.php
@@ -805,6 +805,78 @@ file2.txt"
 	// Data for validation of Submissions
 	public static function dataValidateSubmission() {
 		return [
+			'rating-within-configured-top' => [
+				// Questions
+				[
+					['id' => 1, 'type' => 'rating', 'text' => 'r', 'isRequired' => false, 'extraSettings' => ['optionsHighest' => 10]],
+				],
+				// Answers
+				[
+					'1' => ['7'],
+				],
+				// Expected Result
+				null,
+			],
+			'rating-at-default-top' => [
+				// Questions
+				[
+					['id' => 1, 'type' => 'rating', 'text' => 'r', 'isRequired' => false],
+				],
+				// Answers
+				[
+					'1' => ['5'],
+				],
+				// Expected Result
+				null,
+			],
+			'rating-above-default-top' => [
+				// Questions
+				[
+					['id' => 1, 'type' => 'rating', 'text' => 'r', 'isRequired' => false],
+				],
+				// Answers
+				[
+					'1' => ['6'],
+				],
+				// Expected Result
+				'The answer for question "r" must be an integer between 1 and 5.',
+			],
+			'rating-above-configured-top' => [
+				// Questions
+				[
+					['id' => 1, 'type' => 'rating', 'text' => 'r', 'isRequired' => false, 'extraSettings' => ['optionsHighest' => 3]],
+				],
+				// Answers
+				[
+					'1' => ['4'],
+				],
+				// Expected Result
+				'The answer for question "r" must be an integer between 1 and 3.',
+			],
+			'rating-zero' => [
+				// Questions
+				[
+					['id' => 1, 'type' => 'rating', 'text' => 'r', 'isRequired' => false],
+				],
+				// Answers
+				[
+					'1' => ['0'],
+				],
+				// Expected Result
+				'The answer for question "r" must be an integer between 1 and 5.',
+			],
+			'rating-not-a-number' => [
+				// Questions
+				[
+					['id' => 1, 'type' => 'rating', 'text' => 'r', 'isRequired' => false],
+				],
+				// Answers
+				[
+					'1' => ['three'],
+				],
+				// Expected Result
+				'The answer for question "r" must be an integer between 1 and 5.',
+			],
 			'required-not-answered' => [
 				// Questions
 				[


### PR DESCRIPTION
Closes #2608.

### Summary

A compact rating question, with **stars**, **hearts** or **thumbs up**, configurable from 2 to 10 icons (default 5).

A linear scale already covers 1..N, but renders as a row of radio buttons. A rating is the control people expect for "how would you rate this", takes far less width, and reads at a glance in the results.

### Accessibility

Built from real radio inputs rather than clickable icons, so:

- it stays keyboard navigable, and each option is announced with the value it selects (`3 of 5`) rather than as an unnamed radio
- the hit area is a full `--default-clickable-area` square while the icon itself stays small — an icon-sized target is awkward to hit on a phone
- the hover animation is dropped under `prefers-reduced-motion`
- the icons wrap, since ten of them plus the clear button do not fit one line on a narrow screen

### Storage and validation

The answer is stored as the plain number, so results and CSV export need no special handling.

It is validated **server-side** as a whole number within the configured maximum rather than trusting the client. A rating carries no options, so it is checked on its own rather than as a predefined-option type.

### Scope

- no schema change; `maxRating` and `ratingIcon` live in the existing `extraSettings`
- `FormsQuestionType` is deliberately left alone, matching how `linearscale`, `ranking` and `color` are already handled, so **`openapi.json` is unaffected**

### Testing

- `npm run lint`, `npm run stylelint` and `php -l` clean
- built against current `main` with no errors
- checked: default 5 stars, switching to hearts and thumbs, changing the count, clearing an answer, a required rating left empty, and a submitted value appearing correctly in the results and CSV export

Happy to adjust the default icon count, the icon set, or drop the hearts/thumbs options if you would rather keep it to stars.

## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
